### PR TITLE
Fixes #32846 - create explicit cv-version

### DIFF
--- a/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
@@ -16,7 +16,7 @@ module Actions
                 plan_action(Actions::Pulp3::Repository::CreatePublication, repository, smart_proxy, options)
               end
               plan_action(Actions::Pulp3::ContentGuard::Refresh, smart_proxy) unless repository.unprotected
-              plan_action(Actions::Pulp3::Repository::RefreshDistribution, repository, smart_proxy, :contents_changed => options[:contents_changed]) if repository.environment
+              plan_action(Actions::Pulp3::Repository::RefreshDistribution, repository, smart_proxy, :contents_changed => options[:contents_changed]) if Setting[:distribute_archived_cvv] || repository.environment
             end
           end
 

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -661,6 +661,12 @@ Foreman::Plugin.register :katello do
         default: true,
         full_name: N_('Allow deleting repositories in published content views'),
         description: N_("If this is enabled, repositories can be deleted even when they belong to published content views. The deleted repository will be removed from all content view versions.")
+
+      setting 'distribute_archived_cvv',
+        type: :boolean,
+        default: true,
+        full_name: N_('Distribute archived content view versions'),
+        description: N_("If this is enabled, repositories of content view versions without environments (\"archived\") will be distributed at '/pulp/content/<organization>/content_views/<content view>/X.Y/...'.")
     end
   end
 

--- a/test/actions/katello/repository/multi_clone_contents_test.rb
+++ b/test/actions/katello/repository/multi_clone_contents_test.rb
@@ -25,6 +25,7 @@ module Actions
       @repo.reload
 
       @repo_mapping = { [@repo] => { :dest_repo => @repo_clone, :filters => [] } }
+      ::Katello::Pulp3::Repository.any_instance.stubs(:fail_missing_publication).returns(nil)
     end
 
     def test_metadata_generation_with_changed_checksum_type

--- a/test/fixtures/vcr_cassettes/actions/katello/repository/multi_clone_contents/metadata_generation_with_changed_checksum_type.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/repository/multi_clone_contents/metadata_generation_with_changed_checksum_type.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:48 GMT
+      - Fri, 05 Aug 2022 09:53:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,27 +35,94 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2bf28e055d934e58b86c5722efef9c45
+      - 88d668f0fbb44f78905e5a4313e8c782
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hMmVkZjFjYS1kYzY5LTQzZGMtYjlmOC0wOTgwMmU3Zjc4YzMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNToyNS43Nzc5Mzha
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hMmVkZjFjYS1kYzY5LTQzZGMtYjlmOC0wOTgwMmU3Zjc4YzMv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2EyZWRm
+        MWNhLWRjNjktNDNkYy1iOWY4LTA5ODAyZTdmNzhjMy92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
+        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
+        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
+        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
+        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
+        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
+        ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:48 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:54 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Aug 2022 09:53:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4061c6c9e07a49088d03b6dc1200b699
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2YzQ4MTc3LTUwMmEtNDYy
+        NS1hNmY5LTA1YmNmZGY4NDkxMC8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Aug 2022 09:53:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:48 GMT
+      - Fri, 05 Aug 2022 09:53:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e2cef62ffeda4e13bf9018e06fef7c43
+      - 5acecb850fa04ef3ab22fbc1ffb677a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:48 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f6c48177-502a-4625-a6f9-05bcfdf84910/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:48 GMT
+      - Fri, 05 Aug 2022 09:53:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -137,31 +204,43 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1bdf3902237544ab925e43231cbcabc3
+      - 52cd549489e9437bb410a550120e056a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjZjNDgxNzctNTAy
+        YS00NjI1LWE2ZjktMDViY2ZkZjg0OTEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMDVUMDk6NTM6NTQuODEzNTE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0MDYxYzZjOWUwN2E0OTA4OGQwM2I2ZGMx
+        MjAwYjY5OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTA1VDA5OjUzOjU0Ljg3
+        MTk5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMDVUMDk6NTM6NTUuMTgw
+        MDAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81NmQxNDBmNi1kNWUyLTRkYTgtODQ3ZS1jMTIwZWMxMjU3YmMvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTJlZGYxY2EtZGM2OS00M2Rj
+        LWI5ZjgtMDk4MDJlN2Y3OGMzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:48 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:48 GMT
+      - Fri, 05 Aug 2022 09:53:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ede713153f14a8db60f0b571c876025
+      - e2dc29487cdf4b419040fc0b44869527
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:48 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -222,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -235,7 +314,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:48 GMT
+      - Fri, 05 Aug 2022 09:53:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -247,27 +326,88 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '448'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e07b3af5fb246d4a1f50b1a20eb5a0d
+      - c7a0acae4df44f87b8af665e224b3464
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZjY3YzIwMjktMmY5MC00ZTVjLWI3Y2ItNTI3ODc4YTFlZTBh
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MjkuODQxNjM1
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:48 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/f67c2029-2f90-4e5c-b7cb-527878a1ee0a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Aug 2022 09:53:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8cc8d33a128447b8955f0f0ad7da8c52
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EyMzZkNjI0LTk4ZDQtNDk3
+        NS05YjFmLTJhMDhiMjM0ZTc0Ny8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a236d624-98d4-4975-9b1f-2a08b234e747/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -275,7 +415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -288,7 +428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:49 GMT
+      - Fri, 05 Aug 2022 09:53:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -296,31 +436,42 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4b2e152741d48b3a7006864404c650f
+      - 61c9caa96a1c41ad8c310f47a85c58c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTIzNmQ2MjQtOThk
+        NC00OTc1LTliMWYtMmEwOGIyMzRlNzQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMDVUMDk6NTM6NTUuNjQ2MTg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4Y2M4ZDMzYTEyODQ0N2I4OTU1ZjBmMGFk
+        N2RhOGM1MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTA1VDA5OjUzOjU1LjY4
+        OTQ1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMDVUMDk6NTM6NTUuNzI3
+        MDQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81NmQxNDBmNi1kNWUyLTRkYTgtODQ3ZS1jMTIwZWMxMjU3YmMvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:49 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -328,7 +479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -341,7 +492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:49 GMT
+      - Fri, 05 Aug 2022 09:53:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -359,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 882ad82b98af4bc181b75c2fa0626083
+      - e29a45637c6a4a028de199c037a57705
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:49 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -381,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:49 GMT
+      - Fri, 05 Aug 2022 09:53:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -412,21 +563,127 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8527edd7f3904b4f99eb61c1a2e9b787
+      - 7ee87ff969bb46c0be229bed04e9e4df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:49 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Aug 2022 09:53:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0dfd6075c02a45a5b7b21d7252d281d9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 05 Aug 2022 09:53:55 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Aug 2022 09:53:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 728fc13c976b4bebb6daa924f9de20e6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -442,7 +699,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -455,13 +712,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:49 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/34bf6d26-a398-4a65-bd47-3443b7805e6b/"
+      - "/pulp/api/v3/remotes/rpm/rpm/d1884748-b4ac-4ccb-974b-8379f5449819/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -475,31 +732,31 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 03e02e15e2ae426d8836d0fad5916048
+      - 4377843651554675b9eab80879dc9402
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM0
-        YmY2ZDI2LWEzOTgtNGE2NS1iZDQ3LTM0NDNiNzgwNWU2Yi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTAzLTIxVDE2OjEzOjQ5LjM5NTU1MVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Qx
+        ODg0NzQ4LWI0YWMtNGNjYi05NzRiLTgzNzlmNTQ0OTgxOS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA4LTA1VDA5OjUzOjU2LjE4MTU3NVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwOi8vbXlyZXBvLmNvbSIsImNhX2Nl
         cnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6
         dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBf
-        bGFzdF91cGRhdGVkIjoiMjAyMi0wMy0yMVQxNjoxMzo0OS4zOTU1NzdaIiwi
+        bGFzdF91cGRhdGVkIjoiMjAyMi0wOC0wNVQwOTo1Mzo1Ni4xODE1OTVaIiwi
         ZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxs
         LCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAs
         ImNvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQi
         OjYwLjAsInNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51
         bGwsInJhdGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:49 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -509,7 +766,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -522,13 +779,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:49 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/782b586b-a5a1-4af4-9c60-d648c2a713e1/"
+      - "/pulp/api/v3/repositories/rpm/rpm/bd095227-7fda-49c1-8cea-84c1a7720f30/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -542,22 +799,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3c0ae279570b42aa9424832a33b1acc5
+      - 2197e58260084c2fbff0f63864d72615
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzgyYjU4NmItYTVhMS00YWY0LTljNjAtZDY0OGMyYTcxM2UxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDMtMjFUMTY6MTM6NDkuNjMzNzI2WiIsInZl
+        cG0vYmQwOTUyMjctN2ZkYS00OWMxLThjZWEtODRjMWE3NzIwZjMwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMDVUMDk6NTM6NTYuMzMwMzA4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzgyYjU4NmItYTVhMS00YWY0LTljNjAtZDY0OGMyYTcxM2UxL3ZlcnNp
+        cG0vYmQwOTUyMjctN2ZkYS00OWMxLThjZWEtODRjMWE3NzIwZjMwL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83ODJiNTg2Yi1h
-        NWExLTRhZjQtOWM2MC1kNjQ4YzJhNzEzZTEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZDA5NTIyNy03
+        ZmRhLTQ5YzEtOGNlYS04NGMxYTc3MjBmMzAvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -566,10 +823,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:49 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -577,7 +834,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -590,41 +847,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:49 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5bdd98f1cd01483da597aa93d606a20a
+      - 052f570c1d1e4914815344f439b63d2e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81YzRmZjI4My0wYjQ0LTQ1NWEtYWYyYy0xODNiZjcyNjZlMzAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wMy0xOFQxNzozNzoyOC4zMTc4MDha
+        cnBtL3JwbS9iZGFmNzM1Ny1mYzgyLTQ5NzMtOWY4Ny1kNWViZDc2NWI5YWMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNToyNi43NjA2MDha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81YzRmZjI4My0wYjQ0LTQ1NWEtYWYyYy0xODNiZjcyNjZlMzAv
+        cnBtL3JwbS9iZGFmNzM1Ny1mYzgyLTQ5NzMtOWY4Ny1kNWViZDc2NWI5YWMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzVjNGZm
-        MjgzLTBiNDQtNDU1YS1hZjJjLTE4M2JmNzI2NmUzMC92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JkYWY3
+        MzU3LWZjODItNDk3My05Zjg3LWQ1ZWJkNzY1YjlhYy92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -632,10 +889,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:49 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/5c4ff283-0b44-455a-af2c-183bf7266e30/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -643,7 +900,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,7 +913,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -674,21 +931,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8db7c163bbf41479249611b7d42c31d
+      - b72de2326e924d678b7793063a919414
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1Yzk2NDgwLWI0ZGEtNGIy
-        ZC1iZGNhLThmZTgwOGE0ZWMyMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4MGU0N2MyLTUyNmQtNDFk
+        MC05YWVmLWM1ZjNiZjg0Y2MyYy8ifQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -696,7 +953,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -709,51 +966,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5aa6639c7274413a9cda1897b8850fb7
+      - 7f6ce072502741a3ae45c62ab87a04eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
-      Content-Length:
-      - '366'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMTYyZTBmZWQtMWNhNy00OTVlLTkyOTItOWE4NDdmOTUyNWQ0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDMtMThUMTc6Mzc6MjYuODg4MzE4WiIsIm5h
+        cG0vYjc2NWEwOTItMGY0MC00OTY0LTlhYjUtOGQ4NmYyMjMyNjQ3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MjUuNjM1NDU2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wMy0xOFQxNzozNzoyOC44NjcwOTNaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozNToyNy4xODcxOTlaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/162e0fed-1ca7-495e-9292-9a847f9525d4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b765a092-0f40-4964-9ab5-8d86f2232647/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -761,7 +1018,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -774,7 +1031,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -792,21 +1049,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b17c882a5c24b019fc1f3c379916101
+      - 8fad97af59424cbf84c9eaf22ced9168
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0OTdlNjNhLTM4ZjUtNGUz
-        MS1iOGM3LWYxODI1ZjhlNjM0OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhNDcwNGUwLTE3YTMtNDVm
+        My04ZTFlLWVkODg5OWYxMmRlMC8ifQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/45c96480-b4da-4b2d-bdca-8fe808a4ec20/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/980e47c2-526d-41d0-9aef-c5f3bf84cc2c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -814,7 +1071,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -827,51 +1084,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae43e93b7ff24ce3b3a715faac88a5ba
+      - 239baaa766114c7db22bfb92615a41df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDVjOTY0ODAtYjRk
-        YS00YjJkLWJkY2EtOGZlODA4YTRlYzIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDMtMjFUMTY6MTM6NTAuMDAwODE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTgwZTQ3YzItNTI2
+        ZC00MWQwLTlhZWYtYzVmM2JmODRjYzJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMDVUMDk6NTM6NTYuNTUzOTQ5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjOGRiN2MxNjNiYmY0MTQ3OTI0OTYxMWI3
-        ZDQyYzMxZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTAzLTIxVDE2OjEzOjUwLjA4
-        NzA3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDMtMjFUMTY6MTM6NTAuMTU3
-        OTg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy82NDdkNGRlNy02YTI4LTQ5NDktYmIwMS1iNDBiOTkzYmI5NWUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiNzJkZTIzMjZlOTI0ZDY3OGI3NzkzMDYz
+        YTkxOTQxNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTA1VDA5OjUzOjU2LjU5
+        NDU2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMDVUMDk6NTM6NTYuNjc5
+        MTk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81NmQxNDBmNi1kNWUyLTRkYTgtODQ3ZS1jMTIwZWMxMjU3YmMvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWM0ZmYyODMtMGI0NC00NTVh
-        LWFmMmMtMTgzYmY3MjY2ZTMwLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4Mi00OTcz
+        LTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/2497e63a-38f5-4e31-b8c7-f1825f8e6349/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ba4704e0-17a3-45f3-8e1e-ed8899f12de0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -879,7 +1136,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -892,51 +1149,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4f81b708a45844f1af4444adede2156d
+      - 9e69199ed7314b1aadaeedbb1f3e062a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQ5N2U2M2EtMzhm
-        NS00ZTMxLWI4YzctZjE4MjVmOGU2MzQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDMtMjFUMTY6MTM6NTAuMjU3MTg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmE0NzA0ZTAtMTdh
+        My00NWYzLThlMWUtZWQ4ODk5ZjEyZGUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMDVUMDk6NTM6NTYuNjc5MzMwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0YjE3Yzg4MmE1YzI0YjAxOWZjMWYzYzM3
-        OTkxNjEwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTAzLTIxVDE2OjEzOjUwLjMw
-        ODU0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDMtMjFUMTY6MTM6NTAuMzUx
-        NDU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9jMDkwNTNhYi03NmQ4LTQwNDctOGQyZS1iMWY3N2IzODg4ZjcvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4ZmFkOTdhZjU5NDI0Y2JmODRjOWVhZjIy
+        Y2VkOTE2OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTA1VDA5OjUzOjU2Ljcy
+        Mzk2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMDVUMDk6NTM6NTYuODAx
+        Mjg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81NmQxNDBmNi1kNWUyLTRkYTgtODQ3ZS1jMTIwZWMxMjU3YmMvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE2MmUwZmVkLTFjYTctNDk1ZS05Mjky
-        LTlhODQ3Zjk1MjVkNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I3NjVhMDkyLTBmNDAtNDk2NC05YWI1
+        LThkODZmMjIzMjY0Ny8iXX0=
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -944,7 +1201,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -957,7 +1214,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -975,21 +1232,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5a2e800d3f734d058721afe34f98a898
+      - 155990e0f33841029f06a9c5b213961b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -997,7 +1254,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1010,7 +1267,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1028,21 +1285,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 60a3579708a64cec8424bcee450d7e78
+      - 742331fd375344c4ac67d0abe8d7406e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1050,7 +1307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1063,7 +1320,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1081,21 +1338,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 718eaaedd3a441fd805bde8b58337a20
+      - c296d4f37641402eba01634b9199dbc2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1103,7 +1360,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1116,7 +1373,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1134,21 +1391,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf020cf2573d4ee7a54fc6cf7cc3ac02
+      - de7723508baa4c3f8d3706191d3884e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1156,7 +1413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1169,7 +1426,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1187,21 +1444,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea7280c9792c4fb5940c6d3cabbe5bdf
+      - 862252a7769047c38e6daedbf214b809
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1209,7 +1466,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1222,7 +1479,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:50 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1240,21 +1497,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 426b6c7c6ef4434a9f773f1a3e6f7bdb
+      - 69f43029333b45e6a6315e56b5676ada
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:50 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1264,7 +1521,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1277,13 +1534,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:51 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/35e9ea0e-3c89-4992-bdf3-634d7588dc58/"
+      - "/pulp/api/v3/repositories/rpm/rpm/7852f951-0109-48f3-94cd-6b8e5c32a50c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1297,22 +1554,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a220fbeb9ab94ea7af4a836fa9c37718
+      - 13a60a50adb945eda95e2a8af095c2a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzVlOWVhMGUtM2M4OS00OTkyLWJkZjMtNjM0ZDc1ODhkYzU4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDMtMjFUMTY6MTM6NTEuMTI5NDkzWiIsInZl
+        cG0vNzg1MmY5NTEtMDEwOS00OGYzLTk0Y2QtNmI4ZTVjMzJhNTBjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMDVUMDk6NTM6NTcuMjEzODI0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzVlOWVhMGUtM2M4OS00OTkyLWJkZjMtNjM0ZDc1ODhkYzU4L3ZlcnNp
+        cG0vNzg1MmY5NTEtMDEwOS00OGYzLTk0Y2QtNmI4ZTVjMzJhNTBjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNWU5ZWEwZS0z
-        Yzg5LTQ5OTItYmRmMy02MzRkNzU4OGRjNTgvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83ODUyZjk1MS0w
+        MTA5LTQ4ZjMtOTRjZC02YjhlNWMzMmE1MGMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1320,10 +1577,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:51 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35e9ea0e-3c89-4992-bdf3-634d7588dc58/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7852f951-0109-48f3-94cd-6b8e5c32a50c/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1331,7 +1588,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1344,7 +1601,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:51 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1362,21 +1619,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c36225284d04f4493e1f19261fcfc72
+      - 45605f2a3d4146ef9ca10a98cc450a02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:51 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35e9ea0e-3c89-4992-bdf3-634d7588dc58/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7852f951-0109-48f3-94cd-6b8e5c32a50c/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1384,7 +1641,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1397,7 +1654,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:51 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1415,21 +1672,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - adf1304a6d384502827cd548c4737841
+      - caf720f02670409eabca656264a78916
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:51 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35e9ea0e-3c89-4992-bdf3-634d7588dc58/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7852f951-0109-48f3-94cd-6b8e5c32a50c/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1437,7 +1694,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1450,7 +1707,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:51 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1468,21 +1725,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 721f6d15ff8a4779b69296c0fd8f22cb
+      - 88e713a69adb421cabdc1ed74778235e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:51 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35e9ea0e-3c89-4992-bdf3-634d7588dc58/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7852f951-0109-48f3-94cd-6b8e5c32a50c/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1490,7 +1747,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1503,7 +1760,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:51 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1521,21 +1778,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d384d8e730934068aad8200b6bbd57c5
+      - 01a49b721fdd4a668f0e0d061c87c304
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:51 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35e9ea0e-3c89-4992-bdf3-634d7588dc58/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7852f951-0109-48f3-94cd-6b8e5c32a50c/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1543,7 +1800,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1556,7 +1813,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:51 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1574,21 +1831,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 26378d3da4964d6fbb4686a1e5ed16e0
+      - 82b2bf9f4e5449ac8ed649a1f9429637
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:51 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/35e9ea0e-3c89-4992-bdf3-634d7588dc58/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7852f951-0109-48f3-94cd-6b8e5c32a50c/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1596,7 +1853,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1866,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 Mar 2022 16:13:51 GMT
+      - Fri, 05 Aug 2022 09:53:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,16 +1884,251 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53f78f0fd8784e1e9efd5b030d8b4f37
+      - 315958b447a2457ca3cfe8c674e143fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 21 Mar 2022 16:13:51 GMT
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Aug 2022 09:53:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9d2568975bd349bea3326a0a7f40afac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 05 Aug 2022 09:53:57 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZGV2X2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IjIiLCJw
+        dWJsaWNhdGlvbiI6bnVsbH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Aug 2022 09:53:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 45633102db0a49c09bce04c79726189a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2MGFhN2UxLWUyZDktNDll
+        Ni05MjUxLTRiNTMyNjliMmM5MS8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Aug 2022 09:53:58 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c60aa7e1-e2d9-49e6-9251-4b53269b2c91/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Aug 2022 09:53:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 18803d50b4bc4245bc3fe6be73b6b716
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzYwYWE3ZTEtZTJk
+        OS00OWU2LTkyNTEtNGI1MzI2OWIyYzkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMDVUMDk6NTM6NTguMDQ2NzM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI0NTYzMzEwMmRiMGE0OWMwOWJjZTA0Yzc5
+        NzI2MTg5YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTA1VDA5OjUzOjU4LjA4
+        OTM5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMDVUMDk6NTM6NTguMTg0
+        NTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81NmQxNDBmNi1kNWUyLTRkYTgtODQ3ZS1jMTIwZWMxMjU3YmMvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNjg2
+        ZGFjZWYtYjAxYy00ZTRjLWE5MGEtZDhmZTVlYmFiYTBlLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 05 Aug 2022 09:53:58 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/686dacef-b01c-4e4c-a90a-d8fe5ebaba0e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Aug 2022 09:53:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '384'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4e46937648fa48378e265beedde698ac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzY4NmRhY2VmLWIwMWMtNGU0Yy1hOTBhLWQ4ZmU1ZWJhYmEwZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA4LTA1VDA5OjUzOjU4LjE2MDk2MFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZGV2
+        X2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlv
+        bi9kZXYvZmVkb3JhXzE3X2Rldl9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpu
+        dWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwicmVwb3NpdG9yeSI6
+        bnVsbCwicHVibGljYXRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Fri, 05 Aug 2022 09:53:58 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_distribution_trees_repository/all_distribution_trees_are_copied_by_default.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_distribution_trees_repository/all_distribution_trees_are_copied_by_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:49 GMT
+      - Fri, 29 Jul 2022 09:00:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2cea136033bd46ecafb17073726bd00f
+      - da82d0982bf146d8b6db8875b07d2d22
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zZTcyOTllYy03YjczLTQzZmUtODUzZS0xNmYwZmE4NWZmYWMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDozMS4zMDg2NTJa
+        cnBtL3JwbS9kZjhjZDhmMy1hODM1LTQ1ODEtOTMwYS1hNWVlYTY1ZjJhY2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDo0NS4yMzU3MjZa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zZTcyOTllYy03YjczLTQzZmUtODUzZS0xNmYwZmE4NWZmYWMv
+        cnBtL3JwbS9kZjhjZDhmMy1hODM1LTQ1ODEtOTMwYS1hNWVlYTY1ZjJhY2Iv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNlNzI5
-        OWVjLTdiNzMtNDNmZS04NTNlLTE2ZjBmYTg1ZmZhYy92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2RmOGNk
+        OGYzLWE4MzUtNDU4MS05MzBhLWE1ZWVhNjVmMmFjYi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:53 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 518306ed59564150a47fdb5a644c2b78
+      - e308a1b751e144c58703994b2f411f02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxZWFmMmZiLTNhMTItNGNk
-        MC1hZWIwLTJjY2VhM2Y5ZjA3Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkOTFjZGUzLTFiNzUtNDcz
+        ZC04ZGYwLWI1NjkzNTY0NTdiZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49711110d82d44b98f27170a33414368
+      - 6d3fc603aab841438b8163002bbbec31
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c1eaf2fb-3a12-4cd0-aeb0-2ccea3f9f07c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ed91cde3-1b75-473d-8df0-b569356457bf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b2358496c6f4d9bae1d198160924268
+      - ea565298754e4a3387300bbc9ae23e3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzFlYWYyZmItM2Ex
-        Mi00Y2QwLWFlYjAtMmNjZWEzZjlmMDdjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NDkuOTk4ODk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWQ5MWNkZTMtMWI3
+        NS00NzNkLThkZjAtYjU2OTM1NjQ1N2JmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTQuMDM1NDQ4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MTgzMDZlZDU5NTY0MTUwYTQ3ZmRiNWE2
-        NDRjMmI3OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjUwLjAy
-        NzkyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTAuMDc3
-        NzE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlMzA4YTFiNzUxZTE0NGM1ODcwMzk5NGIy
+        ZjQxMWYwMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjU0LjA3
+        NjIxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NTQuMzMz
+        OTU1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2U3Mjk5ZWMtN2I3My00M2Zl
-        LTg1M2UtMTZmMGZhODVmZmFjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGY4Y2Q4ZjMtYTgzNS00NTgx
+        LTkzMGEtYTVlZWE2NWYyYWNiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46d1c499e70b40e6a30eb9df7ad199c6
+      - 84f9cd8ba3a443fa821b5b341692d010
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6e7623def2e34205b2ecca211c1db3c3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNGZmZDVkODMtNzVjMy00ZjI2LTgwMTQtNzM2ZjMwOTY2MDA2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NDkuNzQ5NDU4
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4ffd5d83-75c3-4f26-8014-736f30966006/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 22514e8f8d3a49b4a234cde7497733b3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlMGNiOWYwLTFiZTMtNDNj
+        Yi04ZTg4LTMzNmZlMDc5YTk4Zi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fe0cb9f0-1be3-43cb-8e88-336fe079a98f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e09ba90f6a2040baa14d5342d91f3cc3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmUwY2I5ZjAtMWJl
+        My00M2NiLThlODgtMzM2ZmUwNzlhOThmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTQuNDk1MjYzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMjUxNGU4ZjhkM2E0OWI0YTIzNGNkZTc0
+        OTc3MzNiMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjU0LjUz
+        NDUzMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NTQuNTY2
+        NjA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7704045d7f943c3a91bc0a2a3b71d17
+      - ee7a1e69345f4ada92962add73c9dc02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ff6cbbb464d45ea8a9796991ed1a06c
+      - a21bf0095972447fa2601f0b63cdb3e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2328ff8949244227b72f09bbdd397d9d
+      - 679e18a47ab14eefbc11ba4fb35385fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b03ec7a54d1a47ebac9abbb9b744e594
+      - 8da3bdeccb5b4e86ae58c124040883b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:20:50 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - b74897d3458a45f3929eac0de01e5949
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/d310d238-123b-4924-aecf-6aa01cb3b406/"
+      - "/pulp/api/v3/remotes/rpm/rpm/bcc2684a-0230-41fb-92f9-f90240d4c091/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 50d026bb9cf342718a15f2639fb4e590
+      - d4573f6e4fa8445ead6d639f76874b4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Qz
-        MTBkMjM4LTEyM2ItNDkyNC1hZWNmLTZhYTAxY2IzYjQwNi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIwOjUwLjM5ODQxOFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Jj
+        YzI2ODRhLTAyMzAtNDFmYi05MmY5LWY5MDI0MGQ0YzA5MS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjU0Ljg2MDUxOFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIwOjUwLjM5ODQzOFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAwOjU0Ljg2MDU1MVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:54 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/"
+      - "/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c2752d9d8474bcbad13cef5cd4121c4
+      - d8b50687579c4d18a432620e7c0e4264
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjcxYjk4MWMtZWExZi00MGNiLTlkNTMtMzk4OGYxNjI2OTU2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6NTAuNTA5MzA4WiIsInZl
+        cG0vNmNhMTI3MWItZjRiOC00NWEyLWFhM2UtOGFjM2NjOTc2MGU4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NTQuOTk3MzcyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjcxYjk4MWMtZWExZi00MGNiLTlkNTMtMzk4OGYxNjI2OTU2L3ZlcnNp
+        cG0vNmNhMTI3MWItZjRiOC00NWEyLWFhM2UtOGFjM2NjOTc2MGU4L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82NzFiOTgxYy1l
-        YTFmLTQwY2ItOWQ1My0zOTg4ZjE2MjY5NTYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82Y2ExMjcxYi1m
+        NGI4LTQ1YTItYWEzZS04YWMzY2M5NzYwZTgvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b9d843f046de438a85f55ad7bb937a4f
+      - 16162766ff6646edb116d93815be6292
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82YzE1ODUzNC04ZTU4LTRjNTAtOTY1OC03ODczYWJjOTQ5Yzkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDozMi4wMDU5NTJa
+        cnBtL3JwbS9lMGQzYzM5Yi03YWJlLTQyZjItOTU2YS0wNzQ5YjdiOWE0NTcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDo0Ni4yNDQwNTRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82YzE1ODUzNC04ZTU4LTRjNTAtOTY1OC03ODczYWJjOTQ5Yzkv
+        cnBtL3JwbS9lMGQzYzM5Yi03YWJlLTQyZjItOTU2YS0wNzQ5YjdiOWE0NTcv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZjMTU4
-        NTM0LThlNTgtNGM1MC05NjU4LTc4NzNhYmM5NDljOS92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UwZDNj
+        MzliLTdhYmUtNDJmMi05NTZhLTA3NDliN2I5YTQ1Ny92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6c158534-8e58-4c50-9658-7873abc949c9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e0d3c39b-7abe-42f2-956a-0749b7b9a457/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9ab5d615754e443ca262a484e4de5066
+      - a860e555cd674f0c9df2695df60f1bc5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmZmUzNTNjLWY4MTktNDMx
-        ZC05ZGVkLTliOTJiN2EyOWRhMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlODY5ZjE2LTQ5Y2YtNGJh
+        Mi05Nzk4LTViN2EzYTM1OGM2NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a6071391d96a4bd89f1e284a1dc15478
+      - 9743331f60454f3db50727b3c838ed9a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNWZiY2Y0Y2MtYTJjNS00NTNhLWFlY2YtZmUyZTQ4ODM3NTVlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MzEuMTk3ODI1WiIsIm5h
+        cG0vMzllOTZhNzMtMDNkMi00MWE3LWI3NTMtNThlMmM2MDg4MDU4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NDUuMDk2MzQ5WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyMDozMi4zMzM0NjNaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMDo0Ni43ODU3MzhaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5fbcf4cc-a2c5-453a-aecf-fe2e4883755e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/39e96a73-03d2-41a7-b753-58e2c6088058/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f3a42abb42f42e394ab9cd0c4e74f74
+      - 5c653210ec2e47cf9444d09a0f1ed623
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlMjAwNDFlLTlmZWMtNDU1
-        NS05NDJiLTA2MDNhYzA5ZTVkMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViZGFjZTgxLWRjNTYtNDI0
+        Ny1hYzhlLWRlYTQzOTg0NzlkNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8ffe353c-f819-431d-9ded-9b92b7a29da0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0e869f16-49cf-4ba2-9798-5b7a3a358c65/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9bfb8807a1dd49a8bee94f7193283be6
+      - e56acaacca024154a35a1b71e15320ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGZmZTM1M2MtZjgx
-        OS00MzFkLTlkZWQtOWI5MmI3YTI5ZGEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTAuNjc5Mjk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGU4NjlmMTYtNDlj
+        Zi00YmEyLTk3OTgtNWI3YTNhMzU4YzY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTUuMjIwNDI3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5YWI1ZDYxNTc1NGU0NDNjYTI2MmE0ODRl
-        NGRlNTA2NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjUwLjcw
-        OTAzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTAuNzY0
-        ODk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhODYwZTU1NWNkNjc0ZjBjOWRmMjY5NWRm
+        NjBmMWJjNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjU1LjI2
+        NjE5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NTUuMzkz
+        MjcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmMxNTg1MzQtOGU1OC00YzUw
-        LTk2NTgtNzg3M2FiYzk0OWM5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBkM2MzOWItN2FiZS00MmYy
+        LTk1NmEtMDc0OWI3YjlhNDU3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/de20041e-9fec-4555-942b-0603ac09e5d1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5bdace81-dc56-4247-ac8e-dea4398479d6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af40a922ea9a4032a68a38253b351ab2
+      - 22305574f3ff43f593d6f879c25581c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGUyMDA0MWUtOWZl
-        Yy00NTU1LTk0MmItMDYwM2FjMDllNWQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTAuNzc1NTg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWJkYWNlODEtZGM1
+        Ni00MjQ3LWFjOGUtZGVhNDM5ODQ3OWQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTUuMzU5NDc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZjNhNDJhYmI0MmY0MmUzOTRhYjljZDBj
-        NGU3NGY3NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjUwLjgw
-        OTk0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTAuODUx
-        NDI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1YzY1MzIxMGVjMmU0N2NmOTQ0NGQwOWEw
+        ZjFlZDYyMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjU1LjQz
+        MjI4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NTUuNTA0
+        MzkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVmYmNmNGNjLWEyYzUtNDUzYS1hZWNm
-        LWZlMmU0ODgzNzU1ZS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM5ZTk2YTczLTAzZDItNDFhNy1iNzUz
+        LTU4ZTJjNjA4ODA1OC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '04385916bbdc482b94fcb87d2447acf9'
+      - 5399f00468bc4b569036414d460404b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7e697137e47b49a0ad61219e87da8e2b
+      - 42efcb6bdad14291ab6c663360d974f8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:50 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7cfa74e370c42cba87508a3c444f0fa
+      - 6583b179b5ee4b1483289d730268100a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:51 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8fcfa396c5946979a48a0c7b81d0e00
+      - 81207e41dea24ade8d55b9a5a59991a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:51 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9bcda570431140f8ae4f022e8f55d339
+      - 56fe40853ea84f9d9aacbd69203ad702
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:51 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d295daa517c54acaba5bbaeaa28b9841
+      - 1ff57a0a063b41e2af0465f3095e2658
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:51 GMT
+      - Fri, 29 Jul 2022 09:00:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/2c61e7a6-aca4-4509-977f-b9fec8bcf757/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0bf31574-a2f1-4852-b544-1edc09626cb0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - faa3341c985b44b28d0f5cfabb5bd694
+      - 3468adf6d4ee4e9d9f160ba662780396
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMmM2MWU3YTYtYWNhNC00NTA5LTk3N2YtYjlmZWM4YmNmNzU3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6NTEuMjIxODcyWiIsInZl
+        cG0vMGJmMzE1NzQtYTJmMS00ODUyLWI1NDQtMWVkYzA5NjI2Y2IwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NTUuOTU3MTA4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMmM2MWU3YTYtYWNhNC00NTA5LTk3N2YtYjlmZWM4YmNmNzU3L3ZlcnNp
+        cG0vMGJmMzE1NzQtYTJmMS00ODUyLWI1NDQtMWVkYzA5NjI2Y2IwL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yYzYxZTdhNi1h
-        Y2E0LTQ1MDktOTc3Zi1iOWZlYzhiY2Y3NTcvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wYmYzMTU3NC1h
+        MmYxLTQ4NTItYjU0NC0xZWRjMDk2MjZjYjAvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:55 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/d310d238-123b-4924-aecf-6aa01cb3b406/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/bcc2684a-0230-41fb-92f9-f90240d4c091/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:51 GMT
+      - Fri, 29 Jul 2022 09:00:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 626239d84f6c4fc787175ab2048dfedb
+      - fa344e9ae10b437eb9636a49c2cdb18c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAwOGFjNTU0LTcyN2UtNDI0
-        MC05MzY1LTYwMzBhM2JhOGI2ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjMDJmN2JiLWY2YzYtNDVh
+        MS05NmE4LTU1ZWZkZjNjZWM5Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/008ac554-727e-4240-9365-6030a3ba8b6d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bc02f7bb-f6c6-45a1-96a8-55efdf3cec9c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:51 GMT
+      - Fri, 29 Jul 2022 09:00:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '058c610d6477454aae0a4bfc7df1c05b'
+      - 66353734ade04d508ac26a4a35fdb79c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDA4YWM1NTQtNzI3
-        ZS00MjQwLTkzNjUtNjAzMGEzYmE4YjZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTEuNTIzNzE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmMwMmY3YmItZjZj
+        Ni00NWExLTk2YTgtNTVlZmRmM2NlYzljLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTYuMzI4MDc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI2MjYyMzlkODRmNmM0ZmM3ODcxNzVhYjIw
-        NDhkZmVkYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjUxLjU1
-        MjUxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTEuNTc0
-        MTM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmYTM0NGU5YWUxMGI0MzdlYjk2MzZhNDlj
+        MmNkYjE4YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjU2LjM2
+        NjQxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NTYuMzk2
+        NDA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2QzMTBkMjM4LTEyM2ItNDkyNC1hZWNm
-        LTZhYTAxY2IzYjQwNi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JjYzI2ODRhLTAyMzAtNDFmYi05MmY5
+        LWY5MDI0MGQ0YzA5MS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2QzMTBk
-        MjM4LTEyM2ItNDkyNC1hZWNmLTZhYTAxY2IzYjQwNi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JjYzI2
+        ODRhLTAyMzAtNDFmYi05MmY5LWY5MDI0MGQ0YzA5MS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:51 GMT
+      - Fri, 29 Jul 2022 09:00:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 18f6baa4350344c58b138f287a56e3eb
+      - 0f5073e68a0f473fada22ef6325c0982
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M0YmFmYTg1LTUwYWUtNDZl
-        OS05N2MwLWNjM2UwOTEwMzlmOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVkYzdhYWRlLWQ5MDYtNDRj
+        OS04ZWJmLTFkOTAxOTEwNTAyMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c4bafa85-50ae-46e9-97c0-cc3e091039f8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5dc7aade-d906-44c9-8ebf-1d9019105020/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:52 GMT
+      - Fri, 29 Jul 2022 09:00:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49d3caa574d04449baa684b48bd1df64
+      - cac4fc8e926447ec9e7dc5409a5da926
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '653'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzRiYWZhODUtNTBh
-        ZS00NmU5LTk3YzAtY2MzZTA5MTAzOWY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTEuNzIxNzY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWRjN2FhZGUtZDkw
+        Ni00NGM5LThlYmYtMWQ5MDE5MTA1MDIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTYuNDk0Mzc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxOGY2YmFhNDM1MDM0NGM1OGIx
-        MzhmMjg3YTU2ZTNlYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjUxLjc1NDM0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        NTIuNTExODcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwZjUwNzNlNjhhMGY0NzNmYWRh
+        MjJlZjYzMjVjMDk4MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjU2LjU1NDg0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        NTcuNzIzMDQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzY3MWI5ODFjLWVhMWYtNDBjYi05ZDUzLTM5ODhm
-        MTYyNjk1Ni92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82NzFi
-        OTgxYy1lYTFmLTQwY2ItOWQ1My0zOTg4ZjE2MjY5NTYvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZDMxMGQyMzgtMTIzYi00OTI0
-        LWFlY2YtNmFhMDFjYjNiNDA2LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS82Y2ExMjcxYi1mNGI4LTQ1YTItYWEzZS04YWMzY2M5
+        NzYwZTgvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmNhMTI3
+        MWItZjRiOC00NWEyLWFhM2UtOGFjM2NjOTc2MGU4LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JjYzI2ODRhLTAyMzAtNDFmYi05
+        MmY5LWY5MDI0MGQ0YzA5MS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNjcxYjk4MWMtZWExZi00MGNiLTlkNTMtMzk4OGYxNjI2
-        OTU2L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNmNhMTI3MWItZjRiOC00NWEyLWFhM2UtOGFjM2NjOTc2
+        MGU4L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:52 GMT
+      - Fri, 29 Jul 2022 09:00:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dcdbae0011d34c6e94409b29be726f9a
+      - debb2c690d7b443791ae2ff7d50680ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlZDA2NDBmLWMyOTQtNGZi
-        MC04ODVhLWE1ZGFmZGYzNzFmYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3ZWQ4Njc3LTkzODItNGNh
+        Zi05ZTc1LWY3NDAyMjNhYzRmYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4ed0640f-c294-4fb0-885a-a5dafdf371fb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/07ed8677-9382-4caf-9e75-f740223ac4fc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:53 GMT
+      - Fri, 29 Jul 2022 09:00:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 92a26c3e77c041029aa2c26100a95375
+      - 6e6cacab3b124bc8ab2cfeba171ecb12
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGVkMDY0MGYtYzI5
-        NC00ZmIwLTg4NWEtYTVkYWZkZjM3MWZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTIuODAxNTM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDdlZDg2NzctOTM4
+        Mi00Y2FmLTllNzUtZjc0MDIyM2FjNGZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTguNDI1MTY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImRjZGJhZTAwMTFkMzRjNmU5NDQwOWIyOWJl
-        NzI2ZjlhIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTIuODMw
-        NjU1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMDo1My4wNjYw
-        ODdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImRlYmIyYzY5MGQ3YjQ0Mzc5MWFlMmZmN2Q1
+        MDY4MGVjIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NTguNDY2
+        MjczWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMDo1OC44NDk3
+        OThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMjFiZjRm
-        ZmUtMzA1Mi00Y2IwLThlY2EtOTM5NTc5MzE4YmIyLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTIzM2Mx
+        ODAtNzdlNy00MTdmLTgzY2EtNDVlYzdiMjg4Y2Y2LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNjcxYjk4MWMtZWExZi00MGNiLTlkNTMtMzk4OGYx
-        NjI2OTU2LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNmNhMTI3MWItZjRiOC00NWEyLWFhM2UtOGFjM2Nj
+        OTc2MGU4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:53 GMT
+      - Fri, 29 Jul 2022 09:00:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbb574286ac4468c93d7a0b38cd46a10
+      - 065c9c79725e41ceb7ee3e3236c3b015
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:59 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/5233c180-77e7-417f-83ca-45ec7b288cf6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 660193d51cb64b96a51f4585a3415f11
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNTIzM2MxODAtNzdlNy00MTdmLTgzY2EtNDVlYzdiMjg4Y2Y2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NTguNDg2OTA1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82Y2ExMjcxYi1mNGI4LTQ1YTItYWEzZS04YWMzY2M5NzYwZTgv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzZjYTEyNzFiLWY0YjgtNDVhMi1hYTNlLThhYzNj
+        Yzk3NjBlOC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:59 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS81MjMzYzE4MC03N2U3LTQxN2YtODNjYS00NWVjN2IyODhjZjYv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 876e0ae67f7a48f6b047aaec9556ff5e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjNDFlNGFmLWI0MGUtNGEy
+        OC1iODAzLTBiMDUxMDU2YTY2NS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:59 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2c41e4af-b40e-4a28-b803-0b051056a665/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e212ba2ab4f44eaeac471bc5bc95de2e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmM0MWU0YWYtYjQw
+        ZS00YTI4LWI4MDMtMGIwNTEwNTZhNjY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTkuMTMzODQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4NzZlMGFlNjdmN2E0OGY2YjA0N2FhZWM5
+        NTU2ZmY1ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjU5LjE3
+        NzYwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NTkuNTA0
+        MjU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNjcx
+        ZDAyYmMtNTE4Ny00ZmNlLTgwMjEtZjZhNjc0OWE3NDg0LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:59 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/671d02bc-5187-4fce-8021-f6a6749a7484/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 28f2c5bea56843b6b2335df6fc1bc7b1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzY3MWQwMmJjLTUxODctNGZjZS04MDIxLWY2YTY3NDlhNzQ4NC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjU5LjQ4Njg5NVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNTIzM2MxODAtNzdlNy00MTdmLTgzY2Et
+        NDVlYzdiMjg4Y2Y2LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:59 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6afbfdc4052d49e987aa4e7bde7e7c3f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:53 GMT
+      - Fri, 29 Jul 2022 09:01:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1747e8cdf3a64e6aa79de08b4f7bafb2
+      - 480ede1657274e1ba5640b25e37172ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:53 GMT
+      - Fri, 29 Jul 2022 09:01:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ba4e218b99c402d93938864875a3d4a
+      - 9de7209a34004c098cc4a5337c2c8f3a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:53 GMT
+      - Fri, 29 Jul 2022 09:01:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a9f41a1009443d5862733451970c35f
+      - 81142995419545a480bca04c0a9cdd79
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:53 GMT
+      - Fri, 29 Jul 2022 09:01:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6099c4c15aa647ffb8462fb122697384
+      - 05b924d4e64e456cb84bae63e041adb3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:53 GMT
+      - Fri, 29 Jul 2022 09:01:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a773d5b6b0f4b4c80bef2e6e49da33b
+      - b1557ae635ae46c9bc97727531499ab8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:53 GMT
+      - Fri, 29 Jul 2022 09:01:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 330c63f8a0c94226b8ac32aa9eed432e
+      - 7bbdabdd5b1a4e7587dca254eb93944c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25338f2630cb4373a0861de5893fd37d
+      - a606269c7d35452e87a0a0c2b8f57de9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad55980083ca4ee8b78928861b0babd7
+      - d83322fe8388488e84e5bf347ff782ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8407dd82a2ed445b88d6da05f3d48473
+      - 1daee54571164ea4a0c355c5cb90a16f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25f821959f454cdf810e67859cec927b
+      - 80d8088c741941cdadfa455cc867f82a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 477f3dd389c7426182bf098c7c4354a9
+      - c38aefc4662c4ef395906eac60bd1d61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57693f11a62b47e9a2ce88763a57c1cf
+      - 83708155bc9048b0ba0dc24aeb684573
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa6faf4f52a44289a99f2c49a4dd6c55
+      - 90b93d6e11ea4e05b1a1df94c9eec64f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:01 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/2c61e7a6-aca4-4509-977f-b9fec8bcf757/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0bf31574-a2f1-4852-b544-1edc09626cb0/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,99 +3819,99 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1d388f8b27b44f78fb19765a8c9fd9c
+      - c90337f782b74c63aba0e4a478c94922
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjMjQ5NzY1LTRkYWUtNDAx
-        Ni04YWI1LWVjMWFlNWRjOTE4OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlYWYzYjJjLTE0ZDEtNDIz
+        OC05MGVmLTY0ZTE2MWJhNmFhOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:01 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/2c61e7a6-aca4-4509-977f-b9fec8bcf757/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0bf31574-a2f1-4852-b544-1edc09626cb0/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80NjRmNzQ1Mi04ODhiLTQyZjctODMyMi03YTlkZGQ1
-        YThhNzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NmExMGJiYmYtNTFlMS00MTVhLWEwMGYtNzliNzFhZTFkM2Q0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzdmZmQ2MDc2LWY3ZGQt
-        NDVkMy04ZjE3LTdmYzQxOGQxYWRmMy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYtZTRkNzNhOGFiMGJlLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VlNzJhOWU2LTNh
-        ZmYtNDI3Ny1iMzJiLWFiOTIwNGE1NTliOS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vYWR2aXNvcmllcy9lZjgyN2RkNy1hMmE5LTQzODUtODAyMS1i
-        ZTJjZDk4ZmU4YzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
-        aWJ1dGlvbl90cmVlcy9jN2UzNTQxNy05ZDg3LTQ4ZGUtOThkOC01MmQ2MzVi
-        M2VlYmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
-        ODc3NjQyNi0zZjNmLTRhNjItYmIxYy05ODRjNTZmYjMwNDMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82OGRjNGJlNC04MzdmLTRm
-        NmItOWY4OC01MWRlYTMwMGRlODcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy84MDBiNTVjNi05NzUzLTQzODEtOWQ3OC0wZmRlMmRk
-        ZmVlNDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9i
-        MTJhMjE2Zi01ZTU2LTQ4ODEtYWZhZi02OWFjNWU1ZmRjMDIvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4
-        YjItODE0My1hNjE5MGRiZWI4YzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy9lNzQxM2ZlMC0zMDY3LTQ1NmQtOTVmYy0wNmIyYmRh
-        MjcyYWMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvNjgwZGFhYjItYWE1Yy00NGJkLTg2NjctZTBhZmNhOWY4OTBiLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2E5ODk4ZmE5
-        LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2MwZmUwNS8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQt
-        ZGNlZWUyZWY3OGMyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8xM2EyNGRmNC03Y2MyLTQ1ZjMtYjViMC01NjhlNmVkMjYzZjUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzIzOTI4Yzg2LTYy
-        YWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMjg0MDQ3ZDgtNWFjNi00NmFiLTk1ZTgtYjI1
-        MDljMjhlMjlhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yYWU3YjhjMy05OWU3LTQ5YjAtOThiZS03MjIzYjY5ODVlMjgvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMt
-        NGQxZC1hZjU0LTRmMTFhZDBjZjRlNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00YTEyLWI2NzktNWNkM2Rk
-        ZGE5YTU3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81
-        ZTI0MGY3My03MWU4LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVmMzFkOWRkLTY5NzgtNDBh
-        Yi1hMjhkLTEzNWUwMjgwNzIyOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0OC00ZWM2LWIyMjEtN2U5N2MzNjg5
-        MWI3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZDYw
-        ZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04
-        ZDgxLWNlNjBkMTY2ZDIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvOTZmOTlkOTItMzc1MC00YTQ5LTk4ZmUtNDY2YTE1MjE3OTcx
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85YWQwN2U2
-        MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1MzI2ZmZlLTZiZTEtNDUyMy04YTY3
-        LWE5Y2RmZDZlNWJmMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvYmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMWMyOTIwNi00
-        MTEwLTQyMDgtYTIwYy1jMzg1NWNkNGY0MGMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2Q1YTJmMWFkLTA0MmEtNDA1ZS1hYzQ0LTBj
-        NGIxNGRiYmVjYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNjZmYzg0Ni0zNDhj
-        LTQzNTAtODZlMS1jMzJiZGNhNDFkM2UvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZDI0NDFlYWEtM2ZjMS00Nzc1
-        LTkyMGUtYTZkNzY4ZDZjMjE3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRh
-        LTg3YmNhOGViMzllMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5N2QtOTkyMTM4
-        NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
-        ZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2ZTE4NGQ5MmIv
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1i
+        OTFkMDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
+        aWJ1dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRk
+        NTBhMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
+        Yzg0MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRl
+        OTktYmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3
+        YTExOTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8z
+        YjliOWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRi
+        NTktODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdh
+        YzAzODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0
+        LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvMDVlMzY4ZDctMjkxYS00MzM2LWFkYmQt
+        ZDg5YjdiMDFkODQ2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1iMjc2ZmZhN2U4MjYvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM1YmJhMDBiLTZm
+        MTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy80ODA2MDhjMS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMt
+        NGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1ZmJiOTc0LTE1MmMtNDk2
+        ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3
+        YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4
+        M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04
+        MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNhMzhh
+        Mi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJi
+        LTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02
+        MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0
+        MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMx
+        LTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4
+        LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
+        dWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQtZjIwM2Nh
+        MzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
+        ZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDliODIzMjMv
         IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRz
-        LzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0YS8iXX0=
+        L2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3499,7 +3924,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3517,21 +3942,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3c23436bbcb47c092becc1e515acf5a
+      - ed5478d5237349d48686fe5d2bb95f2f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhMzBjMmJlLWUwOTAtNDJk
-        Ni05MTMzLWVjYWRkMmJmNWI2OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzYmVhN2Q1LWQ4NzMtNDNj
+        NC05ZjVjLTQyNjQ0NTExMjM4NC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0a30c2be-e090-42d6-9133-ecadd2bf5b69/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f3bea7d5-d873-43c4-9f5c-426445112384/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3552,53 +3977,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:54 GMT
+      - Fri, 29 Jul 2022 09:01:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d0d80c821e84b33b331813944a6a394
+      - 7571ea145c2541acb4f739737862bb21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGEzMGMyYmUtZTA5
-        MC00MmQ2LTkxMzMtZWNhZGQyYmY1YjY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTQuNDM3NDc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjNiZWE3ZDUtZDg3
+        My00M2M0LTlmNWMtNDI2NDQ1MTEyMzg0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDEuODI2NTE3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiM2MyMzQzNmJiY2I0N2MwOTJi
-        ZWNjMWU1MTVhY2Y1YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjU0LjU2MjE4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        NTQuNzI3OTcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlZDU0NzhkNTIzNzM0OWQ0ODY4
+        NmZlNWQyYmI5NWYyZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjAyLjAyMzM3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        MDIuMzA5NzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8yYzYxZTdhNi1hY2E0LTQ1MDktOTc3Zi1iOWZlYzhiY2Y3NTcvdmVyc2lv
+        bS8wYmYzMTU3NC1hMmYxLTQ4NTItYjU0NC0xZWRjMDk2MjZjYjAvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmM2MWU3YTYtYWNhNC00NTA5
-        LTk3N2YtYjlmZWM4YmNmNzU3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGJmMzE1NzQtYTJmMS00ODUy
+        LWI1NDQtMWVkYzA5NjI2Y2IwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3606,7 +4031,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3619,36 +4044,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:55 GMT
+      - Fri, 29 Jul 2022 09:01:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 54f784af27d44c4fa7c403d4583ff24b
+      - 4c32b0e6f3824ffcb5b7b770c03b3689
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3670,10 +4095,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2c61e7a6-aca4-4509-977f-b9fec8bcf757/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0bf31574-a2f1-4852-b544-1edc09626cb0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3681,7 +4106,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3694,36 +4119,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:55 GMT
+      - Fri, 29 Jul 2022 09:01:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2772ec3378ab46a8b39953d6cfefcd37
+      - d7a6feee7d184974b26f7a5c660faf91
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3745,5 +4170,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:02 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_distribution_trees_repository/no_package_environments_are_copied_despite_whitelist_ids.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_distribution_trees_repository/no_package_environments_are_copied_despite_whitelist_ids.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:55 GMT
+      - Fri, 29 Jul 2022 09:01:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce531aef8ba644488094383d79c5605e
+      - b862a63cea3f498291bd425bff1b9991
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82NzFiOTgxYy1lYTFmLTQwY2ItOWQ1My0zOTg4ZjE2MjY5NTYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDo1MC41MDkzMDha
+        cnBtL3JwbS82Y2ExMjcxYi1mNGI4LTQ1YTItYWEzZS04YWMzY2M5NzYwZTgv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDo1NC45OTczNzJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82NzFiOTgxYy1lYTFmLTQwY2ItOWQ1My0zOTg4ZjE2MjY5NTYv
+        cnBtL3JwbS82Y2ExMjcxYi1mNGI4LTQ1YTItYWEzZS04YWMzY2M5NzYwZTgv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY3MWI5
-        ODFjLWVhMWYtNDBjYi05ZDUzLTM5ODhmMTYyNjk1Ni92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZjYTEy
+        NzFiLWY0YjgtNDVhMi1hYTNlLThhYzNjYzk3NjBlOC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:03 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/671b981c-ea1f-40cb-9d53-3988f1626956/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6ca1271b-f4b8-45a2-aa3e-8ac3cc9760e8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:55 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b391e3c6761472b9ac4daf9a171223b
+      - 58a948934fd2414db7070e13f4896c3c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzMzFkMDQ5LTg5MjQtNDU0
-        YS1iNTU5LWM4YmU4NjQxNjkyMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiNTk3MzJhLTE3OWUtNGE4
+        NS1iY2U2LTVmMmFhYTE3ZTU1MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:55 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b04c6e6a36c147e2a7f9a5c410da1285
+      - 7b5f219a2fdf4f28b263936aaf1f845a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5331d049-8924-454a-b559-c8be86416923/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0b59732a-179e-4a85-bce6-5f2aaa17e551/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9449576ad3b4718af60e28c38c2a499
+      - bf70c14b3a65490688b650295e7c38b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTMzMWQwNDktODky
-        NC00NTRhLWI1NTktYzhiZTg2NDE2OTIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTUuODc5MDAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGI1OTczMmEtMTc5
+        ZS00YTg1LWJjZTYtNWYyYWFhMTdlNTUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDQuMDI2OTIwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4YjM5MWUzYzY3NjE0NzJiOWFjNGRhZjlh
-        MTcxMjIzYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjU1Ljkx
-        MTM4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTYuMDM2
-        OTA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1OGE5NDg5MzRmZDI0MTRkYjcwNzBlMTNm
+        NDg5NmMzYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjA0LjA2
+        NjM3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MDQuMjk4
+        NjM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjcxYjk4MWMtZWExZi00MGNi
-        LTlkNTMtMzk4OGYxNjI2OTU2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmNhMTI3MWItZjRiOC00NWEy
+        LWFhM2UtOGFjM2NjOTc2MGU4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7021075d085941e18ad6fbc87479a39b
+      - 936290c14151481e9198275ccfe5a402
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 26e870132b774600acaab89826fbc029
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNjcxZDAyYmMtNTE4Ny00ZmNlLTgwMjEtZjZhNjc0OWE3NDg0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NTkuNDg2ODk1
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/671d02bc-5187-4fce-8021-f6a6749a7484/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4adc282a83c745d08b7c44bd5e277ca8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1MzQ5ZDZhLTUwZWYtNGM0
+        My05ZmQ1LWQ5ZDkyNTEwM2NmYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/25349d6a-50ef-4c43-9fd5-d9d925103cfa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1a5bed0dd39d4b7c97964a5fa0eaf473
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjUzNDlkNmEtNTBl
+        Zi00YzQzLTlmZDUtZDlkOTI1MTAzY2ZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDQuNDYyMTUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0YWRjMjgyYTgzYzc0NWQwOGI3YzQ0YmQ1
+        ZTI3N2NhOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjA0LjUw
+        MTU4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MDQuNTM3
+        NjQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e50557543a09417aaa3451afb0539441
+      - 6149cacb4418453a855051dd714f4ed9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0afe1fc212174c9f827812bec6bca3e2
+      - 129dd7b3d15e46a1bd81fc827a3d49bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2bb005f394f9481c9d80204f00a592e1
+      - 439d217310fb48a98e120e94bd943f15
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 82bd75ce730e4a1bb2a029c55125219b
+      - c3450e26505449e7a25fee13c0f186d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:20:56 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - bd4e7a277bb1497aa026a44cc964fc43
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/192e4c09-0c40-4f3b-90f9-925bcf7f8d62/"
+      - "/pulp/api/v3/remotes/rpm/rpm/1b06b9bb-57ed-41da-a8c8-d5415f706b5d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 02f3a45ef82a470ea8f4171523558785
+      - a951d6e84a8c43bd878be6fea6dda736
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE5
-        MmU0YzA5LTBjNDAtNGYzYi05MGY5LTkyNWJjZjdmOGQ2Mi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIwOjU2LjQwNDU4N1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFi
+        MDZiOWJiLTU3ZWQtNDFkYS1hOGM4LWQ1NDE1ZjcwNmI1ZC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjA0LjgyNDQ0NVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIwOjU2LjQwNDYwNloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAxOjA0LjgyNDQ2OFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/"
+      - "/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 130cc746d9024eb5aed5ed0df20f518a
+      - f485d98230ad4522b1cf77cdbe64d46c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzA0MjlmNjgtZGZhYy00MzcyLWE4MjAtMzliYzQyN2VmMjg0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6NTYuNTE0NDQ5WiIsInZl
+        cG0vNjI3NDZjODQtNzM0OS00NjdmLWFjMWYtMzExM2UzMDI3YzVlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MDQuOTYyMTUxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzA0MjlmNjgtZGZhYy00MzcyLWE4MjAtMzliYzQyN2VmMjg0L3ZlcnNp
+        cG0vNjI3NDZjODQtNzM0OS00NjdmLWFjMWYtMzExM2UzMDI3YzVlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jMDQyOWY2OC1k
-        ZmFjLTQzNzItYTgyMC0zOWJjNDI3ZWYyODQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82Mjc0NmM4NC03
+        MzQ5LTQ2N2YtYWMxZi0zMTEzZTMwMjdjNWUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94e948ec05de4be7ae8b6cc812f468ba
+      - a9bfd98d32eb4476af93107fa09e63b5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yYzYxZTdhNi1hY2E0LTQ1MDktOTc3Zi1iOWZlYzhiY2Y3NTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDo1MS4yMjE4NzJa
+        cnBtL3JwbS8wYmYzMTU3NC1hMmYxLTQ4NTItYjU0NC0xZWRjMDk2MjZjYjAv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDo1NS45NTcxMDha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yYzYxZTdhNi1hY2E0LTQ1MDktOTc3Zi1iOWZlYzhiY2Y3NTcv
+        cnBtL3JwbS8wYmYzMTU3NC1hMmYxLTQ4NTItYjU0NC0xZWRjMDk2MjZjYjAv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJjNjFl
-        N2E2LWFjYTQtNDUwOS05NzdmLWI5ZmVjOGJjZjc1Ny92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBiZjMx
+        NTc0LWEyZjEtNDg1Mi1iNTQ0LTFlZGMwOTYyNmNiMC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/2c61e7a6-aca4-4509-977f-b9fec8bcf757/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0bf31574-a2f1-4852-b544-1edc09626cb0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b52f9897ada14643a46885836cdd3d0e
+      - 231c480583704ac59316474a5921fbaf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjZTAxNmUzLWExNGMtNGRm
-        Ni1hNjBmLWI1ZDA2NDRjYzdiMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJlMGQzYmYyLWRlMjMtNDUz
+        ZS05MzNlLTUwYzNhMTc0YmRhYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2b8c15a43ef4e56a921722f09804660
+      - 0af622f9f7a245019bcf6acc077e42db
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZDMxMGQyMzgtMTIzYi00OTI0LWFlY2YtNmFhMDFjYjNiNDA2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6NTAuMzk4NDE4WiIsIm5h
+        cG0vYmNjMjY4NGEtMDIzMC00MWZiLTkyZjktZjkwMjQwZDRjMDkxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NTQuODYwNTE4WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyMDo1MS41Njk3NjNaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMDo1Ni4zOTA1NTFaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/d310d238-123b-4924-aecf-6aa01cb3b406/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/bcc2684a-0230-41fb-92f9-f90240d4c091/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7e34d3cac4b141449e020906f17ef2d6
+      - 84eea530b65044ebb4978500c343391f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExNWQ5ZmM3LWZhYjYtNGMw
-        Mi04ODM3LWFjNDJkZTQwNTFjMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE0MDY1NjUzLTJjMjEtNGI1
+        MC05M2FiLTY5OThkZThiZTg4Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6ce016e3-a14c-4df6-a60f-b5d0644cc7b2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2e0d3bf2-de23-453e-933e-50c3a174bdab/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a10d05a03882476580aa1cc5b6065ae4
+      - a7cf30012aff4c5d97a90aa3909a39bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmNlMDE2ZTMtYTE0
-        Yy00ZGY2LWE2MGYtYjVkMDY0NGNjN2IyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTYuNzA3MTYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmUwZDNiZjItZGUy
+        My00NTNlLTkzM2UtNTBjM2ExNzRiZGFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDUuMjA1NTY3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiNTJmOTg5N2FkYTE0NjQzYTQ2ODg1ODM2
-        Y2RkM2QwZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjU2Ljc0
-        NTIyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTYuODA3
-        NDc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMzFjNDgwNTgzNzA0YWM1OTMxNjQ3NGE1
+        OTIxZmJhZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjA1LjI1
+        MDQ5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MDUuMzU3
+        NjgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmM2MWU3YTYtYWNhNC00NTA5
-        LTk3N2YtYjlmZWM4YmNmNzU3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGJmMzE1NzQtYTJmMS00ODUy
+        LWI1NDQtMWVkYzA5NjI2Y2IwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a15d9fc7-fab6-4c02-8837-ac42de4051c1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/14065653-2c21-4b50-93ab-6998de8be886/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a57b605bb1b4287a32eed132957eeb9
+      - c3e3ecb8e94b4fdf959e2d4508e45db8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTE1ZDlmYzctZmFi
-        Ni00YzAyLTg4MzctYWM0MmRlNDA1MWMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTYuNzk0ODYzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTQwNjU2NTMtMmMy
+        MS00YjUwLTkzYWItNjk5OGRlOGJlODg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDUuMzQyNDc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3ZTM0ZDNjYWM0YjE0MTQ0OWUwMjA5MDZm
-        MTdlZjJkNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjU2Ljgy
-        NzczOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTYuODY5
-        NjMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NGVlYTUzMGI2NTA0NGViYjQ5Nzg1MDBj
+        MzQzMzkxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjA1LjQw
+        NDI0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MDUuNDYx
+        OTgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2QzMTBkMjM4LTEyM2ItNDkyNC1hZWNm
-        LTZhYTAxY2IzYjQwNi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JjYzI2ODRhLTAyMzAtNDFmYi05MmY5
+        LWY5MDI0MGQ0YzA5MS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c6c147f261ab4cd1bf5d6dd84eb40520
+      - f18a54e9b6ca43989ab5875268fe9840
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:56 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f93124a1f3d4d6c90576be46a126126
+      - d8823a8dc9a34b88a2b4a54e6bc98b40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:57 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a97762b8746e4717ba06c12dcd263af6
+      - 80b8cf6658524161a3d5c434250e0ff5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:57 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33b06e0841104303bc0f1e79d9356dc2
+      - c59e822710b84bf08d20db5e6c007c84
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:57 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '085b2a4212c3495ab593c9313793119d'
+      - c2b48aaf062f4ebe8ef693e469e3de54
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:57 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25dd1990439a4c76858f9127d4ff18e6
+      - f3f38528d11e4298a937903cc7eeb7e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:57 GMT
+      - Fri, 29 Jul 2022 09:01:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/8f39d593-c4f1-4cb0-b360-7fc8101531f7/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d41eb0c9-e1cb-470c-a496-9b107c946693/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c78b217240146cbaeacd716a7ee66d2
+      - 0db4d915c97d4fc99c589a56201d812e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOGYzOWQ1OTMtYzRmMS00Y2IwLWIzNjAtN2ZjODEwMTUzMWY3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6NTcuMjM5ODIzWiIsInZl
+        cG0vZDQxZWIwYzktZTFjYi00NzBjLWE0OTYtOWIxMDdjOTQ2NjkzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MDUuOTQ1NTAxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOGYzOWQ1OTMtYzRmMS00Y2IwLWIzNjAtN2ZjODEwMTUzMWY3L3ZlcnNp
+        cG0vZDQxZWIwYzktZTFjYi00NzBjLWE0OTYtOWIxMDdjOTQ2NjkzL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84ZjM5ZDU5My1j
-        NGYxLTRjYjAtYjM2MC03ZmM4MTAxNTMxZjcvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kNDFlYjBjOS1l
+        MWNiLTQ3MGMtYTQ5Ni05YjEwN2M5NDY2OTMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:05 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/192e4c09-0c40-4f3b-90f9-925bcf7f8d62/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/1b06b9bb-57ed-41da-a8c8-d5415f706b5d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:57 GMT
+      - Fri, 29 Jul 2022 09:01:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c7d203086a204628b54876a4c8cf0010
+      - abbf03f80ac0476dab80b8fe6398f132
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2NjAzZTI3LWE3M2MtNGZm
-        MC1iYWNmLWVjZWMyMDQyNjRiZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzN2Y0ZjcxLTljMzMtNDBk
+        YS05N2E2LTA0MmZiYzY5MmVlYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/56603e27-a73c-4ff0-bacf-ecec204264bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a37f4f71-9c33-40da-97a6-042fbc692eea/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:57 GMT
+      - Fri, 29 Jul 2022 09:01:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7aca544a443743f5ab1b69c11f164886
+      - e439f85f90404496b89d35d7e59f67ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTY2MDNlMjctYTcz
-        Yy00ZmYwLWJhY2YtZWNlYzIwNDI2NGJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTcuNjc3MzE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTM3ZjRmNzEtOWMz
+        My00MGRhLTk3YTYtMDQyZmJjNjkyZWVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDYuMzExMjM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJjN2QyMDMwODZhMjA0NjI4YjU0ODc2YTRj
-        OGNmMDAxMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjU3Ljcx
-        MTQwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTcuNzM2
-        MDk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhYmJmMDNmODBhYzA0NzZkYWI4MGI4ZmU2
+        Mzk4ZjEzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjA2LjM1
+        NzYwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MDYuMzg1
+        OTc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE5MmU0YzA5LTBjNDAtNGYzYi05MGY5
-        LTkyNWJjZjdmOGQ2Mi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFiMDZiOWJiLTU3ZWQtNDFkYS1hOGM4
+        LWQ1NDE1ZjcwNmI1ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE5MmU0
-        YzA5LTBjNDAtNGYzYi05MGY5LTkyNWJjZjdmOGQ2Mi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFiMDZi
+        OWJiLTU3ZWQtNDFkYS1hOGM4LWQ1NDE1ZjcwNmI1ZC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:57 GMT
+      - Fri, 29 Jul 2022 09:01:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7a013740d4d41e7b18ca9205eed457b
+      - a96b32414c3e431389c18112c7f4de35
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3ZTUyOGI1LThmNDUtNGY3
-        Zi05ZGEwLTA1YzIwOTM4OTMxYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlYWZiZGNjLTU0OWUtNDA3
+        MC04YTNhLTYwNzlkMGU3YjcyNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e7e528b5-8f45-4f7f-9da0-05c20938931a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/eeafbdcc-549e-4070-8a3a-6079d0e7b724/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:58 GMT
+      - Fri, 29 Jul 2022 09:01:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6950a243362d4c4395e4853a7c8b6516
+      - 6b22d4214bb64b278b487ea36bc1bf7d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTdlNTI4YjUtOGY0
-        NS00ZjdmLTlkYTAtMDVjMjA5Mzg5MzFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTcuODUzODc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWVhZmJkY2MtNTQ5
+        ZS00MDcwLThhM2EtNjA3OWQwZTdiNzI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDYuNTY0MDg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkN2EwMTM3NDBkNGQ0MWU3YjE4
-        Y2E5MjA1ZWVkNDU3YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjU3Ljg4NDI1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        NTguNjMzNjkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJhOTZiMzI0MTRjM2U0MzEzODlj
+        MTgxMTJjN2Y0ZGUzNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjA2LjYxNzc5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        MDcuNzU5MTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MwNDI5ZjY4LWRmYWMtNDM3Mi1hODIwLTM5YmM0
-        MjdlZjI4NC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jMDQy
-        OWY2OC1kZmFjLTQzNzItYTgyMC0zOWJjNDI3ZWYyODQvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMTkyZTRjMDktMGM0MC00ZjNi
-        LTkwZjktOTI1YmNmN2Y4ZDYyLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS82Mjc0NmM4NC03MzQ5LTQ2N2YtYWMxZi0zMTEzZTMw
+        MjdjNWUvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjI3NDZj
+        ODQtNzM0OS00NjdmLWFjMWYtMzExM2UzMDI3YzVlLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFiMDZiOWJiLTU3ZWQtNDFkYS1h
+        OGM4LWQ1NDE1ZjcwNmI1ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:08 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYzA0MjlmNjgtZGZhYy00MzcyLWE4MjAtMzliYzQyN2Vm
-        Mjg0L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNjI3NDZjODQtNzM0OS00NjdmLWFjMWYtMzExM2UzMDI3
+        YzVlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:59 GMT
+      - Fri, 29 Jul 2022 09:01:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74c08896ed72496099a8267224e1dd57
+      - 3847905c13274f5084bf99c626452a85
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdiYjg1OWZkLWZjZDUtNDM2
-        Ni05MDQ5LTA2ZTdjMjAxYTE5Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjOWI3OTAwLTIyYTMtNDFm
+        Zi05NjM4LWMyZDk0MTA1N2Q1Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7bb859fd-fcd5-4366-9049-06e7c201a19b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0c9b7900-22a3-41ff-9638-c2d941057d57/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:59 GMT
+      - Fri, 29 Jul 2022 09:01:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e39fac0bdc264a95a548026c58dab19e
+      - 6e0f40a7224b4bb7b43397e199a72d7d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '478'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2JiODU5ZmQtZmNk
-        NS00MzY2LTkwNDktMDZlN2MyMDFhMTliLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6NTguOTkwMTA5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGM5Yjc5MDAtMjJh
+        My00MWZmLTk2MzgtYzJkOTQxMDU3ZDU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDguMjEyMzMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6Ijc0YzA4ODk2ZWQ3MjQ5NjA5OWE4MjY3MjI0
-        ZTFkZDU3Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6NTkuMDE5
-        NDk3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMDo1OS4yNjI5
-        NDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjM4NDc5MDVjMTMyNzRmNTA4NGJmOTljNjI2
+        NDUyYTg1Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MDguMjU2
+        ODIzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMTowOC42NTIy
+        ODhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZmM3M2Vi
-        MzItNzEyZC00MTEzLTljZjgtMjA2NWU2NmZmZDY2LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjYyNjlj
+        ODgtZjgzNy00YzMyLTgzZWItYTBkZWY1NWRlYzlkLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYzA0MjlmNjgtZGZhYy00MzcyLWE4MjAtMzliYzQy
-        N2VmMjg0LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNjI3NDZjODQtNzM0OS00NjdmLWFjMWYtMzExM2Uz
+        MDI3YzVlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:59 GMT
+      - Fri, 29 Jul 2022 09:01:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 674dcbd6e1e34fc48ae7d8634cf1344e
+      - 111ed6910cfd4a91b4757ed14c76311c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/66269c88-f837-4c32-83eb-a0def55dec9d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0474b659bf3f48528d9a10614425291b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNjYyNjljODgtZjgzNy00YzMyLTgzZWItYTBkZWY1NWRlYzlkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MDguMjgwMDMyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82Mjc0NmM4NC03MzQ5LTQ2N2YtYWMxZi0zMTEzZTMwMjdjNWUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzYyNzQ2Yzg0LTczNDktNDY3Zi1hYzFmLTMxMTNl
+        MzAyN2M1ZS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:08 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS82NjI2OWM4OC1mODM3LTRjMzItODNlYi1hMGRlZjU1ZGVjOWQv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 207003305cd44e01ac0b5ee38c5b9bd7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiOTY2Yzk2LTI4MzktNDdm
+        Ny04NTFlLTQ3M2RhZmEwYTUwNy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/cb966c96-2839-47f7-851e-473dafa0a507/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b9433f6eebcc44a5aed68a5cee1d9bae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2I5NjZjOTYtMjgz
+        OS00N2Y3LTg1MWUtNDczZGFmYTBhNTA3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MDguOTM4MTI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyMDcwMDMzMDVjZDQ0ZTAxYWMwYjVlZTM4
+        YzViOWJkNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjA4Ljk4
+        MTA4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MDkuMzM3
+        NDQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vODI4
+        NjUxNjgtNjEzMy00MGIwLTgzY2QtYzY2NTc0MzM3ZTc2LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/82865168-6133-40b0-83cd-c66574337e76/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 54fc5593a7ff435e8b193646684d40e2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzgyODY1MTY4LTYxMzMtNDBiMC04M2NkLWM2NjU3NDMzN2U3Ni8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjA5LjMxOTYxMloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNjYyNjljODgtZjgzNy00YzMyLTgzZWIt
+        YTBkZWY1NWRlYzlkLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c2820e2d12844d678f36058523dce699
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:59 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5b4aefe6b24e4898b1874eacb8c0ca2c
+      - 6a7eecf7639b44dea9fd1322b3248f17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:59 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8adb90e99074c1fac2cfe177eb35fb6
+      - df8740bf525741ddbfd75a2a16206c4d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:59 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b8364dafe967435a853dea0370d3537b
+      - 7bc1123281bb44f0b278fa9404845177
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:59 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff0639503bae4181b20d870b83e3d28b
+      - 6dd88276f2e449199ca5c9393b6b3c93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 18942ab3afdb42549b1478d63f8bbc48
+      - cbb5b7d96c5f4fcd932a08ea43883b4a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a002e192a78f4ce0b9b33e5f8dbddc43
+      - 8fce252b565c49a89ae46fcef443e918
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 630503d2385b43c688f6bd94378ca297
+      - 8b5660dd6ea147f2b7a548fd005fe138
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3acdb1ced07641dea846898d030195ac
+      - c02347aeb78a459dbe9285144494fa91
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41b44b31f0084ef197e7e38b3f0b6767
+      - d1cbd1a581b74bb08986a15eb6f55219
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1d4138c3070e4e5fa86bc3dbc1b40354
+      - b255f32c667c4b5486addeee315aa55e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4242f6e96901426d9a736bba08b09cdb
+      - 65eaa1a7fdf4469aa44e6707d778079f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ca97494cecbe4344b2f4076b104a0bbf
+      - ab55668cc24a42ad97c96909b06dc9e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b65455f8e2244d5aab9a0f9aee5f5693
+      - dbbda23d56444f12b3c87145e8ae0fb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/8f39d593-c4f1-4cb0-b360-7fc8101531f7/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d41eb0c9-e1cb-470c-a496-9b107c946693/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,75 +3819,75 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aec2fba6ea57492991f251c42d9ed84e
+      - e6a9193433274a69a5ae6a53d02fd0cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiNjZlOTYzLWVlNDEtNGM2
-        Zi04NzMyLTEwYWUwNmRlY2M2Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg3NjJmN2M3LTc2ZjUtNDk4
+        ZC05Y2U5LTFiZTU0MTI1ZGYzMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/8f39d593-c4f1-4cb0-b360-7fc8101531f7/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d41eb0c9-e1cb-470c-a496-9b107c946693/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80NjRmNzQ1Mi04ODhiLTQyZjctODMyMi03YTlkZGQ1
-        YThhNzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NmExMGJiYmYtNTFlMS00MTVhLWEwMGYtNzliNzFhZTFkM2Q0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzhhYTU1NzE0LTFmOTYt
-        NGRiMy04YTMxLTM1MzI1ZmQ3N2NjMC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9iM2QzNTBiMS1mMDcxLTRkYTAtOWI5Zi1lNGQ3
-        M2E4YWIwYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3RyaWJ1
-        dGlvbl90cmVlcy9jN2UzNTQxNy05ZDg3LTQ4ZGUtOThkOC01MmQ2MzViM2Vl
-        YmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8wODc3
-        NjQyNi0zZjNmLTRhNjItYmIxYy05ODRjNTZmYjMwNDMvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmIt
-        OWY4OC01MWRlYTMwMGRlODcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L21vZHVsZW1kcy84MDBiNTVjNi05NzUzLTQzODEtOWQ3OC0wZmRlMmRkZmVl
-        NDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9iMTJh
-        MjE2Zi01ZTU2LTQ4ODEtYWZhZi02OWFjNWU1ZmRjMDIvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4YjIt
-        ODE0My1hNjE5MGRiZWI4YzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L21vZHVsZW1kcy9lNzQxM2ZlMC0zMDY3LTQ1NmQtOTVmYy0wNmIyYmRhMjcy
-        YWMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
-        NjgwZGFhYjItYWE1Yy00NGJkLTg2NjctZTBhZmNhOWY4OTBiLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4
-        Y2MtNGEzOS05OWJmLTQ5NjJiY2MwZmUwNS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNl
-        ZWUyZWY3OGMyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xM2EyNGRmNC03Y2MyLTQ1ZjMtYjViMC01NjhlNmVkMjYzZjUvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMt
-        NGQxZC1hZjU0LTRmMTFhZDBjZjRlNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00YTEyLWI2NzktNWNkM2Rk
-        ZGE5YTU3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkNjBkYTJmLTBhYTctNDZh
-        Zi1iZjZmLWE5YTNkODZlZTE0OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kZmJl
-        NjJhYi04Nzg5LTQ2MjAtYTUyYy03ZmE2YjQ0MDNiYmYvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZDI0NDFlYWEt
-        M2ZjMS00Nzc1LTkyMGUtYTZkNzY4ZDZjMjE3LyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYt
-        NGI3My1hZTRhLTg3YmNhOGViMzllMS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5
-        N2QtOTkyMTM4NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2
-        ZTE4NGQ5MmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1k
-        X2RlZmF1bHRzLzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0
-        YS8iXX0=
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMt
+        NGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3RyaWJ1
+        dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRkNTBh
+        MjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8wYzg0
+        MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTkt
+        YmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3YTEx
+        OTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8zYjli
+        OWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRiNTkt
+        ODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAz
+        ODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
+        NDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQx
+        MGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYt
+        NDE4OS05Y2M1LTZkOGRjMzVjMTBkNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNjJhNDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5
+        OWZiNjFmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        NmQwMjRjMi0xMGZjLTQwMWMtYWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNj
+        NS05MzZmLTlhYTAzNTYzOWYwNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMw
+        YzRjLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNzI0
+        MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2Yt
+        YjljMC00MjMxLTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUt
+        NGVhZi1hNGE4LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEw
+        MmQtZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
+        b2R1bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlm
+        NDliODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1k
+        X2RlZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3
+        MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3475,7 +3900,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:00 GMT
+      - Fri, 29 Jul 2022 09:01:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3493,21 +3918,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a0440c599d24823a7fd15cbc9d3091b
+      - fac499fcc3c4436890cbad6cf918b9f7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5NjgwNWYzLTg3N2ItNDI1
-        Zi04MmI1LTA0YmMyZTUyMzVhNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0NzlhZTg2LTcwM2UtNDIx
+        Zi1hNjVjLThhY2M1M2FhYTU2ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e96805f3-877b-425f-82b5-04bc2e5235a7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3479ae86-703e-421f-a65c-8acc53aaa56d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3528,53 +3953,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:01 GMT
+      - Fri, 29 Jul 2022 09:01:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d83bfce964a14ce0a8e13d2e07c38cbe
+      - fc3f44457377489f96a3b7e801fe7ac7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTk2ODA1ZjMtODc3
-        Yi00MjVmLTgyYjUtMDRiYzJlNTIzNWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6MDAuNzE2NjM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzQ3OWFlODYtNzAz
+        ZS00MjFmLWE2NWMtOGFjYzUzYWFhNTZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTEuNDI1MzcyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYTA0NDBjNTk5ZDI0ODIzYTdm
-        ZDE1Y2JjOWQzMDkxYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIx
-        OjAwLjg0OTEwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6
-        MDEuMDA3MDE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmYWM0OTlmY2MzYzQ0MzY4OTBj
+        YmFkNmNmOTE4YjlmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjExLjY5NDU1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        MTEuOTg2NTg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84ZjM5ZDU5My1jNGYxLTRjYjAtYjM2MC03ZmM4MTAxNTMxZjcvdmVyc2lv
+        bS9kNDFlYjBjOS1lMWNiLTQ3MGMtYTQ5Ni05YjEwN2M5NDY2OTMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGYzOWQ1OTMtYzRmMS00Y2Iw
-        LWIzNjAtN2ZjODEwMTUzMWY3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDQxZWIwYzktZTFjYi00NzBj
+        LWE0OTYtOWIxMDdjOTQ2NjkzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3582,7 +4007,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3595,36 +4020,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:01 GMT
+      - Fri, 29 Jul 2022 09:01:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c5f3d21cd4ba4a7d9ff33306fa9f6913
+      - 618a6c8439364c4caa42b905d70af81e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3646,10 +4071,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8f39d593-c4f1-4cb0-b360-7fc8101531f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d41eb0c9-e1cb-470c-a496-9b107c946693/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3657,7 +4082,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3670,36 +4095,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:01 GMT
+      - Fri, 29 Jul 2022 09:01:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3c9cc03b3cbe496780e7cf06a9f327d5
+      - f9fdee85d52148e5892f3ed55feea201
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3721,5 +4146,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:12 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_errata_repository/all_errata_copied_if_no_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_errata_repository/all_errata_copied_if_no_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:30 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea07034c2fb34a01809eeec9a193acfb
+      - 6f3ac96c99c44db5b7797dfbb89bda05
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wYzc3ZGRlOC0zYjY5LTQ0N2UtYWUzMS03MmE3MDg4MGM1OGYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDoyNC44NzIyNTVa
+        cnBtL3JwbS82MWYyZGFmOS1iNWEzLTQ4ZmMtODk5MS1lMmM4NTY2MWRjM2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMToyNS43MTQ0MDha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wYzc3ZGRlOC0zYjY5LTQ0N2UtYWUzMS03MmE3MDg4MGM1OGYv
+        cnBtL3JwbS82MWYyZGFmOS1iNWEzLTQ4ZmMtODk5MS1lMmM4NTY2MWRjM2Iv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBjNzdk
-        ZGU4LTNiNjktNDQ3ZS1hZTMxLTcyYTcwODgwYzU4Zi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzYxZjJk
+        YWY5LWI1YTMtNDhmYy04OTkxLWUyYzg1NjYxZGMzYi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:30 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cada948e530f48cd9d73ea9086de95d0
+      - b92cd9e5fc1c4dc48c4f0b68f6b17877
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkZjMzMTFiLTA2ZDMtNGE5
-        Yi05ODk0LWVlZmE3ZGY2ZmVjOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0YzI5ZjliLTkxZmUtNGU5
+        Zi1hMmI1LTJlYmYzNDFmMTA1Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:30 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ee616c0c3cc4e1ba8f217b559826bfd
+      - f2c6ac4d879948ccb537b1b3fe60f870
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8df3311b-06d3-4a9b-9894-eefa7df6fec8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/94c29f9b-91fe-4e9f-a2b5-2ebf341f105c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:30 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 38b2a9a4973c44ddb0a6df4109ef0cf8
+      - db4362ea4bb94709b2e877a3b8c93b55
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGRmMzMxMWItMDZk
-        My00YTliLTk4OTQtZWVmYTdkZjZmZWM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MzAuNjYzOTQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTRjMjlmOWItOTFm
+        ZS00ZTlmLWEyYjUtMmViZjM0MWYxMDVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MzUuMjUzMjYxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjYWRhOTQ4ZTUzMGY0OGNkOWQ3M2VhOTA4
-        NmRlOTVkMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjMwLjY5
-        NjkyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MzAuODIz
-        MDE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiOTJjZDllNWZjMWM0ZGM0OGM0ZjBiNjhm
+        NmIxNzg3NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjM1LjI5
+        NjQwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MzUuNTEw
+        ODQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGM3N2RkZTgtM2I2OS00NDdl
-        LWFlMzEtNzJhNzA4ODBjNThmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjFmMmRhZjktYjVhMy00OGZj
+        LTg5OTEtZTJjODU2NjFkYzNiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:30 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 15ea3b37d79f4386bbba3bfe21f552bc
+      - ef50627f3aab4e229033ba7b8cfb6edb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:30 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3395dd83bd314b128ce62096a39b4daa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNmJmMTc2NjAtMzQ2OC00ZjlhLThmZGItYmFiZjcyZGM1NjAy
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MzAuMTUwODYz
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/6bf17660-3468-4f9a-8fdb-babf72dc5602/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6f410a95b07246d99a6f92fc43b202b4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkOGYzOTc5LTE3NWMtNDQw
+        ZC04ZjlmLWU1YzcwMzk1ZmNmNi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/cd8f3979-175c-440d-8f9f-e5c70395fcf6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b9ca7d16857c41e7a61b9c3a150f313c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2Q4ZjM5NzktMTc1
+        Yy00NDBkLThmOWYtZTVjNzAzOTVmY2Y2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MzUuNjc1NTk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZjQxMGE5NWIwNzI0NmQ5OWE2ZjkyZmM0
+        M2IyMDJiNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjM1Ljcx
+        MjgyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MzUuNzQ4
+        OTIzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7844181c9d984c299aea55e743da1fee
+      - b134b405acd54778ba5cb4aecc2e6001
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 703d72bfa6934f30b71e6f271aac7620
+      - 6faeec2e84ad4f68adb4de1d97512a97
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3eca6e4bd2184f7abd1e8387e05a88ee
+      - 1b0001da0aad4c2189967db2e46f8132
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 05fa4f8acea5465fb5398df59e353875
+      - 6bb6e2a06f844ccdbf06ebcea3409ebf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:20:31 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2d8c3436735b4792802baf2356f7843c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/5fbcf4cc-a2c5-453a-aecf-fe2e4883755e/"
+      - "/pulp/api/v3/remotes/rpm/rpm/6e7f00eb-5f9c-4984-addf-d706e74db13c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b64b1dac212421abab983c520a507e7
+      - 9987a3cb6c444fd4bcb71fe5f00e3d68
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVm
-        YmNmNGNjLWEyYzUtNDUzYS1hZWNmLWZlMmU0ODgzNzU1ZS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIwOjMxLjE5NzgyNVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZl
+        N2YwMGViLTVmOWMtNDk4NC1hZGRmLWQ3MDZlNzRkYjEzYy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjM2LjAzMzcyNloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIwOjMxLjE5Nzg0NFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAxOjM2LjAzMzc1MFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e749b6797d6a4f59b24485bacf89aebf
+      - 0a391c2ebbe640aea8df904e98d1dc9b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vM2U3Mjk5ZWMtN2I3My00M2ZlLTg1M2UtMTZmMGZhODVmZmFjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MzEuMzA4NjUyWiIsInZl
+        cG0vZTViY2JjYTQtNGEwMi00MTYyLWIxZTYtZDM4OWI2NTIxOWNjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MzYuMjI3OTQ3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vM2U3Mjk5ZWMtN2I3My00M2ZlLTg1M2UtMTZmMGZhODVmZmFjL3ZlcnNp
+        cG0vZTViY2JjYTQtNGEwMi00MTYyLWIxZTYtZDM4OWI2NTIxOWNjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZTcyOTllYy03
-        YjczLTQzZmUtODUzZS0xNmYwZmE4NWZmYWMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lNWJjYmNhNC00
+        YTAyLTQxNjItYjFlNi1kMzg5YjY1MjE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 595b0cc4a3394d4eb59f3b5d6dbe5dd7
+      - 4797c7c41b914c20a508d70f0ae2ccbe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82OGU4ZjVjZi00OWI5LTQzMGEtOGI1Zi1hZjljM2M3ZjczZWIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDoyNS41NDU3MDZa
+        cnBtL3JwbS8xMWQwYjhlZS1hYWUzLTQwYTYtODBjYy0yYjQxMDRhMGExYTIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMToyNi42NzEzMjZa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82OGU4ZjVjZi00OWI5LTQzMGEtOGI1Zi1hZjljM2M3ZjczZWIv
+        cnBtL3JwbS8xMWQwYjhlZS1hYWUzLTQwYTYtODBjYy0yYjQxMDRhMGExYTIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY4ZThm
-        NWNmLTQ5YjktNDMwYS04YjVmLWFmOWMzYzdmNzNlYi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzExZDBi
+        OGVlLWFhZTMtNDBhNi04MGNjLTJiNDEwNGEwYTFhMi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 60690f0e53854fa0b30960613d3f1169
+      - 015d5f6ffda940bb9cf3eaadad7ea879
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4ODViYzZiLTZkNmUtNGRj
-        YS04ZjgzLTJjNjc3MjMxMWE4ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiMmUzZWIwLTQxYTItNDlh
+        NC05NzRiLWQ1ZDZhYWFjOTc5My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c57d229aa00d4a4b85345e569948671e
+      - ffa5b1d47ecb4ea1bbda9a352ddf3e82
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMDc3NTdmYzEtM2M5NS00NjMwLWE1YTMtMDYzZDQ4Nzk5Y2YwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MjQuNzYzNjQzWiIsIm5h
+        cG0vNTQwMzA3NmYtYWI4NS00OThjLWIyODMtNTQxY2NmMjkwZWE1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MjUuNTgwODc2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyMDoyNS44NzQ5NTFaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMToyNy4xNzIzMjZaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/07757fc1-3c95-4630-a5a3-063d48799cf0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/5403076f-ab85-498c-b283-541ccf290ea5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad9b6bffab4842f9a71b2b695c8b69a5
+      - c4aa74ab238a47f7be90391bb81f71c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc1MmM2ZTIxLWZmNjItNDdi
-        ZC05ODNlLTY0MDMxNjUwNmUzOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdhNDI1MTgwLThlNTktNDkx
+        Yi04YWY0LWVkODUxOTM1YWY0Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b885bc6b-6d6e-4dca-8f83-2c6772311a8e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bb2e3eb0-41a2-49a4-974b-d5d6aaac9793/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c46b89104949485f82b19856dd0a9cc7
+      - 6abdf735e9204d7d854386995f23533c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjg4NWJjNmItNmQ2
-        ZS00ZGNhLThmODMtMmM2NzcyMzExYThlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MzEuNDYyMTgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmIyZTNlYjAtNDFh
+        Mi00OWE0LTk3NGItZDVkNmFhYWM5NzkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MzYuNDc3ODAwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2MDY5MGYwZTUzODU0ZmEwYjMwOTYwNjEz
-        ZDNmMTE2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjMxLjQ5
-        NDk1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MzEuNTYw
-        OTk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMTVkNWY2ZmZkYTk0MGJiOWNmM2VhYWRh
+        ZDdlYTg3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjM2LjUx
+        Njg3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MzYuNjA5
+        ODc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjhlOGY1Y2YtNDliOS00MzBh
-        LThiNWYtYWY5YzNjN2Y3M2ViLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTFkMGI4ZWUtYWFlMy00MGE2
+        LTgwY2MtMmI0MTA0YTBhMWEyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/752c6e21-ff62-47bd-983e-640316506e38/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7a425180-8e59-491b-8af4-ed851935af47/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6742934d31824b459c01f3a3da9bc7c7
+      - 4595e97e14a1401a81473165fa49a13f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzUyYzZlMjEtZmY2
-        Mi00N2JkLTk4M2UtNjQwMzE2NTA2ZTM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MzEuNTYxNzcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2E0MjUxODAtOGU1
+        OS00OTFiLThhZjQtZWQ4NTE5MzVhZjQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MzYuNjA2MDY0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZDliNmJmZmFiNDg0MmY5YTcxYjJiNjk1
-        YzhiNjlhNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjMxLjU5
-        Mjk3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MzEuNjM1
-        Nzk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjNGFhNzRhYjIzOGE0N2Y3YmU5MDM5MWJi
+        ODFmNzFjNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjM2LjY1
+        NjQ3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MzYuNzE0
+        NzEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA3NzU3ZmMxLTNjOTUtNDYzMC1hNWEz
-        LTA2M2Q0ODc5OWNmMC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0MDMwNzZmLWFiODUtNDk4Yy1iMjgz
+        LTU0MWNjZjI5MGVhNS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e3ebc1e48f764341a233b9de507ca9ac
+      - 15f18270c61a4ef29efc2dbd81499db5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d495c14fd19a45139ea4a3faadc8a8bb
+      - 1e3565c645f54150beb287bee4d0bc43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db4591494e694de19ce6ff67a3543c08
+      - 76e5a30f66a64c2b9bb29a1cb21d8ef8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 77e3b6f65765424aa0d8cd20be2c7c7b
+      - bafff25c41ba4a07968ec7a87b3353d5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 879614b608eb4943b11b420719858fc5
+      - b92a46aa3cbc4d49afdb9f41b2601d05
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:31 GMT
+      - Fri, 29 Jul 2022 09:01:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f0efd950683f4fefae64e13fe19637d9
+      - fb8295e421444cc5bc86603906fabfcd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:37 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:32 GMT
+      - Fri, 29 Jul 2022 09:01:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/6c158534-8e58-4c50-9658-7873abc949c9/"
+      - "/pulp/api/v3/repositories/rpm/rpm/18e24115-087f-41f1-a9d5-80e1495a2d59/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ac666966c4d416bb945f389e3bd2bf2
+      - c4f00228c7a848faa8ce277f7de98f91
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmMxNTg1MzQtOGU1OC00YzUwLTk2NTgtNzg3M2FiYzk0OWM5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MzIuMDA1OTUyWiIsInZl
+        cG0vMThlMjQxMTUtMDg3Zi00MWYxLWE5ZDUtODBlMTQ5NWEyZDU5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MzcuMTg4MzE4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmMxNTg1MzQtOGU1OC00YzUwLTk2NTgtNzg3M2FiYzk0OWM5L3ZlcnNp
+        cG0vMThlMjQxMTUtMDg3Zi00MWYxLWE5ZDUtODBlMTQ5NWEyZDU5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82YzE1ODUzNC04
-        ZTU4LTRjNTAtOTY1OC03ODczYWJjOTQ5YzkvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xOGUyNDExNS0w
+        ODdmLTQxZjEtYTlkNS04MGUxNDk1YTJkNTkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:37 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5fbcf4cc-a2c5-453a-aecf-fe2e4883755e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/6e7f00eb-5f9c-4984-addf-d706e74db13c/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:32 GMT
+      - Fri, 29 Jul 2022 09:01:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c842583fc2cb40aaa4607577ea8c1ef7
+      - 0c7ca2bd64a64f35b441c221316bb896
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc4MzEyOGI2LWI5MDgtNDAy
-        My1iNWRjLTgyZGNkNzhmMWQxMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5MGJmYzExLTQ1ZTktNGVj
+        MC1hOTFiLWFhMGZiM2MyMzlhNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/783128b6-b908-4023-b5dc-82dcd78f1d12/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/290bfc11-45e9-4ec0-a91b-aa0fb3c239a7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:32 GMT
+      - Fri, 29 Jul 2022 09:01:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 773fb9cb72a94a43b6c5826fd350b12f
+      - 7cb4f2a0e79640539d83c8b7d40adc8b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzgzMTI4YjYtYjkw
-        OC00MDIzLWI1ZGMtODJkY2Q3OGYxZDEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MzIuMjgzMjI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjkwYmZjMTEtNDVl
+        OS00ZWMwLWE5MWItYWEwZmIzYzIzOWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MzcuNTc1MjQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJjODQyNTgzZmMyY2I0MGFhYTQ2MDc1Nzdl
-        YThjMWVmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjMyLjMx
-        Mzc4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MzIuMzM3
-        ODQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwYzdjYTJiZDY0YTY0ZjM1YjQ0MWMyMjEz
+        MTZiYjg5NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjM3LjYx
+        NjQxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MzcuNjQ2
+        NTE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVmYmNmNGNjLWEyYzUtNDUzYS1hZWNm
-        LWZlMmU0ODgzNzU1ZS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZlN2YwMGViLTVmOWMtNDk4NC1hZGRm
+        LWQ3MDZlNzRkYjEzYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:37 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVmYmNm
-        NGNjLWEyYzUtNDUzYS1hZWNmLWZlMmU0ODgzNzU1ZS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZlN2Yw
+        MGViLTVmOWMtNDk4NC1hZGRmLWQ3MDZlNzRkYjEzYy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:32 GMT
+      - Fri, 29 Jul 2022 09:01:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e90f8e2aaa8f40ca805f85cde22f6ac9
+      - d8f5e39a750742a9ad2bbae0886de716
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjNTI0ODg4LThkOTQtNGEw
-        OC05MjlkLTM1MmZkMTNjYWRiZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE0MWQ0ZDQwLWE2ZjAtNDlj
+        OC1hMzAxLWIyNzk0MWI3Mzc2Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/bc524888-8d94-4a08-929d-352fd13cadbe/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/141d4d40-a6f0-49c8-a301-b27941b7376f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:33 GMT
+      - Fri, 29 Jul 2022 09:01:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e61b589f1df4ecfb588e3b3ef7142a3
+      - 518bcc798d1442be851647ef91c547f7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '659'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmM1MjQ4ODgtOGQ5
-        NC00YTA4LTkyOWQtMzUyZmQxM2NhZGJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MzIuNDYzNDU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTQxZDRkNDAtYTZm
+        MC00OWM4LWEzMDEtYjI3OTQxYjczNzZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MzcuNzQ5NDc5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJlOTBmOGUyYWFhOGY0MGNhODA1
-        Zjg1Y2RlMjJmNmFjOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjMyLjQ5MjY1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        MzMuMjM0NTQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkOGY1ZTM5YTc1MDc0MmE5YWQy
+        YmJhZTA4ODZkZTcxNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjM3Ljc4ODE4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        MzguOTcyMDUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
-        cnNlZCBNb2R1bGVtZCIsImNvZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRz
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3Vm
-        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQtZGVmYXVs
-        dHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLm1vZHVsZW1kX2RlZmF1bHRzIiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
-        c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiUGFyc2VkIENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
-        ZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZpeCI6bnVsbH0seyJtZXNz
-        YWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5n
-        LmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJk
-        b25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
-        IEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5nLmFydGlmYWN0
-        cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjEs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzNlNzI5OWVjLTdiNzMtNDNmZS04NTNlLTE2ZjBm
-        YTg1ZmZhYy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZTcy
-        OTllYy03YjczLTQzZmUtODUzZS0xNmYwZmE4NWZmYWMvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNWZiY2Y0Y2MtYTJjNS00NTNh
-        LWFlY2YtZmUyZTQ4ODM3NTVlLyJdfQ==
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9lNWJjYmNhNC00YTAyLTQxNjItYjFlNi1kMzg5YjY1
+        MjE5Y2MvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTViY2Jj
+        YTQtNGEwMi00MTYyLWIxZTYtZDM4OWI2NTIxOWNjLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZlN2YwMGViLTVmOWMtNDk4NC1h
+        ZGRmLWQ3MDZlNzRkYjEzYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:33 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:39 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vM2U3Mjk5ZWMtN2I3My00M2ZlLTg1M2UtMTZmMGZhODVm
-        ZmFjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZTViY2JjYTQtNGEwMi00MTYyLWIxZTYtZDM4OWI2NTIx
+        OWNjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:33 GMT
+      - Fri, 29 Jul 2022 09:01:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d034b8f7fa244141a11fc85d724fa7f4
+      - 38ea82597a764a53a2b1f6f8ba9b4154
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2ZmJkZThjLTM4ZGEtNGQ0
-        ZS1hODQ5LWM2MWVkZTdkMjY4NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmYTcyY2MxLWU3NWItNGZi
+        OC04ZWU5LWYyZGVjNzBkNTFkYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:33 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/26fbde8c-38da-4d4e-a849-c61ede7d2684/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8fa72cc1-e75b-4fb8-8ee9-f2dec70d51db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ac4fa630bd24386b70ed8c925aecae5
+      - 4201a07cbd1c40d494e0a7d810c07f89
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjZmYmRlOGMtMzhk
-        YS00ZDRlLWE4NDktYzYxZWRlN2QyNjg0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MzMuNjc2MTg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGZhNzJjYzEtZTc1
+        Yi00ZmI4LThlZTktZjJkZWM3MGQ1MWRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MzkuNzQ5MzM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImQwMzRiOGY3ZmEyNDQxNDFhMTFmYzg1ZDcy
-        NGZhN2Y0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MzMuNzA0
-        NzcyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMDozMy45ODA2
-        NTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjM4ZWE4MjU5N2E3NjRhNTNhMmIxZjZmOGJh
+        OWI0MTU0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MzkuNzkz
+        MDA3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMTo0MC4yMDEy
+        ODhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTA2ZWQz
-        MzAtNzVlZS00NDYxLWJmMzUtYmNlNjg3NjczOWMwLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMWY4Njdk
+        MmQtYzM2ZS00M2JjLTk5NDctZTdmZDc4MjkxZjU5LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vM2U3Mjk5ZWMtN2I3My00M2ZlLTg1M2UtMTZmMGZh
-        ODVmZmFjLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZTViY2JjYTQtNGEwMi00MTYyLWIxZTYtZDM4OWI2
+        NTIxOWNjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a7a2f0a463b4d0e93512eb38b55b3e4
+      - f407e824218e4ac290753fd7e6b76392
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/1f867d2d-c36e-43bc-9947-e7fd78291f59/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 80aa55e2fa96401ea9f4f95f22c9c0af
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMWY4NjdkMmQtYzM2ZS00M2JjLTk5NDctZTdmZDc4MjkxZjU5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MzkuODE3ODYyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lNWJjYmNhNC00YTAyLTQxNjItYjFlNi1kMzg5YjY1MjE5Y2Mv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2U1YmNiY2E0LTRhMDItNDE2Mi1iMWU2LWQzODli
+        NjUyMTljYy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:40 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8xZjg2N2QyZC1jMzZlLTQzYmMtOTk0Ny1lN2ZkNzgyOTFmNTkv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d5c72907c53c49f5bf1d8c268454b80c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyY2U4OTg1LWZjNTktNGY0
+        OS05MmZhLTQ0YzMzNDkyNDk3ZC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/72ce8985-fc59-4f49-92fa-44c33492497d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d5ba7c32ec8e4028b51523556179215f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzJjZTg5ODUtZmM1
+        OS00ZjQ5LTkyZmEtNDRjMzM0OTI0OTdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NDAuNDgyMTg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkNWM3MjkwN2M1M2M0OWY1YmYxZDhjMjY4
+        NDU0YjgwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjQwLjUy
+        MTUyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NDAuODU3
+        MjU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNTFl
+        ZWUwMTktMTUwOS00MGI5LWIzYmYtNjEwZTYwYzhmOGZiLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/51eee019-1509-40b9-b3bf-610e60c8f8fb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ac247f6d522a4d54b22d29e804129360
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzUxZWVlMDE5LTE1MDktNDBiOS1iM2JmLTYxMGU2MGM4ZjhmYi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjQwLjgzNzY2NFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMWY4NjdkMmQtYzM2ZS00M2JjLTk5NDct
+        ZTdmZDc4MjkxZjU5LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - da7fe61059374348a816c879443e2315
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b3600c73f9d4255bfe614bac0f8dc5d
+      - 59fa6bb2a2c5499fae3f9f62f43eed4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f841cae89e3a446c98c30242c7da221b
+      - 30649c413f0f4ff9890c9c8786a7c666
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d862da158b24edf989c07cae97fe450
+      - c11ef2cc1ffc4d36a5f343dcbe1f827a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 025adca83d134cf1842106d6052b7bd7
+      - f9dce449abae4656b2d7e0b248f6f466
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5498009f4d54ec5a31d978e50e0d85a
+      - 7b1407028bad44acbff697abb494658e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bfb5a4f7c41540cfb79a00ffd2376df0
+      - 2508e47ed6a84ca2b0b66b8fdc3f56fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57e3a74949fe49deadf84ee4a20e477b
+      - ae8a27de1af04603a223c3934b16668e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:34 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43be83daec7a4a8cbd80b81d40352174
+      - 790cd7222f464ebbb438c196a13e7743
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:35 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b8ecd70801b4be7b875c119ff826021
+      - 57b35dbc7d4d4bb38feff798d9bd383d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:35 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ca900e7a4144a14abcf5a1380bb973e
+      - bfe1b14367544585b80332b4190fe5a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:35 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1515b8cc5c314905aefacb5035608268
+      - 969b32e17f13478fa3b1e246ce235047
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:35 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - efb6c93404c34963a631b4518e29e7cd
+      - 476479a4856048edbe35fbc1e4108244
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3e7299ec-7b73-43fe-853e-16f0fa85ffac/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:35 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9b55f515844a4b22adf6b603154aba3b
+      - e5a17f26fcb6412889f5e5b4c7fd58e2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6c158534-8e58-4c50-9658-7873abc949c9/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/18e24115-087f-41f1-a9d5-80e1495a2d59/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:35 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,99 +3819,99 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f623d9631d648199ba59a8780eaf9e3
+      - cdd7fcfb50254327a76bd4e38866260b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyYTEyYWZhLTZhN2EtNGQy
-        YS1iNGQwLTM5Mzg1YjhlZDMyYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3NThkNGYwLTk0MGMtNGNl
+        Ni1hZmQyLWVhNjhmNDgwMWJlMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6c158534-8e58-4c50-9658-7873abc949c9/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/18e24115-087f-41f1-a9d5-80e1495a2d59/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80NjRmNzQ1Mi04ODhiLTQyZjctODMyMi03YTlkZGQ1
-        YThhNzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NmExMGJiYmYtNTFlMS00MTVhLWEwMGYtNzliNzFhZTFkM2Q0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzdmZmQ2MDc2LWY3ZGQt
-        NDVkMy04ZjE3LTdmYzQxOGQxYWRmMy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYtZTRkNzNhOGFiMGJlLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VlNzJhOWU2LTNh
-        ZmYtNDI3Ny1iMzJiLWFiOTIwNGE1NTliOS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vYWR2aXNvcmllcy9lZjgyN2RkNy1hMmE5LTQzODUtODAyMS1i
-        ZTJjZDk4ZmU4YzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
-        aWJ1dGlvbl90cmVlcy9jN2UzNTQxNy05ZDg3LTQ4ZGUtOThkOC01MmQ2MzVi
-        M2VlYmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
-        ODc3NjQyNi0zZjNmLTRhNjItYmIxYy05ODRjNTZmYjMwNDMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82OGRjNGJlNC04MzdmLTRm
-        NmItOWY4OC01MWRlYTMwMGRlODcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy84MDBiNTVjNi05NzUzLTQzODEtOWQ3OC0wZmRlMmRk
-        ZmVlNDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9i
-        MTJhMjE2Zi01ZTU2LTQ4ODEtYWZhZi02OWFjNWU1ZmRjMDIvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4
-        YjItODE0My1hNjE5MGRiZWI4YzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy9lNzQxM2ZlMC0zMDY3LTQ1NmQtOTVmYy0wNmIyYmRh
-        MjcyYWMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvNjgwZGFhYjItYWE1Yy00NGJkLTg2NjctZTBhZmNhOWY4OTBiLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2E5ODk4ZmE5
-        LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2MwZmUwNS8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQt
-        ZGNlZWUyZWY3OGMyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8xM2EyNGRmNC03Y2MyLTQ1ZjMtYjViMC01NjhlNmVkMjYzZjUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzIzOTI4Yzg2LTYy
-        YWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMjg0MDQ3ZDgtNWFjNi00NmFiLTk1ZTgtYjI1
-        MDljMjhlMjlhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yYWU3YjhjMy05OWU3LTQ5YjAtOThiZS03MjIzYjY5ODVlMjgvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMt
-        NGQxZC1hZjU0LTRmMTFhZDBjZjRlNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00YTEyLWI2NzktNWNkM2Rk
-        ZGE5YTU3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81
-        ZTI0MGY3My03MWU4LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVmMzFkOWRkLTY5NzgtNDBh
-        Yi1hMjhkLTEzNWUwMjgwNzIyOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0OC00ZWM2LWIyMjEtN2U5N2MzNjg5
-        MWI3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZDYw
-        ZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04
-        ZDgxLWNlNjBkMTY2ZDIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvOTZmOTlkOTItMzc1MC00YTQ5LTk4ZmUtNDY2YTE1MjE3OTcx
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85YWQwN2U2
-        MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1MzI2ZmZlLTZiZTEtNDUyMy04YTY3
-        LWE5Y2RmZDZlNWJmMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvYmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMWMyOTIwNi00
-        MTEwLTQyMDgtYTIwYy1jMzg1NWNkNGY0MGMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2Q1YTJmMWFkLTA0MmEtNDA1ZS1hYzQ0LTBj
-        NGIxNGRiYmVjYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNjZmYzg0Ni0zNDhj
-        LTQzNTAtODZlMS1jMzJiZGNhNDFkM2UvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZDI0NDFlYWEtM2ZjMS00Nzc1
-        LTkyMGUtYTZkNzY4ZDZjMjE3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRh
-        LTg3YmNhOGViMzllMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5N2QtOTkyMTM4
-        NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
-        ZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2ZTE4NGQ5MmIv
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1i
+        OTFkMDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
+        aWJ1dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRk
+        NTBhMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
+        Yzg0MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRl
+        OTktYmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3
+        YTExOTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8z
+        YjliOWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRi
+        NTktODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdh
+        YzAzODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0
+        LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvMDVlMzY4ZDctMjkxYS00MzM2LWFkYmQt
+        ZDg5YjdiMDFkODQ2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1iMjc2ZmZhN2U4MjYvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM1YmJhMDBiLTZm
+        MTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy80ODA2MDhjMS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMt
+        NGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1ZmJiOTc0LTE1MmMtNDk2
+        ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3
+        YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4
+        M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04
+        MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNhMzhh
+        Mi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJi
+        LTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02
+        MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0
+        MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMx
+        LTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4
+        LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
+        dWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQtZjIwM2Nh
+        MzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
+        ZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDliODIzMjMv
         IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRz
-        LzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0YS8iXX0=
+        L2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3499,7 +3924,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:35 GMT
+      - Fri, 29 Jul 2022 09:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3517,21 +3942,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 07624f0b86c54d8bb9935086746bed63
+      - 5f40ea34badc4e3787b5b6daac50bf2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0ZjEwNTgwLWJlMDQtNGRi
-        Zi1iZGM0LTUwYjc3MmU1NmJiOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2OWMyNTk2LWRjNmEtNGZl
+        NS1iOTkxLTk5NzBjMTc1ZjYxZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/04f10580-be04-4dbf-bdc4-50b772e56bb8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e69c2596-dc6a-4fe5-b991-9970c175f61e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3552,53 +3977,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:35 GMT
+      - Fri, 29 Jul 2022 09:01:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d324ba3d2404c30880914267541a046
+      - 8092dd1cb7044e9f83aec80c11092609
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDRmMTA1ODAtYmUw
-        NC00ZGJmLWJkYzQtNTBiNzcyZTU2YmI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MzUuNDAxNzEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTY5YzI1OTYtZGM2
+        YS00ZmU1LWI5OTEtOTk3MGMxNzVmNjFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NDIuODg5NDc4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNzYyNGYwYjg2YzU0ZDhiYjk5
-        MzUwODY3NDZiZWQ2MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjM1LjUzNzUzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        MzUuNzA2MDI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ZjQwZWEzNGJhZGM0ZTM3ODdi
+        NWI2ZGFhYzUwYmYyYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjQzLjE0MzUzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        NDMuNDY0NjcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82YzE1ODUzNC04ZTU4LTRjNTAtOTY1OC03ODczYWJjOTQ5YzkvdmVyc2lv
+        bS8xOGUyNDExNS0wODdmLTQxZjEtYTlkNS04MGUxNDk1YTJkNTkvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmMxNTg1MzQtOGU1OC00YzUw
-        LTk2NTgtNzg3M2FiYzk0OWM5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMThlMjQxMTUtMDg3Zi00MWYx
+        LWE5ZDUtODBlMTQ5NWEyZDU5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6c158534-8e58-4c50-9658-7873abc949c9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/18e24115-087f-41f1-a9d5-80e1495a2d59/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3606,7 +4031,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3619,37 +4044,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:36 GMT
+      - Fri, 29 Jul 2022 09:01:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11bc4bc6766f4ad1b2c6c42f9149311e
+      - ab28f0ed93b84d56bc5e98b3f91dbf69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3722,9 +4147,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3740,8 +4165,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -3759,9 +4184,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -3783,9 +4208,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -3801,9 +4226,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -3812,9 +4237,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -3843,5 +4268,5 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:44 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_errata_repository/errata_copied_if_all_errata_packages_matches_included_packages.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_errata_repository/errata_copied_if_all_errata_packages_matches_included_packages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 550de0fb4833429b96b732b8cdcecf15
+      - d0bb7ac801114ceba488b61782c88309
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82NjllOWNiNS0wNmIxLTQ3Y2YtODllNi0yYmU0NWVjMjZlMGEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxOToxNi44ODYzODVa
+        cnBtL3JwbS9lNGQ1NTgwYi1hYWQ1LTQ3MDMtODM2Ny0yNmVjMGFiYTYwYzkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMToxNC44MDI3MzJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82NjllOWNiNS0wNmIxLTQ3Y2YtODllNi0yYmU0NWVjMjZlMGEv
+        cnBtL3JwbS9lNGQ1NTgwYi1hYWQ1LTQ3MDMtODM2Ny0yNmVjMGFiYTYwYzkv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY2OWU5
-        Y2I1LTA2YjEtNDdjZi04OWU2LTJiZTQ1ZWMyNmUwYS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U0ZDU1
+        ODBiLWFhZDUtNDcwMy04MzY3LTI2ZWMwYWJhNjBjOS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:24 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a5ea998e18d4d5bb06f186c6ac27c4d
+      - 735cadbd706e47d2a54597335e6791d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzNzU3Mzg3LTJlMzUtNDBj
-        OS04YjQ2LWI1YjJhNjE5ZmJhZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwMzk1NWJiLWJkOGMtNDQ2
+        Ni1hOGFlLWQ3NjljNjgxMWQxZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b02ad1aeb63e47cb8539779869e7783a
+      - a275ca14f7584f1fb61cb53b10b85fcf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/23757387-2e35-40c9-8b46-b5b2a619fbae/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/603955bb-bd8c-4466-a8ae-d769c6811d1e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7bf8eaf5515549c0b3aa50f09114dba5
+      - 754d1ba220194c9183eb95b49a8f7188
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjM3NTczODctMmUz
-        NS00MGM5LThiNDYtYjViMmE2MTlmYmFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTEuNDA3NzgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjAzOTU1YmItYmQ4
+        Yy00NDY2LWE4YWUtZDc2OWM2ODExZDFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjQuNTc5ODg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3YTVlYTk5OGUxOGQ0ZDViYjA2ZjE4NmM2
-        YWMyN2M0ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjExLjQz
-        OTQxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTEuNTU0
-        NzUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MzVjYWRiZDcwNmU0N2QyYTU0NTk3MzM1
+        ZTY3OTFkMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjI0LjYy
+        MjU5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MjQuODU0
+        NzAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjY5ZTljYjUtMDZiMS00N2Nm
-        LTg5ZTYtMmJlNDVlYzI2ZTBhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTRkNTU4MGItYWFkNS00NzAz
+        LTgzNjctMjZlYzBhYmE2MGM5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 48ada87cc9b64ab4bdd1e616844c3ca2
+      - c319bc56ba8540c3950c92122d25f46e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2108416fda7a40629161349c61ab52d1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vYmNlOTJkYzctNmYxZS00ZjhhLWJiYWItM2I0M2Y4ODRmODQz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MTkuMzkzNTM5
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/bce92dc7-6f1e-4f8a-bbab-3b43f884f843/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 165288aba0ab4f39a5c36e42a94a8c98
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxMjY3YjJmLTMzMjgtNGY0
+        Ni05YmRlLTdjOWUyNzc2MTA1ZC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c1267b2f-3328-4f46-9bde-7c9e2776105d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9b4abafaacd54253b30fd14cd1fa1a21
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzEyNjdiMmYtMzMy
+        OC00ZjQ2LTliZGUtN2M5ZTI3NzYxMDVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjUuMDUzMzE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxNjUyODhhYmEwYWI0ZjM5YTVjMzZlNDJh
+        OTRhOGM5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjI1LjEw
+        Nzg5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MjUuMTQ2
+        MjY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2bcfa2420f52428dafcee10ceefed806
+      - 4e5fc382a55c4141a0eab12d3fae84b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cdfa7480cd09448a8194243f7417dc78
+      - 0151c129d02b459d80d1530274a6b098
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ddb58993a1f34a3bb29e774d91ecf5ea
+      - d2f389364c2d495a968ee39eac7f40df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:11 GMT
+      - Fri, 29 Jul 2022 09:01:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a352af4b904f42179457bd311b16171c
+      - ddc3893d83ae4e1dade1d39cc2e51eec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:20:11 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - aea357520a934dcbb0298aef93830b09
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/b64e8eaf-c62b-48c0-9571-e42b4c2151e4/"
+      - "/pulp/api/v3/remotes/rpm/rpm/5403076f-ab85-498c-b283-541ccf290ea5/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4c1ffc3fa6e445d9be2c4c59a5b129a2
+      - 5648ba0f8ad3401cb186f9239bb23906
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I2
-        NGU4ZWFmLWM2MmItNDhjMC05NTcxLWU0MmI0YzIxNTFlNC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIwOjEyLjA1MTYxN1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0
+        MDMwNzZmLWFiODUtNDk4Yy1iMjgzLTU0MWNjZjI5MGVhNS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjI1LjU4MDg3NloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIwOjEyLjA1MTY0NVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAxOjI1LjU4MDg5N1oiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/"
+      - "/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3c9a44e112a645b7b1a49b46febbcc2e
+      - 15374dc01d994279b5b57ef2584939ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDU2NjUxZDQtNTkyNy00NjUyLThmYTYtODJiNzM5MzVlNGUzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MTIuMTYyODUwWiIsInZl
+        cG0vNjFmMmRhZjktYjVhMy00OGZjLTg5OTEtZTJjODU2NjFkYzNiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MjUuNzE0NDA4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDU2NjUxZDQtNTkyNy00NjUyLThmYTYtODJiNzM5MzVlNGUzL3ZlcnNp
+        cG0vNjFmMmRhZjktYjVhMy00OGZjLTg5OTEtZTJjODU2NjFkYzNiL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80NTY2NTFkNC01
-        OTI3LTQ2NTItOGZhNi04MmI3MzkzNWU0ZTMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MWYyZGFmOS1i
+        NWEzLTQ4ZmMtODk5MS1lMmM4NTY2MWRjM2IvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6a2dee09c5f74764ab36f083e12b1442
+      - e9d2a8ceed2142e5a47291be6fab4091
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lZmU2MzA3Yi02ZGIzLTQzYTktODBkMS1lYjdhMTI3NDQyMGEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxOToxNy41NzY4Njda
+        cnBtL3JwbS82M2NjMzM1Yy1lMDZmLTQ4YWQtOTFmMi0yYmRmZGE0ZGMzMmUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMToxNS43MzA5NDVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lZmU2MzA3Yi02ZGIzLTQzYTktODBkMS1lYjdhMTI3NDQyMGEv
+        cnBtL3JwbS82M2NjMzM1Yy1lMDZmLTQ4YWQtOTFmMi0yYmRmZGE0ZGMzMmUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2VmZTYz
-        MDdiLTZkYjMtNDNhOS04MGQxLWViN2ExMjc0NDIwYS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzYzY2Mz
+        MzVjLWUwNmYtNDhhZC05MWYyLTJiZGZkYTRkYzMyZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c93419c9675c4463a9fb2205a2fdf96d
+      - d3a638059f6945a4a2a559fc7a37ea4f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzYmU5MDQ2LWFmNTktNGQx
-        OC04ZTljLWEwN2E1YWRhMmI4NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlkOThlNTgwLTU0MmEtNDE2
+        ZC05MmUwLWU5MWEyZWZlYjZiNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25e093265e584dc182dbfdba6ebcb6ce
+      - 2e1f6367921b42a1a4eda04e7e66f744
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vN2UxZWNjMGUtM2NjNy00YmUzLTg4Y2UtNWNlYjgyODY1Yjg2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTk6MTYuNzY5NTAxWiIsIm5h
-        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5v
-        cmcvc3JwbS11bnNpZ25lZC8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2Vy
-        dCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
-        bCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjIt
-        MDUtMjNUMjM6MTk6MTcuOTI1MjQxWiIsImRvd25sb2FkX2NvbmN1cnJlbmN5
-        IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRl
-        IiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYw
-        LjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGlt
-        ZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJz
-        bGVzX2F1dGhfdG9rZW4iOm51bGx9XX0=
+        cG0vNzE4NGZlZjAtMjAyMy00YTAzLWI1YjktODA4NTNlMDc5ODQ3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MTQuNjUwMjI3WiIsIm5h
+        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
+        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
+        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
+        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        Mi0wNy0yOVQwOTowMToxNi4yOTkyMzVaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
+        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
+        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
+        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/7e1ecc0e-3cc7-4be3-88ce-5ceb82865b86/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/7184fef0-2023-4a03-b5b9-80853e079847/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5b0df82bb70433fa980586476746459
+      - 75133179b0bf4dfaae40217d30f070b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1ZDc3ZDA2LTcxYzItNGYz
-        NS04NjU1LTM5ZDIzMmMwYTM3YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlNGRlOTRlLTlhODUtNDgx
+        OC1iM2JhLWQ2YTA5YTJhZDRjYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c3be9046-af59-4d18-8e9c-a07a5ada2b85/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9d98e580-542a-416d-92e0-e91a2efeb6b6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e86fdd2c3e74ac7913a1fbd2ff14958
+      - 7ccf4fe1997a413b89955a9affcf10c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzNiZTkwNDYtYWY1
-        OS00ZDE4LThlOWMtYTA3YTVhZGEyYjg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTIuMzE4MjYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWQ5OGU1ODAtNTQy
+        YS00MTZkLTkyZTAtZTkxYTJlZmViNmI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjUuOTMyODE1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjOTM0MTljOTY3NWM0NDYzYTlmYjIyMDVh
-        MmZkZjk2ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjEyLjM0
-        ODgyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTIuNDA0
-        NTE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkM2E2MzgwNTlmNjk0NWE0YTJhNTU5ZmM3
+        YTM3ZWE0ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjI1Ljk3
+        MjYxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MjYuMDY5
+        OTQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWZlNjMwN2ItNmRiMy00M2E5
-        LTgwZDEtZWI3YTEyNzQ0MjBhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjNjYzMzNWMtZTA2Zi00OGFk
+        LTkxZjItMmJkZmRhNGRjMzJlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/25d77d06-71c2-4f35-8655-39d232c0a37a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4e4de94e-9a85-4818-b3ba-d6a09a2ad4cc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71919ff86dcf40da90978ed35bbaa4ad
+      - ca56681059284c00ac6207798e9e984e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjVkNzdkMDYtNzFj
-        Mi00ZjM1LTg2NTUtMzlkMjMyYzBhMzdhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTIuNDA2OTk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGU0ZGU5NGUtOWE4
+        NS00ODE4LWIzYmEtZDZhMDlhMmFkNGNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjYuMDYwNjAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkNWIwZGY4MmJiNzA0MzNmYTk4MDU4NjQ3
-        Njc0NjQ1OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjEyLjQz
-        ODU0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTIuNDc5
-        NTA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3NTEzMzE3OWIwYmY0ZGZhYWU0MDIxN2Qz
+        MGYwNzBiOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjI2LjEx
+        MjMxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MjYuMTg1
+        NTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdlMWVjYzBlLTNjYzctNGJlMy04OGNl
-        LTVjZWI4Mjg2NWI4Ni8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcxODRmZWYwLTIwMjMtNGEwMy1iNWI5
+        LTgwODUzZTA3OTg0Ny8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb694fc53fbf40198e15712c7062db98
+      - a74990a6cdc44292a74fac25a2b1718e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94a2267a8ff9443caee95efd36b152fc
+      - ff90f53e84ac4458b7b6a93a047616f5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b2c7065b2b8643b1b5173d27859d81c9
+      - e828fa6716f640edb108695c975e0987
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 64f4b7b76a6f41d8b2c1eb2275028a61
+      - 00ec8eabc0b74ebfbd8c93b99639a648
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c5f0a153007a40a288f9c58222c78ad2
+      - ced66e9b52864868836ff71c66138054
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 97fac4345ad74faaad058050d94618d1
+      - 3d24078d867c4a44bc8c9c9a1997ec44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:12 GMT
+      - Fri, 29 Jul 2022 09:01:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/"
+      - "/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c5cffae9539a45f0b57d8d4196461199
+      - ad22a874c04c4a1387eba16225e31b0a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTgxN2I2NDMtY2M5Mi00MjA5LTkyYzYtZWE0MWYxN2ZmMGZmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MTIuODU5NzI0WiIsInZl
+        cG0vMTFkMGI4ZWUtYWFlMy00MGE2LTgwY2MtMmI0MTA0YTBhMWEyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MjYuNjcxMzI2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTgxN2I2NDMtY2M5Mi00MjA5LTkyYzYtZWE0MWYxN2ZmMGZmL3ZlcnNp
+        cG0vMTFkMGI4ZWUtYWFlMy00MGE2LTgwY2MtMmI0MTA0YTBhMWEyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lODE3YjY0My1j
-        YzkyLTQyMDktOTJjNi1lYTQxZjE3ZmYwZmYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xMWQwYjhlZS1h
+        YWUzLTQwYTYtODBjYy0yYjQxMDRhMGExYTIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:26 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/b64e8eaf-c62b-48c0-9571-e42b4c2151e4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/5403076f-ab85-498c-b283-541ccf290ea5/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:13 GMT
+      - Fri, 29 Jul 2022 09:01:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c282135f8774d30895a230457a7908e
+      - 14a0e51f368f4f648e0233fa48a66f28
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUyZTRkZWY0LWEyYjQtNGMw
-        Mi05MDRiLTQ1MTIwMGQxZWYxMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzYjNlN2E2LTQzMjMtNGQx
+        My04NTIxLTViZTFmNWVhNWZlMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:13 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/52e4def4-a2b4-4c02-904b-451200d1ef13/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/63b3e7a6-4323-4d13-8521-5be1f5ea5fe2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:13 GMT
+      - Fri, 29 Jul 2022 09:01:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9eecca87b26c45a4b64c0a524c8ba5a3
+      - 144615ac06d342e2be4c15fa995ff6ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTJlNGRlZjQtYTJi
-        NC00YzAyLTkwNGItNDUxMjAwZDFlZjEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTMuMTI3ODQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjNiM2U3YTYtNDMy
+        My00ZDEzLTg1MjEtNWJlMWY1ZWE1ZmUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjcuMTA5NDAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI2YzI4MjEzNWY4Nzc0ZDMwODk1YTIzMDQ1
-        N2E3OTA4ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjEzLjE1
-        NzIyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTMuMTc5
-        MTMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIxNGEwZTUxZjM2OGY0ZjY0OGUwMjMzZmE0
+        OGE2NmYyOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjI3LjE0
+        OTg3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MjcuMTc3
+        OTMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I2NGU4ZWFmLWM2MmItNDhjMC05NTcx
-        LWU0MmI0YzIxNTFlNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0MDMwNzZmLWFiODUtNDk4Yy1iMjgz
+        LTU0MWNjZjI5MGVhNS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:13 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:27 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I2NGU4
-        ZWFmLWM2MmItNDhjMC05NTcxLWU0MmI0YzIxNTFlNC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0MDMw
+        NzZmLWFiODUtNDk4Yy1iMjgzLTU0MWNjZjI5MGVhNS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:13 GMT
+      - Fri, 29 Jul 2022 09:01:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 69602adc61b24a9e87dca724ba1833ce
+      - c2f10e05c534482f9aaadad13dd5831b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc1YjIyM2RiLThiYzEtNDgz
-        OC1iOGY1LWRmYTViMmUyMDU5Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzMzRhYWE5LWU3N2MtNDAy
+        OC1iNzk0LTI4N2I2ZjlkNWJlMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:13 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/75b223db-8bc1-4838-b8f5-dfa5b2e20596/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6334aaa9-e77c-4028-b794-287b6f9d5be2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:14 GMT
+      - Fri, 29 Jul 2022 09:01:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8291a3c7beb4eea8043ef1b81b579ad
+      - f8dcfdf041de40cbb7a0edeedf994a51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '652'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzViMjIzZGItOGJj
-        MS00ODM4LWI4ZjUtZGZhNWIyZTIwNTk2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTMuMzAwODIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjMzNGFhYTktZTc3
+        Yy00MDI4LWI3OTQtMjg3YjZmOWQ1YmUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjcuMjgzMDk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI2OTYwMmFkYzYxYjI0YTllODdk
-        Y2E3MjRiYTE4MzNjZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjEzLjMzMDA5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        MTMuOTkwMTI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJjMmYxMGUwNWM1MzQ0ODJmOWFh
+        YWRhZDEzZGQ1ODMxYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjI3LjMyNjgxN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        MjguNTQ0MjgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzQ1NjY1MWQ0LTU5MjctNDY1Mi04ZmE2LTgyYjcz
-        OTM1ZTRlMy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80NTY2
-        NTFkNC01OTI3LTQ2NTItOGZhNi04MmI3MzkzNWU0ZTMvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYjY0ZThlYWYtYzYyYi00OGMw
-        LTk1NzEtZTQyYjRjMjE1MWU0LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS82MWYyZGFmOS1iNWEzLTQ4ZmMtODk5MS1lMmM4NTY2
+        MWRjM2IvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjFmMmRh
+        ZjktYjVhMy00OGZjLTg5OTEtZTJjODU2NjFkYzNiLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0MDMwNzZmLWFiODUtNDk4Yy1i
+        MjgzLTU0MWNjZjI5MGVhNS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:14 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:28 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNDU2NjUxZDQtNTkyNy00NjUyLThmYTYtODJiNzM5MzVl
-        NGUzL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNjFmMmRhZjktYjVhMy00OGZjLTg5OTEtZTJjODU2NjFk
+        YzNiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:14 GMT
+      - Fri, 29 Jul 2022 09:01:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2e8b67c54cf4b1f8f9d8a385ff55b83
+      - aa109781d5be4864bbfe24af70422461
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2ZTdlZmNkLWFkNjctNGM5
-        Yi04YzdlLWU0NTk3ZmVkMWUwYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmY2RlYTMxLTU0MTgtNGY0
+        NS1iMDJkLTE4ZmFlOTM3ZmU4Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:14 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c6e7efcd-ad67-4c9b-8c7e-e4597fed1e0b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5fcdea31-5418-4f45-b02d-18fae937fe8b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:14 GMT
+      - Fri, 29 Jul 2022 09:01:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c47ccd5f0854373bede4cfa251f7b53
+      - 83d51094107f4aef93915fe5cbf53331
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzZlN2VmY2QtYWQ2
-        Ny00YzliLThjN2UtZTQ1OTdmZWQxZTBiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTQuMjQ3NDM2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWZjZGVhMzEtNTQx
+        OC00ZjQ1LWIwMmQtMThmYWU5MzdmZThiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjkuMDA4NDIwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImMyZThiNjdjNTRjZjRiMWY4ZjlkOGEzODVm
-        ZjU1YjgzIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTQuMjc4
-        MTY3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMDoxNC41MjA0
-        NDlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImFhMTA5NzgxZDViZTQ4NjRiYmZlMjRhZjcw
+        NDIyNDYxIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MjkuMDYz
+        NTkyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMToyOS40ODg0
+        MTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjk5Y2Iz
-        OTQtYzQ0Zi00OGJmLWE3ZGMtZmRmZDg2MDE3ZjAyLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzRjYzM3
+        ZTAtZDBhNC00NTQ4LWE5YTYtMzJiMjhlMmMzZTgyLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNDU2NjUxZDQtNTkyNy00NjUyLThmYTYtODJiNzM5
-        MzVlNGUzLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNjFmMmRhZjktYjVhMy00OGZjLTg5OTEtZTJjODU2
+        NjFkYzNiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:14 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:14 GMT
+      - Fri, 29 Jul 2022 09:01:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 536ea3a9349f401a958d3feac55fa811
+      - 37add055355d47ec956ac6947617d358
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/c4cc37e0-d0a4-4548-a9a6-32b28e2c3e82/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2a0eb853bcc7441ab0928600e5dbe945
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYzRjYzM3ZTAtZDBhNC00NTQ4LWE5YTYtMzJiMjhlMmMzZTgyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MjkuMDkwMzc1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82MWYyZGFmOS1iNWEzLTQ4ZmMtODk5MS1lMmM4NTY2MWRjM2Iv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzYxZjJkYWY5LWI1YTMtNDhmYy04OTkxLWUyYzg1
+        NjYxZGMzYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:29 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9jNGNjMzdlMC1kMGE0LTQ1NDgtYTlhNi0zMmIyOGUyYzNlODIv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0406704770b44f4c988086e0ce80342f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc2NzE2OTBmLTBkMTctNDY1
+        Mi1hNTAwLTc1ZTk1Y2M4MTk5Ny8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7671690f-0d17-4652-a500-75e95cc81997/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c77a98e8860040b6a43753e2d6771de4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzY3MTY5MGYtMGQx
+        Ny00NjUyLWE1MDAtNzVlOTVjYzgxOTk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjkuNzgwNzU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwNDA2NzA0NzcwYjQ0ZjRjOTg4MDg2ZTBj
+        ZTgwMzQyZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjI5Ljgz
+        MzYxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MzAuMTcw
+        NTUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNmJm
+        MTc2NjAtMzQ2OC00ZjlhLThmZGItYmFiZjcyZGM1NjAyLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/6bf17660-3468-4f9a-8fdb-babf72dc5602/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bdad70cdc7d84da99909c7871fad7607
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzZiZjE3NjYwLTM0NjgtNGY5YS04ZmRiLWJhYmY3MmRjNTYwMi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjMwLjE1MDg2M1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYzRjYzM3ZTAtZDBhNC00NTQ4LWE5YTYt
+        MzJiMjhlMmMzZTgyLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7e5eb84796fe49a5b09cac32dccc0ee4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:14 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:14 GMT
+      - Fri, 29 Jul 2022 09:01:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6fad1307370845ef84e717ce5844e9a2
+      - de3d9c0278884b6398b80747dae1bbd2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:14 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95f866d4f0664a8ea15343162f74edf8
+      - 6f2e2269b7de418192dff801196cf939
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1f964f6afe9b4e3dafbdf46d6445f788
+      - 9ff517fdf4914134b206ff6017bfb895
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 035cc094b6174a569a4f267653ecf971
+      - f233b780e7cb42a7bef38bee3245cedb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc0e6f4907f9436291b9c33e48f95668
+      - 1e8aafd87fa34a378eaafdc9997c6de6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9d5979cc6c814162bc129f062c72c95f
+      - 0ca25109e24644d597f39818a420be02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 533117c09dfe4099b9c04ebbd9e1969f
+      - 57676ea395d04a9eb7a7ed5158e8d358
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c90d4114caf4d14a7f84982d6fd1923
+      - 8a1ea79bdbc148acbfdecc637fa52458
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 72e43746bfd0408b8c1ed9747844417e
+      - 579dcd02f0384d69bba429f4a303dba6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f8b3fe4ed57d4bc4ba75e17eecc98d28
+      - 8554efc100f84f829ee684decef7ed4a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8c25401157f64530a27de33781b94ffa
+      - f6428389aab44236a3141769cffff54c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 826601be63a2420cb64dd13e14d998b9
+      - 816b1a06c091497a8e629b7b6a112cd6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/61f2daf9-b5a3-48fc-8991-e2c85661dc3b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 19fbb0a8d53448a1be944c4befc7b443
+      - '019f745995bd438aa1a1298feeef23b7'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,58 +3819,58 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f01458a321e34f3db9faff60e45d047c
+      - a4c3a9be07294ab1afa9b2ee613bed49
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiNWY1ODUzLTg2YzYtNDk1
-        Ny1hNDU5LTQ4NzU2ZDM3MWFmOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkZDFmMTU0LWQ5N2UtNDFk
+        NC05ZDE3LTEwZGMzMTk2OWUyZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80NjRmNzQ1Mi04ODhiLTQyZjctODMyMi03YTlkZGQ1
-        YThhNzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NmExMGJiYmYtNTFlMS00MTVhLWEwMGYtNzliNzFhZTFkM2Q0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2IzZDM1MGIxLWYwNzEt
-        NGRhMC05YjlmLWU0ZDczYThhYjBiZS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjky
-        MDRhNTU5YjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvZWY4MjdkZDctYTJhOS00Mzg1LTgwMjEtYmUyY2Q5OGZlOGMwLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvYzdl
-        MzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJkNjM1YjNlZWJhLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2Mt
-        NGEzOS05OWJmLTQ5NjJiY2MwZmUwNS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvNWUyNDBmNzMtNzFlOC00YzE4LThiNGItMzllYWM5
-        MjYzYzRjLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4
-        OS04ZDgxLWNlNjBkMTY2ZDIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00MzUwLTg2ZTEtYzMyYmRjYTQx
-        ZDNlLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRh
-        X2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2ZDc2OGQ2YzIxNy8i
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvNGYy
+        NTJlY2UtMzE5NS00N2FiLWE1NjctZTljZGRkZDUwYTIzLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQt
+        NDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1YjFh
+        ZDg0YTI0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83
+        Y2YwNWYyZS1iMmMxLTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E3MjQwZDI2LTkwZjgtNGFj
+        Mi1hOTlhLTIyZmEyMjljOWIwZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00NDY0LTlkMTItMjQxZWY2ZDQ1
+        M2IwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRh
+        X2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUxMzAzYmZkZmE1Zi8i
         LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVudmlyb25tZW50
-        cy8xMjQ4Mzk2OC1iNWM2LTRiNzMtYWU0YS04N2JjYThlYjM5ZTEvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRzLzBiNjA5
-        ODgzLWVmMzEtNGRjNi04OTdkLTk5MjEzODUzMmFmYi8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvMzU3ODczY2YtYmJj
-        ZC00MTQ0LWE4OGQtZGM1NmUxODRkOTJiLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zYmE2NjQ5Mi05N2ZlLTRmOGMt
-        ODU3Ny02NzgxNGQ2ODQ4NGEvIl19
+        cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRhOC02ZTcxOTU3Y2IxNzcvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRzLzQyYmFk
+        ZjhmLTEwMGUtNGE4ZC1hMDJkLWYyMDNjYTMwY2Y5NC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUz
+        Zi00NjBmLTk0ZWYtMDY5ZjQ5YjgyMzIzLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgt
+        YmU2MC02NDE5Yjg2M2U1NzEvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3458,7 +3883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:15 GMT
+      - Fri, 29 Jul 2022 09:01:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3476,21 +3901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce5348dde07f4f839dd563b82b0e2150
+      - 8f9c6b554b6d45e3b7d16e868316204c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzY2UzMmY0LTU1ZjgtNDZl
-        Ni05YmYzLWY4YjhhNzkzNzY1Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmYmZjOTI3LWJlODItNGJl
+        Mi1hZjE5LTRhMDNmZmFmNTMzMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:15 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/93ce32f4-55f8-46e6-9bf3-f8b8a793765b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7fbfc927-be82-4be2-af19-4a03ffaf5330/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3511,53 +3936,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:16 GMT
+      - Fri, 29 Jul 2022 09:01:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22cbe61d74344fa197b282c4b7e4ca73
+      - 80d24b8e032346b48f8837b9039efa8c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTNjZTMyZjQtNTVm
-        OC00NmU2LTliZjMtZjhiOGE3OTM3NjViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTUuODk5NDAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2ZiZmM5MjctYmU4
+        Mi00YmUyLWFmMTktNGEwM2ZmYWY1MzMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MzIuNDc2MzE5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjZTUzNDhkZGUwN2Y0ZjgzOWRk
-        NTYzYjgyYjBlMjE1MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjE2LjAzMzM0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        MTYuMTgxMDU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4ZjljNmI1NTRiNmQ0NWUzYjdk
+        MTZlODY4MzE2MjA0YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjMyLjc2NDIyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        MzIuOTg2NjcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lODE3YjY0My1jYzkyLTQyMDktOTJjNi1lYTQxZjE3ZmYwZmYvdmVyc2lv
+        bS8xMWQwYjhlZS1hYWUzLTQwYTYtODBjYy0yYjQxMDRhMGExYTIvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTgxN2I2NDMtY2M5Mi00MjA5
-        LTkyYzYtZWE0MWYxN2ZmMGZmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTFkMGI4ZWUtYWFlMy00MGE2
+        LTgwY2MtMmI0MTA0YTBhMWEyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:16 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3565,7 +3990,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3578,44 +4003,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:16 GMT
+      - Fri, 29 Jul 2022 09:01:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 386d990a1e5347e1b74542ee2915f1de
+      - 230840b70908485293f2b17c36e9c4dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '195'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4MS1jZTYwZDE2NmQyMmEv
+        YWNrYWdlcy82OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNWUyNDBmNzMtNzFlOC00YzE4LThiNGItMzllYWM5MjYzYzRjLyJ9
+        a2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04NmUxLWMzMmJkY2E0MWQzZS8ifV19
+        Z2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0MWVmNmQ0NTNiMC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:16 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3623,7 +4048,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3636,7 +4061,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:16 GMT
+      - Fri, 29 Jul 2022 09:01:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3654,21 +4079,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a51d4687ebec4692a1fbe4bd9b3be459
+      - 8d629f51fd844c22b73db9294fba7691
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:16 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3676,7 +4101,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3689,37 +4114,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:16 GMT
+      - Fri, 29 Jul 2022 09:01:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6687'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ae5177337f14194b529217395bd227c
+      - 9e3d5d6048b64867b9bd1dc35da2ebe0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1785'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3792,9 +4217,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvNmExMGJiYmYtNTFlMS00MTVhLWEwMGYt
-        NzliNzFhZTFkM2Q0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzQxMDk1WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -3811,9 +4236,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VlNzJhOWU2LTNhZmYtNDI3
-        Ny1iMzJiLWFiOTIwNGE1NTliOS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjE1OjM5LjMyNjIyNloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMtNDVh
+        Yy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI5MzEwMFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAxMTEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRHVw
         bGljYXRlIE9uZSBwYWNrYWdlIGVycmF0YSIsImlzc3VlZF9kYXRlIjoiMjAx
         Mi0wMS0wMSAwMTowMTowMSIsImZyb21zdHIiOiJsemFwK3B1YkByZWRoYXQu
@@ -3835,9 +4260,9 @@ http_interactions:
         aHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90
         eXBlIjoiIiwidmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwi
         cmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvZWY4MjdkZDctYTJhOS00
-        Mzg1LTgwMjEtYmUyY2Q5OGZlOGMwLyIsInB1bHBfY3JlYXRlZCI6IjIwMjIt
-        MDUtMjNUMjM6MTU6MzkuMzI1MTExWiIsImlkIjoiS0FURUxMTy1SSEVBLTIw
+        YXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvOWExY2RiNjgtZTdkZC00
+        OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjIt
+        MDctMjhUMTU6MDQ6MzQuMjkxMTg5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIw
         MTA6MDAwMiIsInVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJP
         bmUgcGFja2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEg
         MDE6MDE6MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0
@@ -3853,9 +4278,9 @@ http_interactions:
         cmMiOiJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwic3VtIjoiIiwi
         c3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4zIn1dfV0sInJlZmVyZW5jZXMi
         OltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy9iM2QzNTBiMS1m
-        MDcxLTRkYTAtOWI5Zi1lNGQ3M2E4YWIwYmUvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMi0wNS0yM1QyMzoxNTozOS4zMTk4NTNaIiwiaWQiOiJLQVRFTExPLVJI
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy9hZmEzNWE2MC05
+        MTRjLTRkNzQtOTI2Ni1iMGUwNzg5NjM4ZDQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNy0yOFQxNTowNDozNC4yNzcyMDdaIiwiaWQiOiJLQVRFTExPLVJI
         RUEtMjAxMDowMDAxIiwidXBkYXRlZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlv
         biI6IkVtcHR5IGVycmF0YSIsImlzc3VlZF9kYXRlIjoiMjAxMC0wMS0wMSAw
         MTowMTowMSIsImZyb21zdHIiOiJsemFwK3B1YkByZWRoYXQuY29tIiwic3Rh
@@ -3865,10 +4290,10 @@ http_interactions:
         LCJwdXNoY291bnQiOiIiLCJwa2dsaXN0IjpbXSwicmVmZXJlbmNlcyI6W10s
         InJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:16 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3876,7 +4301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3889,41 +4314,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:16 GMT
+      - Fri, 29 Jul 2022 09:01:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 44ae19064eab4890ba9688a49d81e0e1
+      - 4bc4872325634e9f9c7b7a298e1c7cb7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:16 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3931,7 +4356,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3944,41 +4369,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:16 GMT
+      - Fri, 29 Jul 2022 09:01:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 344ddb3631c54d42a916e637961becd2
+      - 344dfb06e3cb4b8ebf61ae9745549857
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:16 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/11d0b8ee-aae3-40a6-80cc-2b4104a0a1a2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3986,7 +4411,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3999,36 +4424,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:16 GMT
+      - Fri, 29 Jul 2022 09:01:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dc6ce5fc3bbc40a598125ba130e67e35
+      - 71cb355e602943ccb2e84f972be1858e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4050,5 +4475,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:16 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:33 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_errata_repository/errata_is_not_copied_if_errata_packages_are_not_all_found_in_included_packages.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_errata_repository/errata_is_not_copied_if_errata_packages_are_not_all_found_in_included_packages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb476507409b4385ab776daa2e3e17d7
+      - 491d857423224e9db52304ec4d671a66
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mOTg4YzhhZC0xNzU0LTRkNmYtOGMzYy1lMmI2NzE0MTM0MjMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDoxOC41MDYzNzla
+        cnBtL3JwbS82Mjc0NmM4NC03MzQ5LTQ2N2YtYWMxZi0zMTEzZTMwMjdjNWUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMTowNC45NjIxNTFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mOTg4YzhhZC0xNzU0LTRkNmYtOGMzYy1lMmI2NzE0MTM0MjMv
+        cnBtL3JwbS82Mjc0NmM4NC03MzQ5LTQ2N2YtYWMxZi0zMTEzZTMwMjdjNWUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Y5ODhj
-        OGFkLTE3NTQtNGQ2Zi04YzNjLWUyYjY3MTQxMzQyMy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzYyNzQ2
+        Yzg0LTczNDktNDY3Zi1hYzFmLTMxMTNlMzAyN2M1ZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:13 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/62746c84-7349-467f-ac1f-3113e3027c5e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a615b372bdd7479c9351c02e53d68475
+      - 102b5270f2344760bcdc77350cfc7eb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4NmEzNzM3LTQzODAtNGM1
-        ZS05MTZkLTQwODI5YjViYjU2MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjZGM2YjRlLTM1ODEtNGIz
+        OS1iODVhLTg2ODJmNzJlOWMyNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d73b06832cb4482b73593bf3428d37c
+      - 81f1696b67f14f91b34ada55acb3b5c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f86a3737-4380-4c5e-916d-40829b5bb561/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4cdc6b4e-3581-4b39-b85a-8682f72e9c27/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5b4118dcb4fc45f0a5c53066e0e0beb1
+      - e32405445f37496ea3f8b725434e7e59
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjg2YTM3MzctNDM4
-        MC00YzVlLTkxNmQtNDA4MjliNWJiNTYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjQuMjMwMzc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGNkYzZiNGUtMzU4
+        MS00YjM5LWI4NWEtODY4MmY3MmU5YzI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTMuNjc0NDM3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhNjE1YjM3MmJkZDc0NzljOTM1MWMwMmU1
-        M2Q2ODQ3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjI0LjI2
-        NzE1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MjQuMzg2
-        NzczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxMDJiNTI3MGYyMzQ0NzYwYmNkYzc3MzUw
+        Y2ZjN2ViMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjEzLjcy
+        Njc2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MTMuOTQx
+        MjgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjk4OGM4YWQtMTc1NC00ZDZm
-        LThjM2MtZTJiNjcxNDEzNDIzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjI3NDZjODQtNzM0OS00Njdm
+        LWFjMWYtMzExM2UzMDI3YzVlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86fcb39924344fd98462caf325fe1907
+      - 65e5148fba6040cc87b753a1023ee4c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - cc1eea019c63479fbb2f66cd7dc8abae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vODI4NjUxNjgtNjEzMy00MGIwLTgzY2QtYzY2NTc0MzM3ZTc2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MDkuMzE5NjEy
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/82865168-6133-40b0-83cd-c66574337e76/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6b481d493481409e878af5e1d82d2dad
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFhMDE0ODk2LTczZDMtNGVm
+        Yy05M2Y2LWY3NWRhMzBhNjZiNi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1a014896-73d3-4efc-93f6-f75da30a66b6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 35ef6364a3eb476d95cf60e82c1a1e0d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWEwMTQ4OTYtNzNk
+        My00ZWZjLTkzZjYtZjc1ZGEzMGE2NmI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTQuMTIyODMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2YjQ4MWQ0OTM0ODE0MDllODc4YWY1ZTFk
+        ODJkMmRhZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjE0LjE2
+        NDQ2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MTQuMjA0
+        OTk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f71b4672000643f4aa24cc06317e2ed4
+      - 3b6c05111f2045a2b2da2d8bc01cefab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f883b4826e164231ae10369fd897e9d5
+      - f17ead2d563d49489104b0d174ae102e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f09edd0ed8a34e0893928f126dfa8771
+      - 969121cf2af84f8e8010dd77f4079676
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d8ad7b95379464994a1cc3336282f5e
+      - fb9b51df0f044c84804ddde9575bdb35
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:20:24 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - dfd2fa816c3142da9e087021766f188d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/07757fc1-3c95-4630-a5a3-063d48799cf0/"
+      - "/pulp/api/v3/remotes/rpm/rpm/7184fef0-2023-4a03-b5b9-80853e079847/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a933179bcaa49a899e8885771cffc67
+      - 79c2abc92bf44da29544938835edbc58
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA3
-        NzU3ZmMxLTNjOTUtNDYzMC1hNWEzLTA2M2Q0ODc5OWNmMC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIwOjI0Ljc2MzY0M1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcx
+        ODRmZWYwLTIwMjMtNGEwMy1iNWI5LTgwODUzZTA3OTg0Ny8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjE0LjY1MDIyN1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIwOjI0Ljc2MzY2MloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAxOjE0LjY1MDI1MFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5b57db876f5c47c3991ce39037fbb95b
+      - aea479cbfc584540ade4e26b13aacb28
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMGM3N2RkZTgtM2I2OS00NDdlLWFlMzEtNzJhNzA4ODBjNThmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MjQuODcyMjU1WiIsInZl
+        cG0vZTRkNTU4MGItYWFkNS00NzAzLTgzNjctMjZlYzBhYmE2MGM5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MTQuODAyNzMyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMGM3N2RkZTgtM2I2OS00NDdlLWFlMzEtNzJhNzA4ODBjNThmL3ZlcnNp
+        cG0vZTRkNTU4MGItYWFkNS00NzAzLTgzNjctMjZlYzBhYmE2MGM5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wYzc3ZGRlOC0z
-        YjY5LTQ0N2UtYWUzMS03MmE3MDg4MGM1OGYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lNGQ1NTgwYi1h
+        YWQ1LTQ3MDMtODM2Ny0yNmVjMGFiYTYwYzkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:24 GMT
+      - Fri, 29 Jul 2022 09:01:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e83bb9c79b614c2a9c4c23cf186757d5
+      - 3b91e7fb233c40cc8726babc0334e642
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zYzQ0YjI0NS1jNmFkLTRjMjMtOGUzMC0yMThlZDE0ZWRiOGMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDoxOS4yMDI3OTda
+        cnBtL3JwbS9kNDFlYjBjOS1lMWNiLTQ3MGMtYTQ5Ni05YjEwN2M5NDY2OTMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMTowNS45NDU1MDFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zYzQ0YjI0NS1jNmFkLTRjMjMtOGUzMC0yMThlZDE0ZWRiOGMv
+        cnBtL3JwbS9kNDFlYjBjOS1lMWNiLTQ3MGMtYTQ5Ni05YjEwN2M5NDY2OTMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNjNDRi
-        MjQ1LWM2YWQtNGMyMy04ZTMwLTIxOGVkMTRlZGI4Yy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q0MWVi
+        MGM5LWUxY2ItNDcwYy1hNDk2LTliMTA3Yzk0NjY5My92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:24 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:14 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d41eb0c9-e1cb-470c-a496-9b107c946693/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2a5d66495fe4d31a018f604c0a44394
+      - '062228691528474bbac75a2ed3912a51'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzMjFhYTVjLTIzMmEtNDM4
-        NS05ZDY5LWYzODFkYjc1MTRkYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkNmVmMzIwLTEwNmEtNDI0
+        ZC04NWI3LThhMDY1Y2QxODU0ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dee7eef72ce241ca803fa2a4dd6cd19a
+      - b82772e9f0564b29803037fb8dd398eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMzZhNjVlNzMtNmMzNS00YmQzLWFhOGYtNDc4NTAyNjc5NjQwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MTguMzI2NDgwWiIsIm5h
+        cG0vMWIwNmI5YmItNTdlZC00MWRhLWE4YzgtZDU0MTVmNzA2YjVkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MDQuODI0NDQ1WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyMDoxOS41MjQ0NTFaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMTowNi4zODIxMTVaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/36a65e73-6c35-4bd3-aa8f-478502679640/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/1b06b9bb-57ed-41da-a8c8-d5415f706b5d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 685095e3afa941a5a555ba2b4107bfba
+      - 80d598cafcf043bd83e283c117bd16ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiNzhkNzA1LTA1N2MtNDc2
-        Yi05NGJiLTIwZGY0NjNlOWVkNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2MGFmNGQyLTM5M2UtNDY0
+        ZC05NmQyLWRmYTBjZDY2NTNiYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c321aa5c-232a-4385-9d69-f381db7514dc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2d6ef320-106a-424d-85b7-8a065cd1854d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 54251e320d1248d0986e234ed4e6e43d
+      - bb5d114696ff4e50b6631ef197586ff5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzMyMWFhNWMtMjMy
-        YS00Mzg1LTlkNjktZjM4MWRiNzUxNGRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjUuMDI1MDM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ2ZWYzMjAtMTA2
+        YS00MjRkLTg1YjctOGEwNjVjZDE4NTRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTUuMDI3ODM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhMmE1ZDY2NDk1ZmU0ZDMxYTAxOGY2MDRj
-        MGE0NDM5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjI1LjA1
-        NjE3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MjUuMTE0
-        MDkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNjIyMjg2OTE1Mjg0NzRiYmFjNzVhMmVk
+        MzkxMmE1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjE1LjA3
+        MjEwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MTUuMTg1
+        MzA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2M0NGIyNDUtYzZhZC00YzIz
-        LThlMzAtMjE4ZWQxNGVkYjhjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDQxZWIwYzktZTFjYi00NzBj
+        LWE0OTYtOWIxMDdjOTQ2NjkzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4b78d705-057c-476b-94bb-20df463e9ed4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/560af4d2-393e-464d-96d2-dfa0cd6653bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1b15c70eb9547629efd1c8a948c3538
+      - 2d0b8ed05f7a4d7ea6b9cd392134bcfb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGI3OGQ3MDUtMDU3
-        Yy00NzZiLTk0YmItMjBkZjQ2M2U5ZWQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjUuMTA5NTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTYwYWY0ZDItMzkz
+        ZS00NjRkLTk2ZDItZGZhMGNkNjY1M2JiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTUuMTY3ODgwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ODUwOTVlM2FmYTk0MWE1YTU1NWJhMmI0
-        MTA3YmZiYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjI1LjE0
-        MTU3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MjUuMTg0
-        ODczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4MGQ1OThjYWZjZjA0M2JkODNlMjgzYzEx
+        N2JkMTZiYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjE1LjIz
+        MTg0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MTUuMjky
+        Mzc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM2YTY1ZTczLTZjMzUtNGJkMy1hYThm
-        LTQ3ODUwMjY3OTY0MC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFiMDZiOWJiLTU3ZWQtNDFkYS1hOGM4
+        LWQ1NDE1ZjcwNmI1ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5a3ddf58f9e7478585172fd7d39c3567
+      - 2e1f0ae8e0474dcea1021699b57605c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c3122bf1734c4343bd08154583ead297
+      - 21b7021342cd4994830145bdf2a9d977
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f3351b29cdd64db19086f3ef68042088
+      - 78381497bde84da29764a6b6276f8ae3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 485831b4a16a41cb941276367bca6596
+      - 4ad9238c28db4457a547da1cf1b6050b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae8e83fc899d4474b4a7dac7326fb580
+      - 0d4b9f16a3754e05bb45b7929a682b65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b355308937ee428fb31aa377a7ace95a
+      - dc9ba77640754737a64d0213f5994311
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/"
+      - "/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f92b12233e8a444aa29ea54762be3301
+      - 14121ff2c2a6424aacd58eeb9342c668
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjhlOGY1Y2YtNDliOS00MzBhLThiNWYtYWY5YzNjN2Y3M2ViLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MjUuNTQ1NzA2WiIsInZl
+        cG0vNjNjYzMzNWMtZTA2Zi00OGFkLTkxZjItMmJkZmRhNGRjMzJlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MTUuNzMwOTQ1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjhlOGY1Y2YtNDliOS00MzBhLThiNWYtYWY5YzNjN2Y3M2ViL3ZlcnNp
+        cG0vNjNjYzMzNWMtZTA2Zi00OGFkLTkxZjItMmJkZmRhNGRjMzJlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82OGU4ZjVjZi00
-        OWI5LTQzMGEtOGI1Zi1hZjljM2M3ZjczZWIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82M2NjMzM1Yy1l
+        MDZmLTQ4YWQtOTFmMi0yYmRmZGE0ZGMzMmUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:15 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/07757fc1-3c95-4630-a5a3-063d48799cf0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/7184fef0-2023-4a03-b5b9-80853e079847/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ce69df5fac5442ebc64493a630091a1
+      - 133324d84b5f4bbc8a83cdeb876c68ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVjYTQzOTQ5LWMzMzItNDhi
-        MS04M2ZkLTYyYTYwZjQwOTY0My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0YWQ0NjRhLTU5NzctNDg4
+        MC1hNjQ0LWQyODRlNWFkZDNkYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5ca43949-c332-48b1-83fd-62a60f409643/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/74ad464a-5977-4880-a644-d284e5add3da/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:25 GMT
+      - Fri, 29 Jul 2022 09:01:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c47e90184e344938b17a9ab8dd62e031
+      - 76be454565fe4247be38f99c15f3500f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWNhNDM5NDktYzMz
-        Mi00OGIxLTgzZmQtNjJhNjBmNDA5NjQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjUuODI2MTk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzRhZDQ2NGEtNTk3
+        Ny00ODgwLWE2NDQtZDI4NGU1YWRkM2RhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTYuMTg1MjA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwY2U2OWRmNWZhYzU0NDJlYmM2NDQ5M2E2
-        MzAwOTFhMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjI1Ljg1
-        NzQ1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MjUuODc5
-        MjY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIxMzMzMjRkODRiNWY0YmJjOGE4M2NkZWI4
+        NzZjNjhlZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjE2LjI1
+        ODYzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MTYuMzA4
+        MjgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA3NzU3ZmMxLTNjOTUtNDYzMC1hNWEz
-        LTA2M2Q0ODc5OWNmMC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcxODRmZWYwLTIwMjMtNGEwMy1iNWI5
+        LTgwODUzZTA3OTg0Ny8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:16 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA3NzU3
-        ZmMxLTNjOTUtNDYzMC1hNWEzLTA2M2Q0ODc5OWNmMC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcxODRm
+        ZWYwLTIwMjMtNGEwMy1iNWI5LTgwODUzZTA3OTg0Ny8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:26 GMT
+      - Fri, 29 Jul 2022 09:01:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5156d7223b434ecd942015926aff1992
+      - d705e82fc41941cf8c95a188c5f401a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2YjgyMjdiLWJmZWItNGNk
-        NC1iZDI0LTk0OGRjYmU1ZjFkYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhMTRjNWI1LTBjNTEtNGU2
+        MC04ZGQwLThjNGUyZDNjOTZiYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/56b8227b-bfeb-4cd4-bd24-948dcbe5f1dc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8a14c5b5-0c51-4e60-8dd0-8c4e2d3c96bc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:27 GMT
+      - Fri, 29 Jul 2022 09:01:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90e5e74f0c33463095da3d9c06a34fc7
+      - 978d465241d94969b782f5bfa462f27e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTZiODIyN2ItYmZl
-        Yi00Y2Q0LWJkMjQtOTQ4ZGNiZTVmMWRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjUuOTk2OTAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGExNGM1YjUtMGM1
+        MS00ZTYwLThkZDAtOGM0ZTJkM2M5NmJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTYuNDgxMDg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI1MTU2ZDcyMjNiNDM0ZWNkOTQy
-        MDE1OTI2YWZmMTk5MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjI2LjAyNjIzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        MjYuNzY2ODE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkNzA1ZTgyZmM0MTk0MWNmOGM5
+        NWExODhjNWY0MDFhNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjE2LjUzOTA2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        MTcuODUyNzc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzBjNzdkZGU4LTNiNjktNDQ3ZS1hZTMxLTcyYTcw
-        ODgwYzU4Zi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wYzc3
-        ZGRlOC0zYjY5LTQ0N2UtYWUzMS03MmE3MDg4MGM1OGYvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMDc3NTdmYzEtM2M5NS00NjMw
-        LWE1YTMtMDYzZDQ4Nzk5Y2YwLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9lNGQ1NTgwYi1hYWQ1LTQ3MDMtODM2Ny0yNmVjMGFi
+        YTYwYzkvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTRkNTU4
+        MGItYWFkNS00NzAzLTgzNjctMjZlYzBhYmE2MGM5LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcxODRmZWYwLTIwMjMtNGEwMy1i
+        NWI5LTgwODUzZTA3OTg0Ny8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMGM3N2RkZTgtM2I2OS00NDdlLWFlMzEtNzJhNzA4ODBj
-        NThmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZTRkNTU4MGItYWFkNS00NzAzLTgzNjctMjZlYzBhYmE2
+        MGM5L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:27 GMT
+      - Fri, 29 Jul 2022 09:01:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 12ec5a59c8bc44a0a15bc576d16586ab
+      - b776e30a83a44a15ac5583af056e9288
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiMzM4MzBkLTIzYWUtNGMx
-        MS1iYzJmLThlNGNiZjY3MGY0Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1M2I5YzVhLTE0M2YtNDJl
+        NS04NzQzLTM5NzM1OWM0ZWE3Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b33830d-23ae-4c11-bc2f-8e4cbf670f46/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/353b9c5a-143f-42e5-8743-397359c4ea72/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:27 GMT
+      - Fri, 29 Jul 2022 09:01:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3316122220b7418681e3db209c63ea71
+      - 139b0cec5c424a5a8519649bfa5926ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIzMzgzMGQtMjNh
-        ZS00YzExLWJjMmYtOGU0Y2JmNjcwZjQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjcuMjE4Mzc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzUzYjljNWEtMTQz
+        Zi00MmU1LTg3NDMtMzk3MzU5YzRlYTcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTguMzEwNzM5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjEyZWM1YTU5YzhiYzQ0YTBhMTViYzU3NmQx
-        NjU4NmFiIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MjcuMjQ4
-        MzE5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMDoyNy40ODgz
-        MDZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImI3NzZlMzBhODNhNDRhMTVhYzU1ODNhZjA1
+        NmU5Mjg4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MTguMzU1
+        MzA0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMToxOC43NTI4
+        MzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZWU3NmQ4
-        MTUtZGM3YS00OTQ4LWEyYjYtMzAxMzg5YmUxMmI2LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMWQ3MDU1
+        YjctZjhhOC00M2NiLTkxZmMtZmNkNWM3ZmQwY2RlLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMGM3N2RkZTgtM2I2OS00NDdlLWFlMzEtNzJhNzA4
-        ODBjNThmLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZTRkNTU4MGItYWFkNS00NzAzLTgzNjctMjZlYzBh
+        YmE2MGM5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:27 GMT
+      - Fri, 29 Jul 2022 09:01:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d49a9ad382d4af3b6b99b34c3a09291
+      - c4e4c78a1cce4ae2bd0ec8d6f26f4d10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/1d7055b7-f8a8-43cb-91fc-fcd5c7fd0cde/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 50a8d36e28aa4a759cee28da1782d5b1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMWQ3MDU1YjctZjhhOC00M2NiLTkxZmMtZmNkNWM3ZmQwY2RlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MTguMzgwMjAyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lNGQ1NTgwYi1hYWQ1LTQ3MDMtODM2Ny0yNmVjMGFiYTYwYzkv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2U0ZDU1ODBiLWFhZDUtNDcwMy04MzY3LTI2ZWMw
+        YWJhNjBjOS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:18 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8xZDcwNTViNy1mOGE4LTQzY2ItOTFmYy1mY2Q1YzdmZDBjZGUv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0a53677fdeb9414db13e13afa216890f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5MjEyNjkxLTE0MGMtNDA3
+        MC04NDQyLTEzYzBkYjlhMTVkOS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/19212691-140c-4070-8442-13c0db9a15d9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e412c56ef8904f4c84a44a06abaa5762
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTkyMTI2OTEtMTQw
+        Yy00MDcwLTg0NDItMTNjMGRiOWExNWQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MTkuMDIzODY5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwYTUzNjc3ZmRlYjk0MTRkYjEzZTEzYWZh
+        MjE2ODkwZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjE5LjA2
+        NDA2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6MTkuNDEw
+        MTczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYmNl
+        OTJkYzctNmYxZS00ZjhhLWJiYWItM2I0M2Y4ODRmODQzLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/bce92dc7-6f1e-4f8a-bbab-3b43f884f843/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - '09d8e5ae95814278809ff176f4a603ec'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2JjZTkyZGM3LTZmMWUtNGY4YS1iYmFiLTNiNDNmODg0Zjg0My8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjE5LjM5MzUzOVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMWQ3MDU1YjctZjhhOC00M2NiLTkxZmMt
+        ZmNkNWM3ZmQwY2RlLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ea267e8167c24c9997b3c63ec9f44109
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:27 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b87a78c2be04bdfbb3daaaadcf01b3c
+      - ed3a21d4219f45e580a0c4e05e8fa142
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:27 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bec703d146cf49a38043ce6c3a6ee851
+      - e7ab800106da40239eaf9705a619c393
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7363625adfe5488ba438673ca3bb2108
+      - b35b29fb429c439286455087e8155526
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 055bb2d0f59447a48c3cdd70792de4ac
+      - 7d14ba482ab640738426c49ea74b26a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7f828b5d3a714bf48eff4503811fef58
+      - eb6ff0b0dde8484a907e9525fea8a28e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4f4228e10b9a457d9b9f486c4a7dab51
+      - c2f4c25d46094b0a955cd1449c8ddf3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 539b9bd3e588417d9029445a3a31a23e
+      - 2f4c00b6f9da40fba21beea1f1dd8738
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dbd209ebdb544dffb3f44ff119327de4
+      - ff590d1bb4694628a0f6f5d47f40b9c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e4fefef9396c437385236de7fa8d942c
+      - 8a362ee2b2994ee7b3c41bed011f2430
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 84eec34568384b81b23480f154e078da
+      - 6d3a8788d42640ce95f18e321894fc23
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9aea5fe6d5974fa1bf532cc22db28fd1
+      - b23955bc77514d46bba198e4a883744a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aae69e1721a0444c8d1729f9ee8e726d
+      - f85ab5b8f0624c7880f01e2e7bc8e0a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0c77dde8-3b69-447e-ae31-72a70880c58f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4d5580b-aad5-4703-8367-26ec0aba60c9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fc16e4f3c3434cc29f0287b7499cef6e
+      - d3cfb63bf2f447bc835c6ff08bee26ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:21 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,75 +3819,75 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 259d999923ef403ba22c727d5b9db137
+      - 745e0c31e8114bf28889c1d34b9c59f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IwNDA3MmNkLWRkOTYtNGY0
-        OS05MDM4LTU3OTVlOGYzZDE4Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlZjAzOWNhLTRlNzQtNGI3
+        MS04OGY4LTk3NzE3ZmQ0MTU3MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:21 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80NjRmNzQ1Mi04ODhiLTQyZjctODMyMi03YTlkZGQ1
-        YThhNzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NmExMGJiYmYtNTFlMS00MTVhLWEwMGYtNzliNzFhZTFkM2Q0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzhhYTU1NzE0LTFmOTYt
-        NGRiMy04YTMxLTM1MzI1ZmQ3N2NjMC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9iM2QzNTBiMS1mMDcxLTRkYTAtOWI5Zi1lNGQ3
-        M2E4YWIwYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3RyaWJ1
-        dGlvbl90cmVlcy9jN2UzNTQxNy05ZDg3LTQ4ZGUtOThkOC01MmQ2MzViM2Vl
-        YmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8wODc3
-        NjQyNi0zZjNmLTRhNjItYmIxYy05ODRjNTZmYjMwNDMvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmIt
-        OWY4OC01MWRlYTMwMGRlODcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L21vZHVsZW1kcy84MDBiNTVjNi05NzUzLTQzODEtOWQ3OC0wZmRlMmRkZmVl
-        NDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9iMTJh
-        MjE2Zi01ZTU2LTQ4ODEtYWZhZi02OWFjNWU1ZmRjMDIvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4YjIt
-        ODE0My1hNjE5MGRiZWI4YzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L21vZHVsZW1kcy9lNzQxM2ZlMC0zMDY3LTQ1NmQtOTVmYy0wNmIyYmRhMjcy
-        YWMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
-        NjgwZGFhYjItYWE1Yy00NGJkLTg2NjctZTBhZmNhOWY4OTBiLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4
-        Y2MtNGEzOS05OWJmLTQ5NjJiY2MwZmUwNS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNl
-        ZWUyZWY3OGMyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xM2EyNGRmNC03Y2MyLTQ1ZjMtYjViMC01NjhlNmVkMjYzZjUvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTct
-        NDliMC05OGJlLTcyMjNiNjk4NWUyOC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2RlNDc5YjEtZTdhYy00ZDFkLWFmNTQtNGYxMWFk
-        MGNmNGU0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8z
-        ZTRlZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5OTZjZmFkLTJmNDgtNGVj
-        Ni1iMjIxLTdlOTdjMzY4OTFiNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNmQ2MGRhMmYtMGFhNy00NmFmLWJmNmYtYTlhM2Q4NmVl
-        MTQ5LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85YWQw
-        N2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZDI0NDFlYWEt
-        M2ZjMS00Nzc1LTkyMGUtYTZkNzY4ZDZjMjE3LyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYt
-        NGI3My1hZTRhLTg3YmNhOGViMzllMS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5
-        N2QtOTkyMTM4NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2
-        ZTE4NGQ5MmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1k
-        X2RlZmF1bHRzLzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0
-        YS8iXX0=
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMt
+        NGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3RyaWJ1
+        dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRkNTBh
+        MjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8wYzg0
+        MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTkt
+        YmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3YTEx
+        OTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8zYjli
+        OWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRiNTkt
+        ODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAz
+        ODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
+        NDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQx
+        MGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYt
+        NDE4OS05Y2M1LTZkOGRjMzVjMTBkNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNjJhNDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5
+        OWZiNjFmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNzI0
+        MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2Yt
+        YjljMC00MjMxLTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUt
+        NGVhZi1hNGE4LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEw
+        MmQtZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
+        b2R1bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlm
+        NDliODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1k
+        X2RlZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3
+        MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3475,7 +3900,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:28 GMT
+      - Fri, 29 Jul 2022 09:01:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3493,21 +3918,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 07a54a9032e2448fa2fcd5f3adb2a1c4
+      - 9a4681bd17ff4f4c8973af8ecc685bb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2ZGJhYTYxLTE0MmYtNDc1
-        My04ZWVlLTc4NTc0NThmNzM5Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzM2NlNzhmLTFiMjEtNDc0
+        NS1hOWMxLWJlY2YyOWEzOTBjYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/26dbaa61-142f-4753-8eee-7857458f739f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a33ce78f-1b21-4745-a9c1-becf29a390cb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3528,53 +3953,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:29 GMT
+      - Fri, 29 Jul 2022 09:01:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95d7f20d40204707bcdaad3448592eae
+      - c650ef8fbc434839a464158e0441e849
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjZkYmFhNjEtMTQy
-        Zi00NzUzLThlZWUtNzg1NzQ1OGY3MzlmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjguODQ5NjE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTMzY2U3OGYtMWIy
+        MS00NzQ1LWE5YzEtYmVjZjI5YTM5MGNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6MjEuNTE4NTg0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwN2E1NGE5MDMyZTI0NDhmYTJm
-        Y2Q1ZjNhZGIyYTFjNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjI4Ljk4MjU4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        MjkuMTQ4MDc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5YTQ2ODFiZDE3ZmY0ZjRjODk3
+        M2FmOGVjYzY4NWJiNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjIxLjgxMjMzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        MjIuMTM2NzA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82OGU4ZjVjZi00OWI5LTQzMGEtOGI1Zi1hZjljM2M3ZjczZWIvdmVyc2lv
+        bS82M2NjMzM1Yy1lMDZmLTQ4YWQtOTFmMi0yYmRmZGE0ZGMzMmUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjhlOGY1Y2YtNDliOS00MzBh
-        LThiNWYtYWY5YzNjN2Y3M2ViLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjNjYzMzNWMtZTA2Zi00OGFk
+        LTkxZjItMmJkZmRhNGRjMzJlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3582,7 +4007,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3595,52 +4020,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:29 GMT
+      - Fri, 29 Jul 2022 09:01:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '667'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0b9138c98cca4685b2642797ec5c3639
+      - bf9a59bece9e45a8b31aae7952a1d143
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '288'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcv
+        YWNrYWdlcy80NjAxOTJmYy03ZWZmLTRlZGItYTA4YS1iYmFhNDgzNWFjNWEv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJkMDYxLyJ9
+        a2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJlLTcyMjNiNjk4NWUyOC8ifSx7
+        Z2VzLzY1ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZTRlZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIn0seyJw
+        cy82MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUyZWY3OGMyLyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEz
-        YTI0ZGY0LTdjYzItNDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZGU0
-        NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIn1dfQ==
+        NWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2
+        ZDAyNGMyLTEwZmMtNDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQx
+        ODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3648,7 +4073,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3661,50 +4086,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:29 GMT
+      - Fri, 29 Jul 2022 09:01:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a72b1136134147019c23923cb2039359
+      - e90c3098ac344a9295255bb56a2c423b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '264'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmItOWY4OC01MWRlYTMwMGRlODcv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVmZGMwMi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvODAwYjU1YzYtOTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4YjItODE0My1hNjE5MGRiZWI4YzcvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2U3NDEzZmUwLTMwNjctNDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3712,7 +4137,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3725,37 +4150,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:29 GMT
+      - Fri, 29 Jul 2022 09:01:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6131'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff129decd8b04998a041c82def388217
+      - f5360029bef545b3974925a8f907f959
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1827'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3828,9 +4253,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvNmExMGJiYmYtNTFlMS00MTVhLWEwMGYt
-        NzliNzFhZTFkM2Q0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzQxMDk1WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -3847,9 +4272,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2IzZDM1MGIxLWYwNzEtNGRh
-        MC05YjlmLWU0ZDczYThhYjBiZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjE1OjM5LjMxOTg1M1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -3858,9 +4283,9 @@ http_interactions:
         c29sdXRpb24iOiIiLCJyZWxlYXNlIjoiMSIsInJpZ2h0cyI6IiIsInB1c2hj
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvOGFhNTU3MTQtMWY5Ni00ZGIzLThh
-        MzEtMzUzMjVmZDc3Y2MwLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNU
-        MjM6MTU6MzkuMzE4NTYxWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
+        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvZWE1ZjA0NjItNjJhYi00YzFmLWE2
+        NGQtYjkxZDA2YzQ1YjZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhU
+        MTU6MDQ6MzQuMjcyMTg0WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
         OSIsInVwZGF0ZWRfZGF0ZSI6IjIwMTgtMDctMjAgMDY6MDA6MDEiLCJkZXNj
         cmlwdGlvbiI6IkR1Y2tfS2FuZ2Fyb19FcnJhdHVtIGRlc2NyaXB0aW9uIiwi
         aXNzdWVkX2RhdGUiOiIyMDE4LTAxLTI3IDE2OjA4OjA5IiwiZnJvbXN0ciI6
@@ -3889,10 +4314,10 @@ http_interactions:
         biI6IjAuNyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3Rl
         ZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3900,7 +4325,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3913,43 +4338,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:29 GMT
+      - Fri, 29 Jul 2022 09:01:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 030ba6e173764a069742d036c7a6b617
+      - 6f6850056c0041b8baa9659cc128c232
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3957,7 +4382,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3970,41 +4395,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:29 GMT
+      - Fri, 29 Jul 2022 09:01:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c683debd65dd43bbb1aa6cccda8e47b3
+      - 90169390333747bf9c1ff474afb93d46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/68e8f5cf-49b9-430a-8b5f-af9c3c7f73eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/63cc335c-e06f-48ad-91f2-2bdfda4dc32e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4012,7 +4437,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4025,36 +4450,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:29 GMT
+      - Fri, 29 Jul 2022 09:01:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4bc3bb62d5f946868958b9fb4f8f6f58
+      - 2a7cb2b32fb04870bf0317748950d38a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4076,5 +4501,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:23 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_errata_repository/proper_errata_copied_if_no_errata_packages_matches_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_errata_repository/proper_errata_copied_if_no_errata_packages_matches_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:17 GMT
+      - Fri, 29 Jul 2022 09:01:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 76a6d8da667a41bb9203ec2cba194ed9
+      - 5be9ffe503ec47b2b1658921c011c5d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80NTY2NTFkNC01OTI3LTQ2NTItOGZhNi04MmI3MzkzNWU0ZTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDoxMi4xNjI4NTBa
+        cnBtL3JwbS9lNWJjYmNhNC00YTAyLTQxNjItYjFlNi1kMzg5YjY1MjE5Y2Mv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMTozNi4yMjc5NDda
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80NTY2NTFkNC01OTI3LTQ2NTItOGZhNi04MmI3MzkzNWU0ZTMv
+        cnBtL3JwbS9lNWJjYmNhNC00YTAyLTQxNjItYjFlNi1kMzg5YjY1MjE5Y2Mv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQ1NjY1
-        MWQ0LTU5MjctNDY1Mi04ZmE2LTgyYjczOTM1ZTRlMy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U1YmNi
+        Y2E0LTRhMDItNDE2Mi1iMWU2LWQzODliNjUyMTljYy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:17 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:45 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/456651d4-5927-4652-8fa6-82b73935e4e3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e5bcbca4-4a02-4162-b1e6-d389b65219cc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:17 GMT
+      - Fri, 29 Jul 2022 09:01:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ba9c794a6784963bb10180b465ef471
+      - 49c97128616b4901aee60932b94e6df0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1YzlkM2JlLThjMTMtNDFl
-        Ni1iZjYyLTc1Zjk1NjBkMGVlNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzZjU2Yjc1LTg1OGMtNDcx
+        YS04YWYyLThiMTNmOGFlOTVkYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:17 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:17 GMT
+      - Fri, 29 Jul 2022 09:01:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f3181d2d57b14e3aa6a6df1168e9fda4
+      - 006a67166ae341d3a7a0ee25fe0f67ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:17 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/95c9d3be-8c13-41e6-bf62-75f9560d0ee4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f3f56b75-858c-471a-8af2-8b13f8ae95dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0fbea04f48af42c5bd0b46c2e059a07a
+      - d4ce7eb911b940b4b5a65c37cf3c0af4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTVjOWQzYmUtOGMx
-        My00MWU2LWJmNjItNzVmOTU2MGQwZWU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTcuNzgzOTEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjNmNTZiNzUtODU4
+        Yy00NzFhLThhZjItOGIxM2Y4YWU5NWRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NDUuMzQwMDc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzYmE5Yzc5NGE2Nzg0OTYzYmIxMDE4MGI0
-        NjVlZjQ3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjE3Ljgx
-        ODQyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTcuOTQ4
-        ODE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0OWM5NzEyODYxNmI0OTAxYWVlNjA5MzJi
+        OTRlNmRmMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjQ1LjM4
+        NTA3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NDUuNjE5
+        NTE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDU2NjUxZDQtNTkyNy00NjUy
-        LThmYTYtODJiNzM5MzVlNGUzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTViY2JjYTQtNGEwMi00MTYy
+        LWIxZTYtZDM4OWI2NTIxOWNjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 00da41e75aa446428d4f9463bc93456c
+      - 7e108ef4c3ae4c469c51314712bcc606
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c20224c09bd8423b87571d91f2bb5673
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNTFlZWUwMTktMTUwOS00MGI5LWIzYmYtNjEwZTYwYzhmOGZi
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NDAuODM3NjY0
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:45 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/51eee019-1509-40b9-b3bf-610e60c8f8fb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1e1a738647004a2492766893f00f9bf2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlZjc4MmJkLTk5MTctNDMz
+        My05ZmIwLThmOGNlYTZiYzE2YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bef782bd-9917-4333-9fb0-8f8cea6bc16a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 721257d3882742ce886cd27e6b234940
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmVmNzgyYmQtOTkx
+        Ny00MzMzLTlmYjAtOGY4Y2VhNmJjMTZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NDUuNzcyNjU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxZTFhNzM4NjQ3MDA0YTI0OTI3NjY4OTNm
+        MDBmOWJmMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjQ1Ljgy
+        NDQ0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NDUuODU1
+        NzY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25c3183020f04628815f9f48eef312d9
+      - 3523f0e6fc084272ac7fde36466e4398
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49f2d13991714d89aa1b4b84514f1b81
+      - 99f69a6ebca84cc38682f6c914ddd442
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a8819e348f2d4f82b0f7d9d658681be6
+      - 822b6916a46243c38a02404b0147e8f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 397b5bd6af614e7d9365e8ab984a23ed
+      - 57a0c5b6cd6a4d78a95f4213495af3b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:20:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f10d4ec0a86a4b71b6987714622679b2
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/36a65e73-6c35-4bd3-aa8f-478502679640/"
+      - "/pulp/api/v3/remotes/rpm/rpm/4fe73ddd-0317-4c6f-8190-62c2260ec8df/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ec31f34911e2409b910ea30e01e8bb3f
+      - d2124781bee64a24a3e581f6f76aea08
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM2
-        YTY1ZTczLTZjMzUtNGJkMy1hYThmLTQ3ODUwMjY3OTY0MC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIwOjE4LjMyNjQ4MFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRm
+        ZTczZGRkLTAzMTctNGM2Zi04MTkwLTYyYzIyNjBlYzhkZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjQ2LjQ2Mjc0N1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIwOjE4LjMyNjQ5OVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAxOjQ2LjQ2Mjc3NFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/"
+      - "/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9771981dd0394e6d8a3104e887103b5b
+      - 8cbd23a0d1374e72bfa34f9bd12d8010
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZjk4OGM4YWQtMTc1NC00ZDZmLThjM2MtZTJiNjcxNDEzNDIzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MTguNTA2Mzc5WiIsInZl
+        cG0vY2I3YmJiYTAtMDRhNy00ZjFlLWFkOGUtMjQ3YjJjNmM5MmY1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NDYuNjUxMzI5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZjk4OGM4YWQtMTc1NC00ZDZmLThjM2MtZTJiNjcxNDEzNDIzL3ZlcnNp
+        cG0vY2I3YmJiYTAtMDRhNy00ZjFlLWFkOGUtMjQ3YjJjNmM5MmY1L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mOTg4YzhhZC0x
-        NzU0LTRkNmYtOGMzYy1lMmI2NzE0MTM0MjMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYjdiYmJhMC0w
+        NGE3LTRmMWUtYWQ4ZS0yNDdiMmM2YzkyZjUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 521856382d73401dbf8f4b70de3ed7c3
+      - 3d21d781d85147cd8e586069265ca956
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lODE3YjY0My1jYzkyLTQyMDktOTJjNi1lYTQxZjE3ZmYwZmYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDoxMi44NTk3MjRa
+        cnBtL3JwbS8xOGUyNDExNS0wODdmLTQxZjEtYTlkNS04MGUxNDk1YTJkNTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMTozNy4xODgzMTha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lODE3YjY0My1jYzkyLTQyMDktOTJjNi1lYTQxZjE3ZmYwZmYv
+        cnBtL3JwbS8xOGUyNDExNS0wODdmLTQxZjEtYTlkNS04MGUxNDk1YTJkNTkv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U4MTdi
-        NjQzLWNjOTItNDIwOS05MmM2LWVhNDFmMTdmZjBmZi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzE4ZTI0
+        MTE1LTA4N2YtNDFmMS1hOWQ1LTgwZTE0OTVhMmQ1OS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e817b643-cc92-4209-92c6-ea41f17ff0ff/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/18e24115-087f-41f1-a9d5-80e1495a2d59/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95d9bede57c64fd0afe997a49371e43f
+      - e9139520f22d44558b6e4ec00f3b3a52
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwMjNkYTA0LTdhOWQtNDcw
-        Yy05ZTI3LTY3OGNlMTQzNDQ5ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhY2Q2ODQ1LTljYWUtNDU4
+        OC04MDZjLTYxMTE1YWJiMjcxMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3bb27a7ca5c246d5abe1660450023d17
+      - f9184c77bc0e44d9aafd5d600a0933e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '368'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYjY0ZThlYWYtYzYyYi00OGMwLTk1NzEtZTQyYjRjMjE1MWU0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MTIuMDUxNjE3WiIsIm5h
+        cG0vNmU3ZjAwZWItNWY5Yy00OTg0LWFkZGYtZDcwNmU3NGRiMTNjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6MzYuMDMzNzI2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyMDoxMy4xNzQ5MDBaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMTozNy42Mzg2MDNaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:46 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/b64e8eaf-c62b-48c0-9571-e42b4c2151e4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/6e7f00eb-5f9c-4984-addf-d706e74db13c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11faa26c12634c67be9abaefbc2f804d
+      - 0663ad31c3454ac59e0dbfd472074ca4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1NDE4YThlLThlZDgtNDMy
-        OS04NDZhLTljMzRlYjczZmU3YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyYWZjMzdhLTQ0N2YtNDVj
+        Ny1hMzg5LTcyZTEzODg2ZDA2OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c023da04-7a9d-470c-9e27-678ce143449d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9acd6845-9cae-4588-806c-61115abb2713/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e94b5a46bbab489aa7f8ab46611c6584
+      - 574bf837e1d2433d9f0090db858cf5de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzAyM2RhMDQtN2E5
-        ZC00NzBjLTllMjctNjc4Y2UxNDM0NDlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTguNjY2Njk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWFjZDY4NDUtOWNh
+        ZS00NTg4LTgwNmMtNjExMTVhYmIyNzEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NDYuODY0MDk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NWQ5YmVkZTU3YzY0ZmQwYWZlOTk3YTQ5
-        MzcxZTQzZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjE4LjY5
-        NjkzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTguNzY0
-        MzgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlOTEzOTUyMGYyMmQ0NDU1OGI2ZTRlYzAw
+        ZjNiM2E1MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjQ2Ljkx
+        OTk5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NDcuMDA3
+        ODYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTgxN2I2NDMtY2M5Mi00MjA5
-        LTkyYzYtZWE0MWYxN2ZmMGZmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMThlMjQxMTUtMDg3Zi00MWYx
+        LWE5ZDUtODBlMTQ5NWEyZDU5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a5418a8e-8ed8-4329-846a-9c34eb73fe7a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/82afc37a-447f-45c7-a389-72e13886d069/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9a27dd4502ef46f49302ce89d9368362
+      - e71fa2c6a2d44d3ab4a198b75c13e551
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTU0MThhOGUtOGVk
-        OC00MzI5LTg0NmEtOWMzNGViNzNmZTdhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTguNzU5OTkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODJhZmMzN2EtNDQ3
+        Zi00NWM3LWEzODktNzJlMTM4ODZkMDY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NDYuOTg4NzM3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxMWZhYTI2YzEyNjM0YzY3YmU5YWJhZWZi
-        YzJmODA0ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjE4Ljc5
-        MjkxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTguODM1
-        NDI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNjYzYWQzMWMzNDU0YWM1OWUwZGJmZDQ3
+        MjA3NGNhNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjQ3LjA1
+        NTU2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NDcuMTEx
+        ODEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I2NGU4ZWFmLWM2MmItNDhjMC05NTcx
-        LWU0MmI0YzIxNTFlNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZlN2YwMGViLTVmOWMtNDk4NC1hZGRm
+        LWQ3MDZlNzRkYjEzYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e8cc2f2dafdc4cae8a2d26829cf5e2d7
+      - 87e4c99892f541ac9944ea7a67905aa5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 15fb852dfd9c4300b1e76f15675e10a4
+      - d1ff9df055b040eb888336af3b6d637a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:18 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1e53e1c442145978eec42139898cacb
+      - c772fbf0eabd4174a12692bb760f856f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:19 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c28fc2fbf85e4becb0001381b9817bd5
+      - d9d310670b104129b428e37b836a9918
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:19 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58ac2c94b0ca4cc88d8a40e8f75b22a1
+      - 2516d89ab60e44d5ba549b3cb141fa0e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:19 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bca3665ec1c44b8186ceba923903f954
+      - 817f7f905047432d96b3ff71cbf9c250
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:19 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/"
+      - "/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5ad80c00e2a43a0a64f5676ddbafacc
+      - 58152c6152954e00acbf3bac6451e917
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vM2M0NGIyNDUtYzZhZC00YzIzLThlMzAtMjE4ZWQxNGVkYjhjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjA6MTkuMjAyNzk3WiIsInZl
+        cG0vZmY3ZWVlMmEtNzc4ZS00MGZhLTlmYzEtOTI0NjM0ZTg0OWQxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NDcuNTQ3NjQxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vM2M0NGIyNDUtYzZhZC00YzIzLThlMzAtMjE4ZWQxNGVkYjhjL3ZlcnNp
+        cG0vZmY3ZWVlMmEtNzc4ZS00MGZhLTlmYzEtOTI0NjM0ZTg0OWQxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zYzQ0YjI0NS1j
-        NmFkLTRjMjMtOGUzMC0yMThlZDE0ZWRiOGMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mZjdlZWUyYS03
+        NzhlLTQwZmEtOWZjMS05MjQ2MzRlODQ5ZDEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/36a65e73-6c35-4bd3-aa8f-478502679640/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/4fe73ddd-0317-4c6f-8190-62c2260ec8df/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:19 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dcbf5f1156d84fec9d3b6bd887aea432
+      - 85575fa2139c430da1f1efb6f2ef98bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0ZTU4NTA0LWYzMzMtNDUz
-        Yi1iZWIxLWUzYWVlNTNmMDgxNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlZDE0OWUyLTYwNWYtNGEx
+        Yi04NDM3LWVhN2NiODIwNGFlNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e4e58504-f333-453b-beb1-e3aee53f0816/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fed149e2-605f-4a1b-8437-ea7cb8204ae5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:19 GMT
+      - Fri, 29 Jul 2022 09:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b56a2b734a24d6082fe09c4bcc8a91a
+      - 9cbefbbe41c648dc9a2b83f9eedb2bba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTRlNTg1MDQtZjMz
-        My00NTNiLWJlYjEtZTNhZWU1M2YwODE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTkuNDc3MDM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmVkMTQ5ZTItNjA1
+        Zi00YTFiLTg0MzctZWE3Y2I4MjA0YWU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NDcuOTAzNjM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJkY2JmNWYxMTU2ZDg0ZmVjOWQzYjZiZDg4
-        N2FlYTQzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIwOjE5LjUw
-        NjYyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MTkuNTI4
-        ODk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4NTU3NWZhMjEzOWM0MzBkYTFmMWVmYjZm
+        MmVmOThiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjQ3Ljk0
+        NTAyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NDcuOTY5
+        NDQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM2YTY1ZTczLTZjMzUtNGJkMy1hYThm
-        LTQ3ODUwMjY3OTY0MC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmZTczZGRkLTAzMTctNGM2Zi04MTkw
+        LTYyYzIyNjBlYzhkZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM2YTY1
-        ZTczLTZjMzUtNGJkMy1hYThmLTQ3ODUwMjY3OTY0MC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmZTcz
+        ZGRkLTAzMTctNGM2Zi04MTkwLTYyYzIyNjBlYzhkZi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:19 GMT
+      - Fri, 29 Jul 2022 09:01:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - df75020ed844434e818f9bbe2a7aec48
+      - 9fc2e47bb52242b0a1471d2cac125ba0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE3ZTYzOTA4LTg4MGEtNGQz
-        Zi05MjM3LWFmNjI1NjcwNWI1Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4Y2U2ZDJlLWMxM2EtNDU2
+        Yi05ODkzLWE5NTA4YjEzNmI1Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/17e63908-880a-4d3f-9237-af6256705b57/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/08ce6d2e-c13a-456b-9893-a9508b136b5f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:20 GMT
+      - Fri, 29 Jul 2022 09:01:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 543c62884f2743c3be7edc42bf352485
+      - 32cd3e2d1f794127bd7d298a59b8dc56
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '658'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdlNjM5MDgtODgw
-        YS00ZDNmLTkyMzctYWY2MjU2NzA1YjU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MTkuNjUyNjU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDhjZTZkMmUtYzEz
+        YS00NTZiLTk4OTMtYTk1MDhiMTM2YjVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NDguMDYwMTY0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkZjc1MDIwZWQ4NDQ0MzRlODE4
-        ZjliYmUyYTdhZWM0OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjE5LjY4MzMwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        MjAuNDg4MzM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI5ZmMyZTQ3YmI1MjI0MmIwYTE0
+        NzFkMmNhYzEyNWJhMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjQ4LjA5OTk2NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        NDkuMjk3NzM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
-        IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2Fn
-        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoy
-        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJj
-        b2RlIjoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
-        OiJEb3dubG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJzeW5jLmRv
-        d25sb2FkaW5nLm1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
-        bCI6bnVsbCwiZG9uZSI6Nywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJE
-        b3dubG9hZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGlu
-        Zy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxs
-        LCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0
-        aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQyLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBNb2R1bGVtZCIsImNvZGUi
-        OiJzeW5jLnBhcnNpbmcubW9kdWxlbWRzIiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
-        OiJQYXJzZWQgTW9kdWxlbWQtZGVmYXVsdHMiLCJjb2RlIjoic3luYy5wYXJz
-        aW5nLm1vZHVsZW1kX2RlZmF1bHRzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6MywiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2Y5ODhjOGFkLTE3NTQtNGQ2Zi04YzNjLWUyYjY3
-        MTQxMzQyMy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mOTg4
-        YzhhZC0xNzU0LTRkNmYtOGMzYy1lMmI2NzE0MTM0MjMvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMzZhNjVlNzMtNmMzNS00YmQz
-        LWFhOGYtNDc4NTAyNjc5NjQwLyJdfQ==
+        IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
+        bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9jYjdiYmJhMC0wNGE3LTRmMWUtYWQ4ZS0yNDdiMmM2
+        YzkyZjUvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2I3YmJi
+        YTAtMDRhNy00ZjFlLWFkOGUtMjQ3YjJjNmM5MmY1LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmZTczZGRkLTAzMTctNGM2Zi04
+        MTkwLTYyYzIyNjBlYzhkZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:49 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZjk4OGM4YWQtMTc1NC00ZDZmLThjM2MtZTJiNjcxNDEz
-        NDIzL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vY2I3YmJiYTAtMDRhNy00ZjFlLWFkOGUtMjQ3YjJjNmM5
+        MmY1L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:20 GMT
+      - Fri, 29 Jul 2022 09:01:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b7b67eb30a71496898c0f33af4fd8ad0
+      - c05b0947448845979dfbd348c8461940
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdjNzUxMjk5LWQyNTItNDFk
-        Ni05OTQ5LWQ2ZGI3YzBlODgzYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EyM2QwNjUxLWMwYTMtNGU1
+        Zi1iZTA2LTZlNWMxNjQ5YmEzMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7c751299-d252-41d6-9949-d6db7c0e883b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a23d0651-c0a3-4e5f-be06-6e5c1649ba31/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5b95fc76f0347bf9d55b5a302ba3b24
+      - eeb37fdf9c7e4caf910e0c5740d84ffe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2M3NTEyOTktZDI1
-        Mi00MWQ2LTk5NDktZDZkYjdjMGU4ODNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjAuNzMwODUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTIzZDA2NTEtYzBh
+        My00ZTVmLWJlMDYtNmU1YzE2NDliYTMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTAuMDEzNzA2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImI3YjY3ZWIzMGE3MTQ5Njg5OGMwZjMzYWY0
-        ZmQ4YWQwIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6MjAuNzYw
-        OTk1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMDoyMS4wMDI5
-        MDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImMwNWIwOTQ3NDQ4ODQ1OTc5ZGZiZDM0OGM4
+        NDYxOTQwIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NTAuMDU2
+        ODE1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMTo1MC40Nzcx
+        MDdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzNlZTg0
-        YzYtYzgxMy00ZWZkLWFiZTEtYjc5NmZiYmU3OWYwLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTVkZDUx
+        NGUtM2Y4NS00NTYxLThkNWQtZTQzYmU3NmYzNTEzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZjk4OGM4YWQtMTc1NC00ZDZmLThjM2MtZTJiNjcx
-        NDEzNDIzLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vY2I3YmJiYTAtMDRhNy00ZjFlLWFkOGUtMjQ3YjJj
+        NmM5MmY1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9be5ee1b28ef43ec9cd79aa490ce1496
+      - 8cb6336971d34e50a73c49f2449d2a39
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/95dd514e-3f85-4561-8d5d-e43be76f3513/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 55aa3e7edd274559aa0071ca40c8154e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vOTVkZDUxNGUtM2Y4NS00NTYxLThkNWQtZTQzYmU3NmYzNTEzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NTAuMDc4MjE2WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9jYjdiYmJhMC0wNGE3LTRmMWUtYWQ4ZS0yNDdiMmM2YzkyZjUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2NiN2JiYmEwLTA0YTctNGYxZS1hZDhlLTI0N2Iy
+        YzZjOTJmNS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:50 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS85NWRkNTE0ZS0zZjg1LTQ1NjEtOGQ1ZC1lNDNiZTc2ZjM1MTMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e121722d064a4e8eb031fca1d0fc3e81
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxMTg2NWU3LWZhZTctNDIy
+        ZC04NDYxLTM5Njg1ZTJmNzliOC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/011865e7-fae7-422d-8461-39685e2f79b8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 89f173e8e523469d9123a843f8c05c19
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDExODY1ZTctZmFl
+        Ny00MjJkLTg0NjEtMzk2ODVlMmY3OWI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTAuNzQ2ODExWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlMTIxNzIyZDA2NGE0ZThlYjAzMWZjYTFk
+        MGZjM2U4MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjUwLjc4
+        NzA3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NTEuMTAw
+        MjU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZjQ3
+        ZmY5ZjktZTE4Mi00OTA2LWE4ODgtMmVhOTgyZTZmYWZmLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/f47ff9f9-e182-4906-a888-2ea982e6faff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2fc168d2daee4654a78edf001bbb7199
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2Y0N2ZmOWY5LWUxODItNDkwNi1hODg4LTJlYTk4MmU2ZmFmZi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjUxLjA4MzY1MVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vOTVkZDUxNGUtM2Y4NS00NTYxLThkNWQt
+        ZTQzYmU3NmYzNTEzLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f3ef7dadf54e452fa6c40d6ac58e6074
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8fdb7aafaa8147429b130d856578a4cb
+      - d4fdafe5815342a1894c2e9043e05244
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 04b7eb15fd284b0bb5657c4d4de8c3de
+      - 9e20a20844944892b8656cbe40b4b226
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68e57dc0ce8d4960a3ac7c8f7e1b6c00
+      - 537dca99381c431a83d936508becc870
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4dab92c2820840b8afe4799a5d36e323
+      - b826c8db864e499694528e22309493d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96de62a5147747ef9741265dd2e369a1
+      - beab95fe0d984cdf9b6208e7fff22031
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a0d171f4f39849a3b39e2a742d19ea6f
+      - 00bbec8b1931438c9137b9c503b6c9b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1484adb6949f424db389553613803bab
+      - 1d20c98cd43a40d0b1e9b5466aadfa4f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:21 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 60f0eda7408e44d2bab2e02ca927a21f
+      - b2add310bd984e1392a90df9e3691d98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:22 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7c2047a7a30f41108ee9f6771127b14d
+      - cd0b0984e2cf497686da7a546805b47d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:22 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1a4b1e170a14463ab58c8a7ce3b4b1e
+      - 89b4b449128f4e6b89461ed110079621
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:22 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a2e8ae043ba48f0b6cb978f2b3cd1d8
+      - 3c6e42c2f9c34f4ba46328ddd039372f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:22 GMT
+      - Fri, 29 Jul 2022 09:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 374575fb7ab44ecab99e792469c8f6aa
+      - 9d7bb93751234c3d9fd6ae9cd5e9745c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f988c8ad-1754-4d6f-8c3c-e2b671413423/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:22 GMT
+      - Fri, 29 Jul 2022 09:01:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2d88ca54c5d4fc88e51024b7f9d7bb9
+      - 6ee9a785a0224ecf826a75d7a8ab3660
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:22 GMT
+      - Fri, 29 Jul 2022 09:01:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,51 +3819,51 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21bc969f5caa4b358a84f8c4dd806096
+      - 5f746d5890b14ccfa704b63e59d7688d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU3YTJjZDkwLTRjM2YtNDJm
-        My05MTFlLTQ0ODMwMDQxNzliYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NhM2FjYzBjLTcxZWUtNDFh
+        My05ZjdmLWUzZjJlYTcyYTRhYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80NjRmNzQ1Mi04ODhiLTQyZjctODMyMi03YTlkZGQ1
-        YThhNzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NmExMGJiYmYtNTFlMS00MTVhLWEwMGYtNzliNzFhZTFkM2Q0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2IzZDM1MGIxLWYwNzEt
-        NGRhMC05YjlmLWU0ZDczYThhYjBiZS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzL2M3ZTM1NDE3LTlkODctNDhkZS05
-        OGQ4LTUyZDYzNWIzZWViYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNj
-        MGZlMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZk
-        NjBkYTJmLTBhYTctNDZhZi1iZjZmLWE5YTNkODZlZTE0OS8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDFjMjkyMDYtNDExMC00MjA4
-        LWEyMGMtYzM4NTVjZDRmNDBjLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9yZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBl
-        LWE2ZDc2OGQ2YzIxNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZWVudmlyb25tZW50cy8xMjQ4Mzk2OC1iNWM2LTRiNzMtYWU0YS04N2Jj
-        YThlYjM5ZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1k
-        X2RlZmF1bHRzLzBiNjA5ODgzLWVmMzEtNGRjNi04OTdkLTk5MjEzODUzMmFm
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVs
-        dHMvMzU3ODczY2YtYmJjZC00MTQ0LWE4OGQtZGM1NmUxODRkOTJiLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zYmE2
-        NjQ5Mi05N2ZlLTRmOGMtODU3Ny02NzgxNGQ2ODQ4NGEvIl19
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMt
+        NGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdhYi1h
+        NTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkz
+        ZjkyMGEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E3
+        MjQwZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIwZS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQx
+        LWE4ZGYtZmQ4NDNhN2VkNWE4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9yZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2Qy
+        LWUxMzAzYmZkZmE1Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRhOC02ZTcx
+        OTU3Y2IxNzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1k
+        X2RlZmF1bHRzLzQyYmFkZjhmLTEwMGUtNGE4ZC1hMDJkLWYyMDNjYTMwY2Y5
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVs
+        dHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5ZjQ5YjgyMzIzLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQw
+        NGQyZC0zYWRkLTRmZDgtYmU2MC02NDE5Yjg2M2U1NzEvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3451,7 +3876,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:22 GMT
+      - Fri, 29 Jul 2022 09:01:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3469,21 +3894,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '099361726a81440f95dce45abed5f450'
+      - 0b3791c107134f008ca6f772338e5bec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0NDkxZjU0LTRlZmUtNDQz
-        NS05MDdmLTVkYjMwN2NhNjYwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyYjRiMDBmLWU1NTEtNDBh
+        ZC1hYmM2LTVlYzI4NDEwNzIwMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a4491f54-4efe-4435-907f-5db307ca6601/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2b4b00f-e551-40ad-abc6-5ec284107203/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3504,53 +3929,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:22 GMT
+      - Fri, 29 Jul 2022 09:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 753da4313f714871b3193e2abf1e1fea
+      - b049f0edeb65491691730e49a09f093a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQ0OTFmNTQtNGVm
-        ZS00NDM1LTkwN2YtNWRiMzA3Y2E2NjAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjA6MjIuMzcyMDc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJiNGIwMGYtZTU1
+        MS00MGFkLWFiYzYtNWVjMjg0MTA3MjAzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTMuMjc5MzQ5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwOTkzNjE3MjZhODE0NDBmOTVk
-        Y2U0NWFiZWQ1ZjQ1MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIw
-        OjIyLjUxMDk5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjA6
-        MjIuNjUyMTk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYjM3OTFjMTA3MTM0ZjAwOGNh
+        NmY3NzIzMzhlNWJlYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjUzLjUyMDI0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6
+        NTMuNzk5MDMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8zYzQ0YjI0NS1jNmFkLTRjMjMtOGUzMC0yMThlZDE0ZWRiOGMvdmVyc2lv
+        bS9mZjdlZWUyYS03NzhlLTQwZmEtOWZjMS05MjQ2MzRlODQ5ZDEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2M0NGIyNDUtYzZhZC00YzIz
-        LThlMzAtMjE4ZWQxNGVkYjhjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmY3ZWVlMmEtNzc4ZS00MGZh
+        LTlmYzEtOTI0NjM0ZTg0OWQxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3558,7 +3983,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3571,41 +3996,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:23 GMT
+      - Fri, 29 Jul 2022 09:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33079d08d9bf45cb981b01ab78fe3b22
+      - 87bef1f0cb58425789ac5cd2c244be67
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9kMWMyOTIwNi00MTEwLTQyMDgtYTIwYy1jMzg1NWNkNGY0MGMv
+        YWNrYWdlcy9mZGI5NTdiMS1jOTEyLTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:23 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3613,7 +4038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3626,7 +4051,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:23 GMT
+      - Fri, 29 Jul 2022 09:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3644,21 +4069,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94f873b23b694727a4a2c848156dc167
+      - 8828059884ab4b98a3753d6693aa8932
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:23 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3666,7 +4091,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3679,37 +4104,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:23 GMT
+      - Fri, 29 Jul 2022 09:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4790'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e15e0d0b47da41a5a6861b2ba8a6394a
+      - d941f77999a34ef58d3dc8e134429c5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1599'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3782,9 +4207,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvNmExMGJiYmYtNTFlMS00MTVhLWEwMGYt
-        NzliNzFhZTFkM2Q0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzQxMDk1WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -3801,9 +4226,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2IzZDM1MGIxLWYwNzEtNGRh
-        MC05YjlmLWU0ZDczYThhYjBiZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjE1OjM5LjMxOTg1M1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -3813,10 +4238,10 @@ http_interactions:
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:23 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3824,7 +4249,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3837,41 +4262,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:23 GMT
+      - Fri, 29 Jul 2022 09:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6463328dbe0045309f4211aa30bf8bdc
+      - 102be104d828460aace726ea58056fdc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:23 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3879,7 +4304,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3892,41 +4317,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:23 GMT
+      - Fri, 29 Jul 2022 09:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 831d928e26984ecc84c8555b729f1180
+      - 1bbc4c6193c44bfc9fdcc327724bfb4b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:23 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3c44b245-c6ad-4c23-8e30-218ed14edb8c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3934,7 +4359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3947,36 +4372,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:20:23 GMT
+      - Fri, 29 Jul 2022 09:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd60bf78ab6f499a8220dd7ccdbbc3c0
+      - 24ff6691b85647edae3e553691c41985
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3998,5 +4423,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:20:23 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:54 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_module_stream_repository/all_module_streams_copied_if_empty_modular_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_module_stream_repository/all_module_streams_copied_if_empty_modular_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:34 GMT
+      - Fri, 29 Jul 2022 09:02:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5a818eb54471411f971d677d896c5999
+      - 2b55b33c0d5e4fde85cb76eeb61ee4be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MWNkNWI1Ny01YmQwLTQ3ZmEtYjJkMy1mMDA4MDhlNTU5ZGEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzozMDoyOC4xMjA1OTZa
+        cnBtL3JwbS8zZjkzNjM4Yi03Njc2LTRkMjYtYWUxZC1iNzczY2Q0ZWM0MmYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjowNy44Nzg2OTla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MWNkNWI1Ny01YmQwLTQ3ZmEtYjJkMy1mMDA4MDhlNTU5ZGEv
+        cnBtL3JwbS8zZjkzNjM4Yi03Njc2LTRkMjYtYWUxZC1iNzczY2Q0ZWM0MmYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcxY2Q1
-        YjU3LTViZDAtNDdmYS1iMmQzLWYwMDgwOGU1NTlkYS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNmOTM2
+        MzhiLTc2NzYtNGQyNi1hZTFkLWI3NzNjZDRlYzQyZi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:17 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:34 GMT
+      - Fri, 29 Jul 2022 09:02:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd5166f47c8543aa8210d580aa343c90
+      - b2fbb80babed4bbc8c026a9a9d173556
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2Y2U2NGI1LWVhNGYtNGRi
-        Yy1hNzIyLTllMDFiM2JkNzMzYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjMTc1ZjU2LWNkZjQtNDQx
+        ZC1iZDZlLTQ1NGEyZmRjYTQ3MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:34 GMT
+      - Fri, 29 Jul 2022 09:02:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c347e6258c88489e8fbe8c06541f22e0
+      - abb4fa7ac5b144019855ecb81b21e2b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c6ce64b5-ea4f-4dbc-a722-9e01b3bd733a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ac175f56-cdf4-441d-bd6e-454a2fdca471/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b013bf0d92a4d209a98f5561643df4f
+      - 700d4bfee3824c3184f37f6d8bba5756
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzZjZTY0YjUtZWE0
-        Zi00ZGJjLWE3MjItOWUwMWIzYmQ3MzNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzQuNzgxMjU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWMxNzVmNTYtY2Rm
+        NC00NDFkLWJkNmUtNDU0YTJmZGNhNDcxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MTcuNDU5MDkyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZDUxNjZmNDdjODU0M2FhODIxMGQ1ODBh
-        YTM0M2M5MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjM0Ljgx
-        MTU1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MzQuOTQy
-        ODA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiMmZiYjgwYmFiZWQ0YmJjOGMwMjZhOWE5
+        ZDE3MzU1NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjE3LjUw
+        MjI1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MTcuNzEx
+        NjI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFjZDViNTctNWJkMC00N2Zh
-        LWIyZDMtZjAwODA4ZTU1OWRhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2Y5MzYzOGItNzY3Ni00ZDI2
+        LWFlMWQtYjc3M2NkNGVjNDJmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 543c56a219a04a71a618b251ed189ee9
+      - 33db41e999d6436ea5e7cf6fbbaeb3ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2f140392cb1d4bd8b9a1b989462bc7a3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vOTQ2ZWM2ZDctNTBmMC00N2Y5LWEwOWUtNzVhNjE4NWNkOGFm
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MTIuMjI0Nzc2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:17 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/946ec6d7-50f0-47f9-a09e-75a6185cd8af/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d9d011687b3e4f6eae6c9d50d6fdb3ed
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcwNjgzM2ZlLWMxYmQtNDUw
+        OS1iYmEyLTdkN2YyOTVmMWUyNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/706833fe-c1bd-4509-bba2-7d7f295f1e24/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f5a9a61215d443018027e669a5117fc9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzA2ODMzZmUtYzFi
+        ZC00NTA5LWJiYTItN2Q3ZjI5NWYxZTI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MTcuODgzMjY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkOWQwMTE2ODdiM2U0ZjZlYWU2YzlkNTBk
+        NmZkYjNlZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjE3Ljky
+        MzYzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MTcuOTU3
+        MDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a641ae317bd44798ff5cc6f88dd1534
+      - 0f9eda68f41a4b47a9c0455da91fc8c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0017b047191e4630b48e269605993c83
+      - cb4bb0966d8f43ce93c2f008f0180832
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f6ccc4b7add3490c88e15cb37a06583e
+      - a92d18dd396e4ed0b13536a023e88da9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a89ef94f358648cba29f9c95ca758253
+      - db162fa330c0441e984a4c134b9d7ad2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:30:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - c69dfec869a44c04983a30ce8d28c1b9
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/871c839d-7084-43c1-a3c9-556e27f286c3/"
+      - "/pulp/api/v3/remotes/rpm/rpm/b4a1fa46-57f8-42c4-b676-1b018768ef1f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 23508284478146e3994d7932c8186b74
+      - 59772880a7b04ecdbf0428f64926518e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3
-        MWM4MzlkLTcwODQtNDNjMS1hM2M5LTU1NmUyN2YyODZjMy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjMwOjM1LjM3MDg5NFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I0
+        YTFmYTQ2LTU3ZjgtNDJjNC1iNjc2LTFiMDE4NzY4ZWYxZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjE4LjQwNjQyNloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjMwOjM1LjM3MDkxM1oiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAyOjE4LjQwNjQ0OFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/"
+      - "/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed02f022c6ee4388897c5db033c93bbf
+      - 4a4549028bf44ab387df013406803082
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjdjYWQ4NjEtYzVlYS00MmQ1LTliZjItMjk5N2NiMWRlM2JhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6MzUuNTA4NTU4WiIsInZl
+        cG0vYTdkZDA5ODUtM2U2MS00ZmQ2LWE5NDMtOTY4NGY5YWJlZGQ3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MTguNTQ4NDcxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjdjYWQ4NjEtYzVlYS00MmQ1LTliZjItMjk5N2NiMWRlM2JhL3ZlcnNp
+        cG0vYTdkZDA5ODUtM2U2MS00ZmQ2LWE5NDMtOTY4NGY5YWJlZGQ3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yN2NhZDg2MS1j
-        NWVhLTQyZDUtOWJmMi0yOTk3Y2IxZGUzYmEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hN2RkMDk4NS0z
+        ZTYxLTRmZDYtYTk0My05Njg0ZjlhYmVkZDcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33dbde75754042b1b25a703931dc6f1e
+      - dea6ca02c4644f4887bba84f68c166e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80NjY2YThlMi02OGU5LTQxZDQtODM5My1kMDVhYjAyOTNhYzEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzozMDoyOC45MjM3MDFa
+        cnBtL3JwbS9iY2MwNTVlNi1jZTk5LTRjMTctYmZmOS0wMGY4NjMwNmM0Yjkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjowOC43Nzg0MzVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80NjY2YThlMi02OGU5LTQxZDQtODM5My1kMDVhYjAyOTNhYzEv
+        cnBtL3JwbS9iY2MwNTVlNi1jZTk5LTRjMTctYmZmOS0wMGY4NjMwNmM0Yjkv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQ2NjZh
-        OGUyLTY4ZTktNDFkNC04MzkzLWQwNWFiMDI5M2FjMS92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JjYzA1
+        NWU2LWNlOTktNGMxNy1iZmY5LTAwZjg2MzA2YzRiOS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da349b436cfc469ca75ecc0c4a790215
+      - b02c8fb34eda430c9e9c597b9f402a09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmMTA0MWNlLTcwZjUtNDhh
-        Yy04Mzc2LWQ4Y2FkN2I0YWI4ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5Y2QzMDM2LTU3MTMtNDgx
+        Zi05ZGI0LTBkMjhhYWI4OGMyZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f62066aab0634fe6be0eb20389a278c1
+      - 663a1e9203074f6b97355c1d14af8b8a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '368'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMTQzNzcyYmQtZmZkYi00YzVhLTk3YTYtYTkyMDZhMGRmZjY0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6MjguMDEyNjIwWiIsIm5h
+        cG0vY2M3ZDllMGUtZDQ1OS00YmIxLTllMDUtZjViMzA2MzJmYWU2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MDcuNzM2MzE2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzozMDoyOS4yNDgzOTdaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMjowOS4yNjYwNjdaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/143772bd-ffdb-4c5a-97a6-a9206a0dff64/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/cc7d9e0e-d459-4bb1-9e05-f5b30632fae6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 14f6fa7892b54b3d80ad8409bf13612d
+      - 4e9afd6e273c44e9b49e776afc3e6cfd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxZDk1NmFhLWFjZTctNDc2
-        My1iNWQ2LTg2ZDkwOGVkZDQwNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkNDRiMjFkLTllOWUtNDY2
+        Yi05ZjNjLTZmZjA1N2U2YjFjNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7f1041ce-70f5-48ac-8376-d8cad7b4ab8d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/79cd3036-5713-481f-9db4-0d28aab88c2e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d795735292b45cd85b5cb4cf790408d
+      - 6d0a724eadc644e580f15e7bfbc149e0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2YxMDQxY2UtNzBm
-        NS00OGFjLTgzNzYtZDhjYWQ3YjRhYjhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzUuNjYzMTI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzljZDMwMzYtNTcx
+        My00ODFmLTlkYjQtMGQyOGFhYjg4YzJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MTguNzY5MTMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkYTM0OWI0MzZjZmM0NjljYTc1ZWNjMGM0
-        YTc5MDIxNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjM1LjY5
-        NDA5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MzUuNzU0
-        NDI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiMDJjOGZiMzRlZGE0MzBjOWU5YzU5N2I5
+        ZjQwMmEwOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjE4Ljgx
+        OTQ5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MTguOTUz
+        OTc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhlOS00MWQ0
-        LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNjMDU1ZTYtY2U5OS00YzE3
+        LWJmZjktMDBmODYzMDZjNGI5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/71d956aa-ace7-4763-b5d6-86d908edd407/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8d44b21d-9e9e-466b-9f3c-6ff057e6b1c5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aae437d12e784712b4e689c90d09551b
+      - 9707b0a26d3d45c6a77fad49b69a816d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzFkOTU2YWEtYWNl
-        Ny00NzYzLWI1ZDYtODZkOTA4ZWRkNDA3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzUuNzUwOTAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGQ0NGIyMWQtOWU5
+        ZS00NjZiLTlmM2MtNmZmMDU3ZTZiMWM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MTguOTAyMjIxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxNGY2ZmE3ODkyYjU0YjNkODBhZDg0MDli
-        ZjEzNjEyZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjM1Ljc4
-        NjQxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MzUuODI4
-        NjE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0ZTlhZmQ2ZTI3M2M0NGU5YjQ5ZTc3NmFm
+        YzNlNmNmZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjE4Ljk4
+        MzIzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MTkuMDY2
+        NDIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE0Mzc3MmJkLWZmZGItNGM1YS05N2E2
-        LWE5MjA2YTBkZmY2NC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NjN2Q5ZTBlLWQ0NTktNGJiMS05ZTA1
+        LWY1YjMwNjMyZmFlNi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e52f2dbf04794710bdecdcdacf4cecc4
+      - dc6c34c5742f43b4943cd1c561897137
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ddd7b2b947f4f94acac46c828a7ddf2
+      - 37aec3f2df6640edbd72feeedb950b99
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fe517dcdf44f4f1f96f5182a15eb1f1e
+      - 86c9a3fda3bd46d5be06b0aa7a342925
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:35 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 849c378b5cc6443186a133026d07d3f6
+      - 3042fcd11ca642dc8b772b552a22be6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:36 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff786b990640488b815a0e958ff3bbcb
+      - 8dc35cd678754931a76c4b900f8de298
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:36 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9f3a05be019d434e92614b1fb942266d
+      - '05464583448a4353a978804f648f97a5'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:36 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/"
+      - "/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a13816d7bf3549d188e25d90150d5f85
+      - c05ebe1ec1494d2bbd873071f726183e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTUyYjFhZGQtNGMwNy00MjdlLWFiOGItZTAyODc3MGI4OGU2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6MzYuMjAyMDk1WiIsInZl
+        cG0vMDIzODRiYmItMzI2Yi00NWIyLWExY2QtMWMwZTQ5Zjk5ODBmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MTkuNTA0NTI1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTUyYjFhZGQtNGMwNy00MjdlLWFiOGItZTAyODc3MGI4OGU2L3ZlcnNp
+        cG0vMDIzODRiYmItMzI2Yi00NWIyLWExY2QtMWMwZTQ5Zjk5ODBmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hNTJiMWFkZC00
-        YzA3LTQyN2UtYWI4Yi1lMDI4NzcwYjg4ZTYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wMjM4NGJiYi0z
+        MjZiLTQ1YjItYTFjZC0xYzBlNDlmOTk4MGYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/871c839d-7084-43c1-a3c9-556e27f286c3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b4a1fa46-57f8-42c4-b676-1b018768ef1f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:36 GMT
+      - Fri, 29 Jul 2022 09:02:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce4db302d979489da415f9566f02e148
+      - 72c6fdbb90a5416ba9361f70bc7e7e81
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFhOGZiMDE2LWQ0NjctNDg5
-        NC1iOGE1LTU4YzQxYmIyZTFkNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJlMjM1ZjUxLWM5ZjUtNDFm
+        Yi1hYTcwLTY3YjhkOGFlZDk1Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1a8fb016-d467-4894-b8a5-58c41bb2e1d7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2e235f51-c9f5-41fb-aa70-67b8d8aed956/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:36 GMT
+      - Fri, 29 Jul 2022 09:02:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4b9c22d05544256bee9c621fc6bd258
+      - 2f61866ddde542439974396e20e8acf2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWE4ZmIwMTYtZDQ2
-        Ny00ODk0LWI4YTUtNThjNDFiYjJlMWQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzYuNTMwMDIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmUyMzVmNTEtYzlm
+        NS00MWZiLWFhNzAtNjdiOGQ4YWVkOTU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MTkuODUzMzM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJjZTRkYjMwMmQ5Nzk0ODlkYTQxNWY5NTY2
-        ZjAyZTE0OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjM2LjU2
-        MDY0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MzYuNTgy
-        OTY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3MmM2ZmRiYjkwYTU0MTZiYTkzNjFmNzBi
+        YzdlN2U4MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjE5Ljkw
+        MTQ1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MTkuOTI2
+        NjkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3MWM4MzlkLTcwODQtNDNjMS1hM2M5
-        LTU1NmUyN2YyODZjMy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I0YTFmYTQ2LTU3ZjgtNDJjNC1iNjc2
+        LTFiMDE4NzY4ZWYxZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:20 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3MWM4
-        MzlkLTcwODQtNDNjMS1hM2M5LTU1NmUyN2YyODZjMy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I0YTFm
+        YTQ2LTU3ZjgtNDJjNC1iNjc2LTFiMDE4NzY4ZWYxZi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:36 GMT
+      - Fri, 29 Jul 2022 09:02:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f49447d5abe483985d14e8643e93daa
+      - becb0c4675c1420baf3cc9d17b4fa507
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhZWU4YjdkLTJkYWEtNDZm
-        Ny1iZmNiLTJjNGVlOWYzZDcxNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1OWZjYzY2LWViZjItNGFm
+        YS1hMGYzLTRkOGY1Y2Q3Y2NmMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/faee8b7d-2daa-46f7-bfcb-2c4ee9f3d714/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/959fcc66-ebf2-4afa-a0f3-4d8f5cd7ccf1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:37 GMT
+      - Fri, 29 Jul 2022 09:02:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f225128b767461eb2781e7c332bd3b4
+      - c811ed7bd7674c5f9a6f206506d64e2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmFlZThiN2QtMmRh
-        YS00NmY3LWJmY2ItMmM0ZWU5ZjNkNzE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzYuNzA3NDg3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTU5ZmNjNjYtZWJm
+        Mi00YWZhLWEwZjMtNGQ4ZjVjZDdjY2YxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MjAuMTAwMDI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzZjQ5NDQ3ZDVhYmU0ODM5ODVk
-        MTRlODY0M2U5M2RhYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjM2LjczNzc5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzcuNDU5Njk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJiZWNiMGM0Njc1YzE0MjBiYWYz
+        Y2M5ZDE3YjRmYTUwNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjIwLjEzNzczOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        MjEuMjMxNzg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzI3Y2FkODYxLWM1ZWEtNDJkNS05YmYyLTI5OTdj
-        YjFkZTNiYS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yN2Nh
-        ZDg2MS1jNWVhLTQyZDUtOWJmMi0yOTk3Y2IxZGUzYmEvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vODcxYzgzOWQtNzA4NC00M2Mx
-        LWEzYzktNTU2ZTI3ZjI4NmMzLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9hN2RkMDk4NS0zZTYxLTRmZDYtYTk0My05Njg0Zjlh
+        YmVkZDcvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTdkZDA5
+        ODUtM2U2MS00ZmQ2LWE5NDMtOTY4NGY5YWJlZGQ3LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I0YTFmYTQ2LTU3ZjgtNDJjNC1i
+        Njc2LTFiMDE4NzY4ZWYxZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:37 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:21 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMjdjYWQ4NjEtYzVlYS00MmQ1LTliZjItMjk5N2NiMWRl
-        M2JhL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYTdkZDA5ODUtM2U2MS00ZmQ2LWE5NDMtOTY4NGY5YWJl
+        ZGQ3L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:37 GMT
+      - Fri, 29 Jul 2022 09:02:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2cd0e49ebf3b4083a04e4451f364498d
+      - 88109a1050b04c9c9eb03ce1688b4fbe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4NjIxNmFkLTU5NTMtNDI4
-        MS1hZjA3LWNjNjMzNDUyZjNkOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2NGI5MTgzLTU1MjMtNDYz
+        ZS04ZDRlLTA3NTk4Njg4MzU1Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:37 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f86216ad-5953-4281-af07-cc633452f3d9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/964b9183-5523-463e-8d4e-075986883556/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:38 GMT
+      - Fri, 29 Jul 2022 09:02:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ae99cdaae9545cf906d66237e4ee70e
+      - fb60bb275b2046e4a14c6436064ab1f7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjg2MjE2YWQtNTk1
-        My00MjgxLWFmMDctY2M2MzM0NTJmM2Q5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzcuOTE3NzgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTY0YjkxODMtNTUy
+        My00NjNlLThkNGUtMDc1OTg2ODgzNTU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MjEuNzAyODAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjJjZDBlNDllYmYzYjQwODNhMDRlNDQ1MWYz
-        NjQ0OThkIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MzcuOTU3
-        MzI3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzozMDozOC4yMTcz
-        NjVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6Ijg4MTA5YTEwNTBiMDRjOWM5ZWIwM2NlMTY4
+        OGI0ZmJlIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MjEuNzUx
+        MDQzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMjoyMi4yMzQx
+        MjNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMmJjYWMx
-        NTctMDEzZi00ZDAwLWI3Y2ItM2Y5NzZlN2YzNzU3LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vY2VjZTYz
+        YjYtODgzNi00NTMyLWE5OWItMWExNDMxMDZhNjkxLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMjdjYWQ4NjEtYzVlYS00MmQ1LTliZjItMjk5N2Ni
-        MWRlM2JhLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYTdkZDA5ODUtM2U2MS00ZmQ2LWE5NDMtOTY4NGY5
+        YWJlZGQ3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:38 GMT
+      - Fri, 29 Jul 2022 09:02:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b44f4c02fe894321a2e71fbf322bf833
+      - 54790a1e9c5442088bedc02e1ede42a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/cece63b6-8836-4532-a99b-1a143106a691/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 550015240cae4173a4e265faffb47c9d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vY2VjZTYzYjYtODgzNi00NTMyLWE5OWItMWExNDMxMDZhNjkxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MjEuNzc5ODQ3WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hN2RkMDk4NS0zZTYxLTRmZDYtYTk0My05Njg0ZjlhYmVkZDcv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2E3ZGQwOTg1LTNlNjEtNGZkNi1hOTQzLTk2ODRm
+        OWFiZWRkNy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:22 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9jZWNlNjNiNi04ODM2LTQ1MzItYTk5Yi0xYTE0MzEwNmE2OTEv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 96305e56e19e4a668a410741001aaec7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkOGM0MDY2LWVlYjYtNDEy
+        NS1hYmRmLWZmM2M3YmViMzhmOS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8d8c4066-eeb6-4125-abdf-ff3c7beb38f9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8918910c0ff74b86a874845ba8a6f143
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGQ4YzQwNjYtZWVi
+        Ni00MTI1LWFiZGYtZmYzYzdiZWIzOGY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MjIuNDY5MDkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5NjMwNWU1NmUxOWU0YTY2OGE0MTA3NDEw
+        MDFhYWVjNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjIyLjUw
+        NjE0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MjIuODIz
+        NDI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNGVl
+        ZmIwNmUtNjIxYi00Yzc2LWFlNDUtM2NhYWQ0NzU1NDE3LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4eefb06e-621b-4c76-ae45-3caad4755417/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 540d02981de2440ab6733ac7b4927340
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzRlZWZiMDZlLTYyMWItNGM3Ni1hZTQ1LTNjYWFkNDc1NTQxNy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjIyLjgwMTk2MFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vY2VjZTYzYjYtODgzNi00NTMyLWE5OWIt
+        MWExNDMxMDZhNjkxLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 401b62cb4c1b43098467f7117ffe856b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:38 GMT
+      - Fri, 29 Jul 2022 09:02:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fcbdedd3655440d3bf94a804c55761dd
+      - 4d336ca6c8024f1f9ec53f776bb9cf65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:38 GMT
+      - Fri, 29 Jul 2022 09:02:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6d33154f03a941e4afdab6b3f640b30a
+      - fcd7d5813b034c7b9117216e021d4de1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:38 GMT
+      - Fri, 29 Jul 2022 09:02:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2e93cb7c98647588a10e7156f34df81
+      - 3e4aabada1224b5982d2d117ec23567e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:38 GMT
+      - Fri, 29 Jul 2022 09:02:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1443cc44a76148ccb08c66e5800c2c37
+      - 6ecb4360dffc4869ac07bb7197df4a53
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:38 GMT
+      - Fri, 29 Jul 2022 09:02:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f35a843754f4f3aaaacba8578d0427a
+      - 587e71fb0e404482a6e0c5b75cbc037b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b8680d134f664c43bafa326820de83b0
+      - 14cdae63d31f4b84b96a3a05be179bbf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bcda5ff06a3c4e05a84d51418e0597e5
+      - ca9571f817734aaeaabcaffb03d8d7bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 449cc87ae44f4403a0a3948350b4a7cf
+      - 2ad1fa44a82049cda29870fc308a05dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 19d005ceafc24b5d960d3036d8a97b10
+      - 1a92bff3dea3408fb8a7811ec6d0df0f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 98a78cbdcd604a8a834c3b8b701f7225
+      - 7e3cba040da048e49e8634d2667878ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 45e629a757ab49bc9e5ea8e0a1563486
+      - 28fb950106554f1ebb26094c810d85f8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ddc57fc9f52943d8a3b5a2c8ebcd0e3c
+      - 543328abe78e4306b15af3c87607f0aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cffb5bdf739144b4992e27079cb507ed
+      - ff687faed31b47ed8c782638fccdbb61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,99 +3819,99 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6fbe069183e9489db851998f10b1b6ef
+      - 7f262dd77c9a413b82ba5775d93c52b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUyNjViOTBlLTg3NjAtNDcw
-        YS1hZjZiLTAwOGY3MzBmMjgwOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlMmQxOTE1LWRhYjYtNDZm
+        ZS1hZjhmLTBlOTY5YWVlMWIwMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8wMTJlMDA1OS0zZGE0LTRjNGUtOWVmNy1kMDhlMTM4
-        Njg0ZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        MjFhNDk3NzEtODJmMy00MWQ4LTk3YTgtZDQ5NDM5MTgxNzAzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUt
-        NDMzYy1hM2NkLTY0MWMxMDA5NTExMy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEw
-        NmE0Y2Y5NTAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvNjNmYmYwMmEtNDI1OS00M2FlLTlhNzYtMTJiZmI4Nzg5NTZmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzdhYWQwMzA4LTE4
-        MmMtNGM0YS04ZTFkLWQ3MTUzYWQ3ODQyMi8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vYWR2aXNvcmllcy9mMTc4OTMwOC1kMjNkLTQ0ODAtOGYyMS0y
-        YzkyMDEwNzEzZjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
-        aWJ1dGlvbl90cmVlcy81ODk3OTA5OS01NmNlLTQxNWQtYjg3My0yMTRhNzM1
-        NmQxMDAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy80
-        ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy80ZTU2MTBlNy05MzQ3LTRi
-        MzgtODI1Zi0yMjRmOGE2ZjM4N2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy81NjhjN2EzMC02OTcwLTQ4ZGEtOGI4NS1mOTNiZGMx
-        MWY3NjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy84
-        YWFiODJhMy1kZDIwLTRkMTctOTYwNS03NDk2NmUzZWM2OWIvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2
-        MmEtYWIyMC0wNjJhYmNiNGFjZWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy9kNGZiODc4MS0zOTAzLTQ1NzAtOTNkYy0xNzYzMWNj
-        NGY0Y2IvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvMGZjYTEwM2MtMmVjNi00NDdiLWFjNzEtNmIyYzg2YWQ4ZGJiLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRk
-        LTAzZDctNDkwZC1hYjk2LWZkMmU3MWE2ZGFhMy8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMDNmOGVlNGYtNWI3MS00MTU1LWE0NzMt
-        Zjc5YzU1MDQzMWUzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8wNTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3
-        MzEtNGFjMy1iNGQ3LTZlNjdlNTkzZWQzMy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00NDVkLWE4NzctOTM5
-        OWY4ZTY1YzBkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yOWU2YTIxZC0yZjY5LTRjZDItYjcxMS02MWNjODljZjcwY2UvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM3YzM4MGEwLWFhZmYt
-        NDNmMi05YTZkLTdhMjUyYjA5YWE5Ni8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkw
-        ZWZhN2VmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80
-        OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2MvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUwYzgyZTlkLWFmODktNDMx
-        My1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZj
-        ODVkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83NjA4
-        Y2UzNy0xYzcxLTRhZDAtOTBhYy1lZWQ3NDYwYzU2MWIvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1h
-        YjM5LTgwZDAyMTliZDQ4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvOGIyNTE3MzgtNmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZm
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThjNWEtNDgwMS1iNTY3
-        LTFmMmIxZGI3M2RlYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvYTE5ZTQ3Y2ItZDZkNi00MmVhLTk3MzItMzI4NTIxNjQyNDJlLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jYmIzODQ4Ny05
-        Njc3LTRhNDMtODNlMy00MzkwYjNkMjA1YjQvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZm
-        ODUwYjkyNmU1Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZjA3NzkyYzMtYTQyZC00NzBjLWEyNjAtYmViYTYyMDAzNDlmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2Ex
-        LTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZjQ3YTNmZTYtMmM0Ni00M2Vk
-        LWJlZjQtZDMxMjQ0MTFiZDI0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZm
-        LWM5NTMxYzI0OWFkYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUzYThj
-        ZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
-        ZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3NjQ4NmIv
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1i
+        OTFkMDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
+        aWJ1dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRk
+        NTBhMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
+        Yzg0MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRl
+        OTktYmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3
+        YTExOTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8z
+        YjliOWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRi
+        NTktODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdh
+        YzAzODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0
+        LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvMDVlMzY4ZDctMjkxYS00MzM2LWFkYmQt
+        ZDg5YjdiMDFkODQ2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1iMjc2ZmZhN2U4MjYvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM1YmJhMDBiLTZm
+        MTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy80ODA2MDhjMS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMt
+        NGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1ZmJiOTc0LTE1MmMtNDk2
+        ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3
+        YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4
+        M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04
+        MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNhMzhh
+        Mi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJi
+        LTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02
+        MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0
+        MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMx
+        LTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4
+        LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
+        dWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQtZjIwM2Nh
+        MzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
+        ZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDliODIzMjMv
         IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRz
-        L2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8iXX0=
+        L2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3499,7 +3924,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:39 GMT
+      - Fri, 29 Jul 2022 09:02:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3517,21 +3942,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7aa9a2d07af4562af257e331e03b197
+      - 2d3b6fca77e34ce4aaa51d9f79903879
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhYzc1ZGUwLTljNGItNDdm
-        YS04ZjE1LTZjNDk3NmVlOTUxZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkZDlkNjkwLTBkNDMtNDJh
+        NS05NGNlLWJhNGI3Yzc5MTkxNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8ac75de0-9c4b-47fa-8f15-6c4976ee951d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4dd9d690-0d43-42a5-94ce-ba4b7c791916/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3552,53 +3977,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:40 GMT
+      - Fri, 29 Jul 2022 09:02:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ff0ef41c95948718f111fd51e40e3b5
+      - 690ea9f3c64b4294b7c92ba7ac9f5b02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGFjNzVkZTAtOWM0
-        Yi00N2ZhLThmMTUtNmM0OTc2ZWU5NTFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzkuNjIxMjAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGRkOWQ2OTAtMGQ0
+        My00MmE1LTk0Y2UtYmE0YjdjNzkxOTE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MjQuODgyMjQxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkN2FhOWEyZDA3YWY0NTYyYWYy
-        NTdlMzMxZTAzYjE5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjM5Ljc2ODU5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzkuOTQ3MDI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyZDNiNmZjYTc3ZTM0Y2U0YWFh
+        NTFkOWY3OTkwMzg3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjI1LjEyMzQwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        MjUuNDA5NjM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hNTJiMWFkZC00YzA3LTQyN2UtYWI4Yi1lMDI4NzcwYjg4ZTYvdmVyc2lv
+        bS8wMjM4NGJiYi0zMjZiLTQ1YjItYTFjZC0xYzBlNDlmOTk4MGYvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTUyYjFhZGQtNGMwNy00Mjdl
-        LWFiOGItZTAyODc3MGI4OGU2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDIzODRiYmItMzI2Yi00NWIy
+        LWExY2QtMWMwZTQ5Zjk5ODBmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3606,7 +4031,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3619,76 +4044,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:40 GMT
+      - Fri, 29 Jul 2022 09:02:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6e2e6c9783f445c9a104d076fc267b9a
+      - 8beacdd1257944a2950731a82bb088f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '566'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
-        NTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2Ji
-        Mzg0ODctOTY3Ny00YTQzLTgzZTMtNDM5MGIzZDIwNWI0LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhiMjUx
-        NzM4LTZhNDgtNDNjYi1iNzlhLWYwYWM5NjYyNWRmZi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQt
-        MmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThj
-        NWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZm
-        LTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00
-        NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTViNzEtNDE1
-        NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkw
-        YWMtZWVkNzQ2MGM1NjFiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YwNzc5MmMzLWE0MmQtNDcwYy1hMjYw
-        LWJlYmE2MjAwMzQ5Zi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00YjY2LWFlYWQtZmY4
-        NTBiOTI2ZTVjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3696,7 +4121,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3709,50 +4134,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:40 GMT
+      - Fri, 29 Jul 2022 09:02:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53ade813622f4a4aa55cd7a3c00c44ef
+      - 403131e075424cd4a2b1b8ba526620cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3760,7 +4185,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3773,37 +4198,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:40 GMT
+      - Fri, 29 Jul 2022 09:02:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f803805f90d4774a02c5a8d6a8d12f8
+      - 6184c1d42b6b4be5bfebc3039f40853c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3876,9 +4301,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3894,8 +4319,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -3913,9 +4338,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -3937,9 +4362,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -3955,9 +4380,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -3966,9 +4391,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -3997,10 +4422,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4008,7 +4433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4021,43 +4446,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:40 GMT
+      - Fri, 29 Jul 2022 09:02:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ff35b23c1cd4333945b33d1230a6209
+      - 616e59e18b454dac9ce783c9e61d781d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4065,7 +4490,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4078,41 +4503,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:40 GMT
+      - Fri, 29 Jul 2022 09:02:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '02218ce5eb9c422082a4942b54140f7c'
+      - 473fbef3b6b74227aa2ddddf57e4eda5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4120,7 +4545,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4133,36 +4558,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:40 GMT
+      - Fri, 29 Jul 2022 09:02:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f8af51fd402a4454b23733817bb4a9af
+      - 6a3379bf2e7d41dab89d806a9eb86790
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4184,5 +4609,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:26 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_module_stream_repository/all_module_streams_copied_if_no_modular_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_module_stream_repository/all_module_streams_copied_if_no_modular_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - addd02e87aef40519edb86ac1e0f9a59
+      - fe4b17f235184251b634f3c48014a6d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yN2NhZDg2MS1jNWVhLTQyZDUtOWJmMi0yOTk3Y2IxZGUzYmEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzozMDozNS41MDg1NTha
+        cnBtL3JwbS9iMzI4NzFkYy0zMDBlLTQwMGYtYmQ4Mi03ODllNWZiMTY1N2Qv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMTo1Ny4zMzg4Mjla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yN2NhZDg2MS1jNWVhLTQyZDUtOWJmMi0yOTk3Y2IxZGUzYmEv
+        cnBtL3JwbS9iMzI4NzFkYy0zMDBlLTQwMGYtYmQ4Mi03ODllNWZiMTY1N2Qv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI3Y2Fk
-        ODYxLWM1ZWEtNDJkNS05YmYyLTI5OTdjYjFkZTNiYS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IzMjg3
+        MWRjLTMwMGUtNDAwZi1iZDgyLTc4OWU1ZmIxNjU3ZC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:06 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/27cad861-c5ea-42d5-9bf2-2997cb1de3ba/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e419a68e4aec4c4dbe007b2a586695a7
+      - '0791f349e2c64c51a9ac4b3eed716af5'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhN2E2NzQ0LTkzZDctNDE0
-        NC1iMjY0LTI3MWI4ODA2YzM5OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkZjdhMzZiLTM0ZDUtNDQx
+        YS1hZGE5LWQzODg2OTYzNGYwZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc56f7e832ec465481ba66c914ae8c44
+      - 47a81d411e5d4b93889f6546712189f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0a7a6744-93d7-4144-b264-271b8806c398/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/cdf7a36b-34d5-441a-ada9-d38869634f0d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 797eed8a9e044f5d9b62c28b807cd55c
+      - b94fd83131b64162be3ed44091faffc2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGE3YTY3NDQtOTNk
-        Ny00MTQ0LWIyNjQtMjcxYjg4MDZjMzk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDEuNDU3MzYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2RmN2EzNmItMzRk
+        NS00NDFhLWFkYTktZDM4ODY5NjM0ZjBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDYuODA3NDUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNDE5YTY4ZTRhZWM0YzRkYmUwMDdiMmE1
-        ODY2OTVhNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjQxLjQ4
-        OTkzMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDEuNjE3
-        NDEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNzkxZjM0OWUyYzY0YzUxYTlhYzRiM2Vl
+        ZDcxNmFmNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjA2Ljg1
+        MjMzNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MDcuMDYx
+        MDU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjdjYWQ4NjEtYzVlYS00MmQ1
-        LTliZjItMjk5N2NiMWRlM2JhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjMyODcxZGMtMzAwZS00MDBm
+        LWJkODItNzg5ZTVmYjE2NTdkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 347cfb1396574133ad1801b73b718e88
+      - daf696f8f86747f8ba7388cee8447f18
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0d8174203b784b66a6fd98b8b0dabb23
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMDBkMzI1YzMtNGI5Ni00ODVmLWIzN2EtNTkxYWNjYzZiNzJj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MDEuODk1NzY4
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/00d325c3-4b96-485f-b37a-591accc6b72c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c4e33906d21640ae8ab99ce1ba7369f1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmYTVlODVmLTExZmEtNGFm
+        Yy1hOTAxLTBmYWIwZDFhODU0Ny8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bfa5e85f-11fa-4afc-a901-0fab0d1a8547/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 10e3e697ab2e4c32989ea353d03adcd9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmZhNWU4NWYtMTFm
+        YS00YWZjLWE5MDEtMGZhYjBkMWE4NTQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDcuMjMyNzk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjNGUzMzkwNmQyMTY0MGFlOGFiOTljZTFi
+        YTczNjlmMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjA3LjI3
+        NDY1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MDcuMzA1
+        NTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ae4ff4818464077b8197c60e0538dab
+      - 5a0707e7bf6d4a29881c55701117c12f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7c8a356b322543f5b6535bd0d6ab0c9e
+      - 307535259e1d44f09103a895c2cce853
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b72a98712fef41a49f3b8e1b7ae90404
+      - 558a13fd47c64f8d9307649fa3a83e14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b876bd7062ae49819610b20bf2578540
+      - '0638838279c642949ad86f13652ade0f'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:30:41 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - dc6b557c9de04b63835fc102090afe8c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:41 GMT
+      - Fri, 29 Jul 2022 09:02:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/8aadcf70-b71e-4e68-ad2f-f8b06cd50d4c/"
+      - "/pulp/api/v3/remotes/rpm/rpm/cc7d9e0e-d459-4bb1-9e05-f5b30632fae6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a7e1b45f0fd24438ace81c912f17bf73
+      - a018e4ab538e43e9ac939a83f5cefd98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhh
-        YWRjZjcwLWI3MWUtNGU2OC1hZDJmLWY4YjA2Y2Q1MGQ0Yy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjMwOjQxLjk4NTE4MVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Nj
+        N2Q5ZTBlLWQ0NTktNGJiMS05ZTA1LWY1YjMwNjMyZmFlNi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjA3LjczNjMxNloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjMwOjQxLjk4NTIwMFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAyOjA3LjczNjM1MloiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/"
+      - "/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7552d3e22b14415e84781d5c0f2d34d0
+      - bcd599d941a04ac68a3153f2f25d6a7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmMxMjYzODYtZTI2OS00MDVhLThmMjYtMTM0MDY2MDM2NjdjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6NDIuMDk0Njg0WiIsInZl
+        cG0vM2Y5MzYzOGItNzY3Ni00ZDI2LWFlMWQtYjc3M2NkNGVjNDJmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MDcuODc4Njk5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmMxMjYzODYtZTI2OS00MDVhLThmMjYtMTM0MDY2MDM2NjdjL3ZlcnNp
+        cG0vM2Y5MzYzOGItNzY3Ni00ZDI2LWFlMWQtYjc3M2NkNGVjNDJmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82YzEyNjM4Ni1l
-        MjY5LTQwNWEtOGYyNi0xMzQwNjYwMzY2N2MvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZjkzNjM4Yi03
+        Njc2LTRkMjYtYWUxZC1iNzczY2Q0ZWM0MmYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22422bab7870460f958455be716a2df0
+      - 1b2edea4a1ff410b8140471114bb489d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hNTJiMWFkZC00YzA3LTQyN2UtYWI4Yi1lMDI4NzcwYjg4ZTYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzozMDozNi4yMDIwOTVa
+        cnBtL3JwbS9lZmU1ZDcwOS0zMzFkLTRhMTctYmY1Mi04NzYzMjAyMDkzNWIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMTo1OC40MTM0MDJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hNTJiMWFkZC00YzA3LTQyN2UtYWI4Yi1lMDI4NzcwYjg4ZTYv
+        cnBtL3JwbS9lZmU1ZDcwOS0zMzFkLTRhMTctYmY1Mi04NzYzMjAyMDkzNWIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2E1MmIx
-        YWRkLTRjMDctNDI3ZS1hYjhiLWUwMjg3NzBiODhlNi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2VmZTVk
+        NzA5LTMzMWQtNGExNy1iZjUyLTg3NjMyMDIwOTM1Yi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a52b1add-4c07-427e-ab8b-e028770b88e6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2164e75e1def4f0bad0082fad2f9d551
+      - b13b59af59bb4fbab4755d540504d779
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI3NDE0N2U1LWVhNjctNGNh
-        Ny1iY2VlLTY3ZTQxMTkzN2Q1OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlZTBlMzZjLWU5MTMtNGRk
+        Yi05NTBjLWJjODg1MTc1MTI4NC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a534fa4f730a4d5abd4a25d8518dcfde
+      - 404aa6d9fa6e4e79b94930a121b8754a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vODcxYzgzOWQtNzA4NC00M2MxLWEzYzktNTU2ZTI3ZjI4NmMzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6MzUuMzcwODk0WiIsIm5h
+        cG0vMDQxOTRhZTktNTRhNS00NTg2LThiYzAtYzk4YWFjNmJiY2RiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NTcuMTg4NTI4WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzozMDozNi41Nzg2NjBaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMTo1OC44NTg4NjdaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/871c839d-7084-43c1-a3c9-556e27f286c3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/04194ae9-54a5-4586-8bc0-c98aac6bbcdb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1de1885f742f4758a7b7988a41ba0933
+      - 2bc799683e384642ab9e960434e0a9f8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwM2FkOGE1LTI1YmYtNDA0
-        Yi05MjY3LTMyOTczODU1ZDY5Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViNDcyNDQ0LWRjYWItNDVk
+        MS1iMjdmLWVlMzkzOTY0NDQ4Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/274147e5-ea67-4ca7-bcee-67e411937d59/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/eee0e36c-e913-4ddb-950c-bc8851751284/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9dca8d4e3b4341039d60a75b5060e140
+      - 5ad1f70d0b914ab4b56ec9c709ac1026
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjc0MTQ3ZTUtZWE2
-        Ny00Y2E3LWJjZWUtNjdlNDExOTM3ZDU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDIuMjQ5NjM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWVlMGUzNmMtZTkx
+        My00ZGRiLTk1MGMtYmM4ODUxNzUxMjg0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDguMDk1MzEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMTY0ZTc1ZTFkZWY0ZjBiYWQwMDgyZmFk
-        MmY5ZDU1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjQyLjI4
-        MjYwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDIuMzQ3
-        MDI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiMTNiNTlhZjU5YmI0ZmJhYjQ3NTVkNTQw
+        NTA0ZDc3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjA4LjE0
+        MjM0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MDguMjQz
+        MTE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTUyYjFhZGQtNGMwNy00Mjdl
-        LWFiOGItZTAyODc3MGI4OGU2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWZlNWQ3MDktMzMxZC00YTE3
+        LWJmNTItODc2MzIwMjA5MzViLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a03ad8a5-25bf-404b-9267-32973855d692/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/eb472444-dcab-45d1-b27f-ee393964448f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b1fa1c49935949f7be7d1c810115de38
+      - 1d331aefcb9c4377afd1790e54e4b337
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTAzYWQ4YTUtMjVi
-        Zi00MDRiLTkyNjctMzI5NzM4NTVkNjkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDIuMzM4NTYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWI0NzI0NDQtZGNh
+        Yi00NWQxLWIyN2YtZWUzOTM5NjQ0NDhmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDguMjEzNjQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxZGUxODg1Zjc0MmY0NzU4YTdiNzk4OGE0
-        MWJhMDkzMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjQyLjM3
-        NTEwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDIuNDE4
-        NTE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyYmM3OTk2ODNlMzg0NjQyYWI5ZTk2MDQz
+        NGUwYTlmOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjA4LjI3
+        MzEwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MDguMzM5
+        ODkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3MWM4MzlkLTcwODQtNDNjMS1hM2M5
-        LTU1NmUyN2YyODZjMy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0MTk0YWU5LTU0YTUtNDU4Ni04YmMw
+        LWM5OGFhYzZiYmNkYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2e31a9fd32c64f8bb767436fec871f68
+      - fdb14bfd984141858c52a241d5c2e739
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71a24dff43d34a68a51a7a875eb1e78a
+      - 911ea3a858aa4ef6a8236ee0d8651657
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8da64d91f2c6466293840f5165dbcd36
+      - b40e9f7c3da041efb6e228586115235d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7160318d7c454dd69a10b192c43b264c
+      - 1ec1819bfd804ecfaeffb6fc7aaafffe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f54e48d21eed43498fcd1b2183f881dd
+      - 54d69fae80234a3384c5a6703b592d3b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7509e927f701400aa095c53f55f9087d
+      - f677127367224fb69ad12e47ebea2c29
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:42 GMT
+      - Fri, 29 Jul 2022 09:02:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/"
+      - "/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71267ec5b8a64d5aa87c6e65cf724b66
+      - 84ee04a5f8d04d79a5bc97db43e59467
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZGNkMzdmYTUtNGNmOC00Y2M3LTlkODctMGZmMzdlN2RiZmNiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6NDIuNzg0OTU4WiIsInZl
+        cG0vYmNjMDU1ZTYtY2U5OS00YzE3LWJmZjktMDBmODYzMDZjNGI5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MDguNzc4NDM1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZGNkMzdmYTUtNGNmOC00Y2M3LTlkODctMGZmMzdlN2RiZmNiL3ZlcnNp
+        cG0vYmNjMDU1ZTYtY2U5OS00YzE3LWJmZjktMDBmODYzMDZjNGI5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kY2QzN2ZhNS00
-        Y2Y4LTRjYzctOWQ4Ny0wZmYzN2U3ZGJmY2IvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iY2MwNTVlNi1j
+        ZTk5LTRjMTctYmZmOS0wMGY4NjMwNmM0YjkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:08 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/8aadcf70-b71e-4e68-ad2f-f8b06cd50d4c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/cc7d9e0e-d459-4bb1-9e05-f5b30632fae6/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:43 GMT
+      - Fri, 29 Jul 2022 09:02:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c09df83d26db44d18b62fbd625d42677
+      - eb058def9c2845ef85687006548c4bee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1ZGY1NDAwLTFiYjctNGYz
-        OS04YTIwLWNlOTIwNWQ3NzY5MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxYTIxYWVkLTgzZDktNDk2
+        Yy1hMmM3LWI3Y2Y2ZDUyZmQ2MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/35df5400-1bb7-4f39-8a20-ce9205d77690/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/91a21aed-83d9-496c-a2c7-b7cf6d52fd61/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:43 GMT
+      - Fri, 29 Jul 2022 09:02:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 385ebc6d398d4935a1ecc2eb424d1f16
+      - b1e43daaca7346d3a3a89db0a1a52fed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzVkZjU0MDAtMWJi
-        Ny00ZjM5LThhMjAtY2U5MjA1ZDc3NjkwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDMuMDU3MjYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTFhMjFhZWQtODNk
+        OS00OTZjLWEyYzctYjdjZjZkNTJmZDYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDkuMTg4MDU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJjMDlkZjgzZDI2ZGI0NGQxOGI2MmZiZDYy
-        NWQ0MjY3NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjQzLjA4
-        ODgxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDMuMTE1
-        ODQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlYjA1OGRlZjljMjg0NWVmODU2ODcwMDY1
+        NDhjNGJlZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjA5LjIz
+        Njg5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MDkuMjcx
+        NDYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhhYWRjZjcwLWI3MWUtNGU2OC1hZDJm
-        LWY4YjA2Y2Q1MGQ0Yy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NjN2Q5ZTBlLWQ0NTktNGJiMS05ZTA1
+        LWY1YjMwNjMyZmFlNi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:09 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhhYWRj
-        ZjcwLWI3MWUtNGU2OC1hZDJmLWY4YjA2Y2Q1MGQ0Yy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NjN2Q5
+        ZTBlLWQ0NTktNGJiMS05ZTA1LWY1YjMwNjMyZmFlNi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:43 GMT
+      - Fri, 29 Jul 2022 09:02:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dbf4a18f5c724612a538f1fbca45ef98
+      - 10f8e092266f4b1380da95c131c1686e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5NmFiM2NlLWE3YzAtNGEy
-        ZC1hMmU0LWM1OTNhNDA3MzAxNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzMTBjNzAzLWNhMTktNGRi
+        My1iNTk3LWI5NWRkOGJkODJmMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/596ab3ce-a7c0-4a2d-a2e4-c593a4073017/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a310c703-ca19-4db3-b597-b95dd8bd82f0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:44 GMT
+      - Fri, 29 Jul 2022 09:02:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1dab9e4503541f3ac52eb971356b071
+      - 3350d7e8ae30459f984a6f53200ea863
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '654'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTk2YWIzY2UtYTdj
-        MC00YTJkLWEyZTQtYzU5M2E0MDczMDE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDMuMjQwMTM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTMxMGM3MDMtY2Ex
+        OS00ZGIzLWI1OTctYjk1ZGQ4YmQ4MmYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDkuNDQxOTAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkYmY0YTE4ZjVjNzI0NjEyYTUz
-        OGYxZmJjYTQ1ZWY5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjQzLjI3MzcxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        NDQuMDA5MDgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxMGY4ZTA5MjI2NmY0YjEzODBk
+        YTk1YzEzMWMxNjg2ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjA5LjUwMjg3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        MTAuNjUwNjkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzZjMTI2Mzg2LWUyNjktNDA1YS04ZjI2LTEzNDA2
-        NjAzNjY3Yy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82YzEy
-        NjM4Ni1lMjY5LTQwNWEtOGYyNi0xMzQwNjYwMzY2N2MvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vOGFhZGNmNzAtYjcxZS00ZTY4
-        LWFkMmYtZjhiMDZjZDUwZDRjLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS8zZjkzNjM4Yi03Njc2LTRkMjYtYWUxZC1iNzczY2Q0
+        ZWM0MmYvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2Y5MzYz
+        OGItNzY3Ni00ZDI2LWFlMWQtYjc3M2NkNGVjNDJmLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NjN2Q5ZTBlLWQ0NTktNGJiMS05
+        ZTA1LWY1YjMwNjMyZmFlNi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:44 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNmMxMjYzODYtZTI2OS00MDVhLThmMjYtMTM0MDY2MDM2
-        NjdjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vM2Y5MzYzOGItNzY3Ni00ZDI2LWFlMWQtYjc3M2NkNGVj
+        NDJmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:44 GMT
+      - Fri, 29 Jul 2022 09:02:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d543f2728450488483b4310724e6ec4f
+      - bcc97d5f010b46fa85011eee4421c82d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5YjdmNmViLWFkZjYtNDQw
-        YS1hYTdkLTgyMzUzM2ZlMzJjZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliMGFhZGZjLTQ3MTMtNDE4
+        ZC1iOWJkLTExNzNhZWI3M2M3Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:44 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a9b7f6eb-adf6-440a-aa7d-823533fe32ce/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9b0aadfc-4713-418d-b9bd-1173aeb73c77/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:44 GMT
+      - Fri, 29 Jul 2022 09:02:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b99287a076724c708e7048891c6879d4
+      - 903faa5e396c428baee39351ad1a5160
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTliN2Y2ZWItYWRm
-        Ni00NDBhLWFhN2QtODIzNTMzZmUzMmNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDQuMjc0ODQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWIwYWFkZmMtNDcx
+        My00MThkLWI5YmQtMTE3M2FlYjczYzc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MTEuMTE0MDQzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImQ1NDNmMjcyODQ1MDQ4ODQ4M2I0MzEwNzI0
-        ZTZlYzRmIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDQuMzA2
-        NTI3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzozMDo0NC41NjI1
-        MjVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImJjYzk3ZDVmMDEwYjQ2ZmE4NTAxMWVlZTQ0
+        MjFjODJkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MTEuMTY1
+        NTIyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMjoxMS42MjA0
+        MjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZTIxMzFm
-        NTQtMmUxOS00ODVjLWE4ZWItOGFhNGM0MzdiMDRkLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMWI1ZTdj
+        MWMtODBmNi00N2VhLWJhMTgtOGExMWM0NDQ1YTg3LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNmMxMjYzODYtZTI2OS00MDVhLThmMjYtMTM0MDY2
-        MDM2NjdjLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vM2Y5MzYzOGItNzY3Ni00ZDI2LWFlMWQtYjc3M2Nk
+        NGVjNDJmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:44 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:44 GMT
+      - Fri, 29 Jul 2022 09:02:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5f073e157ff47f78d731ec8bbd5715a
+      - 7d32dab200a349de8be5ac1d07e729cb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:11 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/1b5e7c1c-80f6-47ea-ba18-8a11c4445a87/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fcc1b5b11a3847f8950ebdaad0289be2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMWI1ZTdjMWMtODBmNi00N2VhLWJhMTgtOGExMWM0NDQ1YTg3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MTEuMTkzNzM4WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8zZjkzNjM4Yi03Njc2LTRkMjYtYWUxZC1iNzczY2Q0ZWM0MmYv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzNmOTM2MzhiLTc2NzYtNGQyNi1hZTFkLWI3NzNj
+        ZDRlYzQyZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:11 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8xYjVlN2MxYy04MGY2LTQ3ZWEtYmExOC04YTExYzQ0NDVhODcv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d7e7e900ae004e19bf8dcfff572adf5e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5ODlkY2I5LWIyNmItNDE1
+        MS1hNzQ4LTZiNGNjOTIzODNhOC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:11 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d989dcb9-b26b-4151-a748-6b4cc92383a8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2d2fdebb2d05474a86816f14088237c0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDk4OWRjYjktYjI2
+        Yi00MTUxLWE3NDgtNmI0Y2M5MjM4M2E4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MTEuODc2ODU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkN2U3ZTkwMGFlMDA0ZTE5YmY4ZGNmZmY1
+        NzJhZGY1ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjExLjkx
+        NzcwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MTIuMjQy
+        MTAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vOTQ2
+        ZWM2ZDctNTBmMC00N2Y5LWEwOWUtNzVhNjE4NWNkOGFmLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:12 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/946ec6d7-50f0-47f9-a09e-75a6185cd8af/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 589e1b5632874f9c8e85fd0de52eaa88
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzk0NmVjNmQ3LTUwZjAtNDdmOS1hMDllLTc1YTYxODVjZDhhZi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjEyLjIyNDc3NloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMWI1ZTdjMWMtODBmNi00N2VhLWJhMTgt
+        OGExMWM0NDQ1YTg3LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:12 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f49f3988d1434b77968c3c88a4903f8c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:44 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 243f8a7b0c74416fa047f2a65fc4ab57
+      - '079e49383ef04b098e9af3b0aa32f79a'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b3b62a560f644baaa3f353c76cf40f7
+      - 64b5a71df87a471da2ff655e04af5f5d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a54f828904304e7789a392fb79c9a765
+      - f54de47bd5474e4fb3483f8994003f53
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed8847a252674c9f8ff70d6f1249994e
+      - fd27cc89cdf546e1909db277c06f920f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0fd2061667c04d558dd9500742263f43
+      - e6367cde02ce4f5093b2e5e7124ee128
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e51854a2f8c44d6baf19d67c3510916
+      - a6fbef66fd324fbda1cd982a67593996
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ca4068770b91412fae35b633b4a90d49
+      - 9db2621a6b8440cc8e0d5b8cf9eff485
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2bbacfb8e514460af04066b403a8c2f
+      - d1837d81b12143f4ad0e6d47a0605277
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 06f27d7b44454bd4be01576e42f89bf7
+      - 83e42b3d35a0467db4de713152b594a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc6fb1fb108345a3ade9eb7aa88cef64
+      - d7e7b60da7da46d68ce20719a70854ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 442251900e91486ea7ed38f3aaa7b941
+      - dd8ca883cb4a4ce7825e41ada97491c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46d259f82ed14635b600e5c1166c19f1
+      - 77148fb9507d4d67831025eb25e3a9f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3f93638b-7676-4d26-ae1d-b773cd4ec42f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 924801793d6f460f88bfebf51d77bff1
+      - 7b80b50353db4ee6a41cbffa037f90f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:14 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:45 GMT
+      - Fri, 29 Jul 2022 09:02:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,99 +3819,99 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c56adfa999134850a68f46e4a805d420
+      - 75049246d4b84dfdb589ff646326ff3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4ZjNiMGM2LWJhMmYtNGE2
-        Ni04MTU1LWMzYWY5YzBhZTc1Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzZDk2OWNmLTVjMWYtNDk4
+        Yi1hY2NlLWM1ZTIyYTEyNjgzYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:14 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8wMTJlMDA1OS0zZGE0LTRjNGUtOWVmNy1kMDhlMTM4
-        Njg0ZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        MjFhNDk3NzEtODJmMy00MWQ4LTk3YTgtZDQ5NDM5MTgxNzAzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUt
-        NDMzYy1hM2NkLTY0MWMxMDA5NTExMy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEw
-        NmE0Y2Y5NTAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvNjNmYmYwMmEtNDI1OS00M2FlLTlhNzYtMTJiZmI4Nzg5NTZmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzdhYWQwMzA4LTE4
-        MmMtNGM0YS04ZTFkLWQ3MTUzYWQ3ODQyMi8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vYWR2aXNvcmllcy9mMTc4OTMwOC1kMjNkLTQ0ODAtOGYyMS0y
-        YzkyMDEwNzEzZjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
-        aWJ1dGlvbl90cmVlcy81ODk3OTA5OS01NmNlLTQxNWQtYjg3My0yMTRhNzM1
-        NmQxMDAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy80
-        ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy80ZTU2MTBlNy05MzQ3LTRi
-        MzgtODI1Zi0yMjRmOGE2ZjM4N2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy81NjhjN2EzMC02OTcwLTQ4ZGEtOGI4NS1mOTNiZGMx
-        MWY3NjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy84
-        YWFiODJhMy1kZDIwLTRkMTctOTYwNS03NDk2NmUzZWM2OWIvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2
-        MmEtYWIyMC0wNjJhYmNiNGFjZWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy9kNGZiODc4MS0zOTAzLTQ1NzAtOTNkYy0xNzYzMWNj
-        NGY0Y2IvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvMGZjYTEwM2MtMmVjNi00NDdiLWFjNzEtNmIyYzg2YWQ4ZGJiLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRk
-        LTAzZDctNDkwZC1hYjk2LWZkMmU3MWE2ZGFhMy8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMDNmOGVlNGYtNWI3MS00MTU1LWE0NzMt
-        Zjc5YzU1MDQzMWUzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8wNTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3
-        MzEtNGFjMy1iNGQ3LTZlNjdlNTkzZWQzMy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00NDVkLWE4NzctOTM5
-        OWY4ZTY1YzBkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yOWU2YTIxZC0yZjY5LTRjZDItYjcxMS02MWNjODljZjcwY2UvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM3YzM4MGEwLWFhZmYt
-        NDNmMi05YTZkLTdhMjUyYjA5YWE5Ni8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkw
-        ZWZhN2VmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80
-        OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2MvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUwYzgyZTlkLWFmODktNDMx
-        My1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZj
-        ODVkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83NjA4
-        Y2UzNy0xYzcxLTRhZDAtOTBhYy1lZWQ3NDYwYzU2MWIvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1h
-        YjM5LTgwZDAyMTliZDQ4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvOGIyNTE3MzgtNmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZm
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThjNWEtNDgwMS1iNTY3
-        LTFmMmIxZGI3M2RlYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvYTE5ZTQ3Y2ItZDZkNi00MmVhLTk3MzItMzI4NTIxNjQyNDJlLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jYmIzODQ4Ny05
-        Njc3LTRhNDMtODNlMy00MzkwYjNkMjA1YjQvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZm
-        ODUwYjkyNmU1Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZjA3NzkyYzMtYTQyZC00NzBjLWEyNjAtYmViYTYyMDAzNDlmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2Ex
-        LTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZjQ3YTNmZTYtMmM0Ni00M2Vk
-        LWJlZjQtZDMxMjQ0MTFiZDI0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZm
-        LWM5NTMxYzI0OWFkYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUzYThj
-        ZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
-        ZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3NjQ4NmIv
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1i
+        OTFkMDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
+        aWJ1dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRk
+        NTBhMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
+        Yzg0MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRl
+        OTktYmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3
+        YTExOTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8z
+        YjliOWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRi
+        NTktODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdh
+        YzAzODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0
+        LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvMDVlMzY4ZDctMjkxYS00MzM2LWFkYmQt
+        ZDg5YjdiMDFkODQ2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1iMjc2ZmZhN2U4MjYvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM1YmJhMDBiLTZm
+        MTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy80ODA2MDhjMS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMt
+        NGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1ZmJiOTc0LTE1MmMtNDk2
+        ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3
+        YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4
+        M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04
+        MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNhMzhh
+        Mi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJi
+        LTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02
+        MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0
+        MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMx
+        LTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4
+        LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
+        dWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQtZjIwM2Nh
+        MzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
+        ZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDliODIzMjMv
         IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRz
-        L2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8iXX0=
+        L2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3499,7 +3924,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:46 GMT
+      - Fri, 29 Jul 2022 09:02:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3517,21 +3942,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7dfd2a79b5704cad8e0466d45ea596c6
+      - 99b5d26ffbdc4f1c99293e862a57f51e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiZjA3NDgwLWRkNGYtNDE5
-        Zi1hMDU3LWQxYTEwNzQwMTA3OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIxOWRiNDA0LWViNDUtNDFj
+        NC04NWVjLTk2OGM0OTY1MjcwNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1bf07480-dd4f-419f-a057-d1a107401079/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/219db404-eb45-41c4-85ec-968c49652706/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3552,53 +3977,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:46 GMT
+      - Fri, 29 Jul 2022 09:02:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 575650bb79304d57bf1be8b5e8657e11
+      - 4e2d9ad70bba4385834e279b79cfff70
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWJmMDc0ODAtZGQ0
-        Zi00MTlmLWEwNTctZDFhMTA3NDAxMDc5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDUuOTg1MzQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjE5ZGI0MDQtZWI0
+        NS00MWM0LTg1ZWMtOTY4YzQ5NjUyNzA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MTQuNDQxODUzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZGZkMmE3OWI1NzA0Y2FkOGUw
-        NDY2ZDQ1ZWE1OTZjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjQ2LjExOTgyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        NDYuMjg4Mzc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5OWI1ZDI2ZmZiZGM0ZjFjOTky
+        OTNlODYyYTU3ZjUxZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjE0LjY4MDg5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        MTQuOTU2NzkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9kY2QzN2ZhNS00Y2Y4LTRjYzctOWQ4Ny0wZmYzN2U3ZGJmY2IvdmVyc2lv
+        bS9iY2MwNTVlNi1jZTk5LTRjMTctYmZmOS0wMGY4NjMwNmM0YjkvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGNkMzdmYTUtNGNmOC00Y2M3
-        LTlkODctMGZmMzdlN2RiZmNiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNjMDU1ZTYtY2U5OS00YzE3
+        LWJmZjktMDBmODYzMDZjNGI5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3606,7 +4031,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3619,76 +4044,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:46 GMT
+      - Fri, 29 Jul 2022 09:02:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f6a6d6972f740dfb4e18db26dbe9156
+      - 5aebc2ef169945578e75119343728371
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '566'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
-        NTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2Ji
-        Mzg0ODctOTY3Ny00YTQzLTgzZTMtNDM5MGIzZDIwNWI0LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhiMjUx
-        NzM4LTZhNDgtNDNjYi1iNzlhLWYwYWM5NjYyNWRmZi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQt
-        MmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThj
-        NWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZm
-        LTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00
-        NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTViNzEtNDE1
-        NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkw
-        YWMtZWVkNzQ2MGM1NjFiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YwNzc5MmMzLWE0MmQtNDcwYy1hMjYw
-        LWJlYmE2MjAwMzQ5Zi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00YjY2LWFlYWQtZmY4
-        NTBiOTI2ZTVjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3696,7 +4121,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3709,50 +4134,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:46 GMT
+      - Fri, 29 Jul 2022 09:02:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4938f2b0fee3410394cb35cdfc508277
+      - bc1292ed7e8e4e71a5e7d0278d683bd1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3760,7 +4185,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3773,37 +4198,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:46 GMT
+      - Fri, 29 Jul 2022 09:02:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ca2adba727c94963b9c0ad737ae33cb1
+      - 4915436a55484f9f85181c925d64f70e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3876,9 +4301,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3894,8 +4319,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -3913,9 +4338,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -3937,9 +4362,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -3955,9 +4380,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -3966,9 +4391,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -3997,10 +4422,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4008,7 +4433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4021,43 +4446,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:46 GMT
+      - Fri, 29 Jul 2022 09:02:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f4bbd157de74c8fad1ac71cdc97780a
+      - a635d6a9f3544ea98369211ce0ffc1ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4065,7 +4490,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4078,41 +4503,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:46 GMT
+      - Fri, 29 Jul 2022 09:02:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c91250d2b434647bf73f6b37e30c09a
+      - 24264e36ae274553aa12a2f03b250bf5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/bcc055e6-ce99-4c17-bff9-00f86306c4b9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4120,7 +4545,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4133,36 +4558,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:47 GMT
+      - Fri, 29 Jul 2022 09:02:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2235632be71f49aaaad597b446a33753
+      - 1c2f250cc2764e6abc4eec14d1b7e566
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4184,5 +4609,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:15 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_module_stream_repository/module_streams_copied_with_include_modular_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_module_stream_repository/module_streams_copied_with_include_modular_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 50be92d1353f4a679bb3c45289484533
+      - cff61046e1e74e9d83403aa0f5567723
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '314'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNGIxM2M1My1lZTA0LTQ0NGUtYjczMi0wMzljN2Q5ZTcwOWIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzozMDo0OC41ODE1MDZa
+        cnBtL3JwbS9jYjdiYmJhMC0wNGE3LTRmMWUtYWQ4ZS0yNDdiMmM2YzkyZjUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMTo0Ni42NTEzMjla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNGIxM2M1My1lZTA0LTQ0NGUtYjczMi0wMzljN2Q5ZTcwOWIv
+        cnBtL3JwbS9jYjdiYmJhMC0wNGE3LTRmMWUtYWQ4ZS0yNDdiMmM2YzkyZjUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM0YjEz
-        YzUzLWVlMDQtNDQ0ZS1iNzMyLTAzOWM3ZDllNzA5Yi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2NiN2Ji
+        YmEwLTA0YTctNGYxZS1hZDhlLTI0N2IyYzZjOTJmNS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/cb7bbba0-04a7-4f1e-ad8e-247b2c6c92f5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dd2125ae59424951a326eb70baf199bf
+      - 2459d927bb8a425fa6d7f4729ad76dd2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjMjRjOTgwLTQzY2MtNDc5
-        MS1iZjA3LTI1ZDM3OThiYzI0Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxMmEyYjMzLTc2YmItNDE4
+        Ni04MTdlLTk4ODkyYTIyMzM5OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a1a2b975c320455cb67105cc9412a1d9
+      - b2fd2d83a8bc4382b7ec6062f4c5a359
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0c24c980-43cc-4791-bf07-25d3798bc246/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f12a2b33-76bb-4186-817e-98892a223398/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9abaf4378b8b4ae1a1ec15d5a1efdfe2
+      - 8362d946aff2485fae1e56544207bc5d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGMyNGM5ODAtNDNj
-        Yy00NzkxLWJmMDctMjVkMzc5OGJjMjQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTQuMzQxNjc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjEyYTJiMzMtNzZi
+        Yi00MTg2LTgxN2UtOTg4OTJhMjIzMzk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTYuMzc1MzE1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZDIxMjVhZTU5NDI0OTUxYTMyNmViNzBi
-        YWYxOTliZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjU0LjM3
-        MjY5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NTQuNTAw
-        MTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyNDU5ZDkyN2JiOGE0MjVmYTZkN2Y0NzI5
+        YWQ3NmRkMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjU2LjQy
+        NDAzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NTYuNjQ1
+        OTQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzRiMTNjNTMtZWUwNC00NDRl
-        LWI3MzItMDM5YzdkOWU3MDliLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2I3YmJiYTAtMDRhNy00ZjFl
+        LWFkOGUtMjQ3YjJjNmM5MmY1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0625e20201dc442dafbfece0b489c924
+      - d69335c1c8fe4131b0d8084f2eb4b4a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f86cee2fac6348d8a1fc3e9410cd0761
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZjQ3ZmY5ZjktZTE4Mi00OTA2LWE4ODgtMmVhOTgyZTZmYWZm
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NTEuMDgzNjUx
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/f47ff9f9-e182-4906-a888-2ea982e6faff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ed35bb1498c54a98901b5b169cafa616
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgxMzFhMWNmLWI0MGItNGU0
+        NC1hM2JkLWE1ZTQ4YzFkMzdkYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8131a1cf-b40b-4e44-a3bd-a5e48c1d37dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 021ba1a29fd84049a2fb0569de8e0750
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODEzMWExY2YtYjQw
+        Yi00ZTQ0LWEzYmQtYTVlNDhjMWQzN2RjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTYuODI1OTUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlZDM1YmIxNDk4YzU0YTk4OTAxYjViMTY5
+        Y2FmYTYxNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjU2Ljg2
+        MjM1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NTYuODk1
+        MjE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:01:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b14869e8daa34743b2bb9c3c91c9342f
+      - db1ba36f0ff44c938f4a2f00e94039fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 79e890f27ac24ca191824a0e1e243ecb
+      - 12ee3d3e74bc4709a12a06e495a82ccf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e5c17c0cff1f47b5a58534bcfed538f0
+      - 0d8b3a77f8924719ba6f39b2f149d8be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1d66d4c5a0048a2882821615647ac89
+      - 2fca148d83bf4876b6145cf4976891b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:30:54 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1cde7065f0d742ca8a0b0ab4f9155175
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/2e77010b-07d4-4e55-b3c6-8b5f237f62d4/"
+      - "/pulp/api/v3/remotes/rpm/rpm/04194ae9-54a5-4586-8bc0-c98aac6bbcdb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5622610f3f384acea808eff70227cf58
+      - f0c658de5cf944f5a2d6330a64d7b799
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzJl
-        NzcwMTBiLTA3ZDQtNGU1NS1iM2M2LThiNWYyMzdmNjJkNC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjMwOjU0Ljg2NTg2OFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0
+        MTk0YWU5LTU0YTUtNDU4Ni04YmMwLWM5OGFhYzZiYmNkYi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAxOjU3LjE4ODUyOFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjMwOjU0Ljg2NTg4OVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAxOjU3LjE4ODU1MVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:54 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c915218381be4a79b8103b58d5d77b64
+      - 541d9d60b6784767af61ffa694e109d6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTNkMDFhZjktY2RlZi00MTY4LWE5ZDUtOGY3MmVjNTdmMzNhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6NTQuOTc2Mjg0WiIsInZl
+        cG0vYjMyODcxZGMtMzAwZS00MDBmLWJkODItNzg5ZTVmYjE2NTdkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NTcuMzM4ODI5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTNkMDFhZjktY2RlZi00MTY4LWE5ZDUtOGY3MmVjNTdmMzNhL3ZlcnNp
+        cG0vYjMyODcxZGMtMzAwZS00MDBmLWJkODItNzg5ZTVmYjE2NTdkL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hM2QwMWFmOS1j
-        ZGVmLTQxNjgtYTlkNS04ZjcyZWM1N2YzM2EvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMzI4NzFkYy0z
+        MDBlLTQwMGYtYmQ4Mi03ODllNWZiMTY1N2QvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dbc2ff2773b848eea8dd3e381f224b5e
+      - dcd709ec1a83467f8988e70bbad2f1ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '311'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82YTMxZmE2NC1mNGJmLTQyMTAtOGI1Yy1iYzUyNzU4NDA2ZjUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzozMDo0OS4zMDU3ODNa
+        cnBtL3JwbS9mZjdlZWUyYS03NzhlLTQwZmEtOWZjMS05MjQ2MzRlODQ5ZDEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMTo0Ny41NDc2NDFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82YTMxZmE2NC1mNGJmLTQyMTAtOGI1Yy1iYzUyNzU4NDA2ZjUv
+        cnBtL3JwbS9mZjdlZWUyYS03NzhlLTQwZmEtOWZjMS05MjQ2MzRlODQ5ZDEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZhMzFm
-        YTY0LWY0YmYtNDIxMC04YjVjLWJjNTI3NTg0MDZmNS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ZmN2Vl
+        ZTJhLTc3OGUtNDBmYS05ZmMxLTkyNDYzNGU4NDlkMS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ff7eee2a-778e-40fa-9fc1-924634e849d1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9436faf230484f22b85735f8a0a84fb6
+      - c1211e0496644a36acacbe5acc0a7070
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdiNjdmMTczLWEzZWQtNDFk
-        NC05MmRlLWQ5MGM5N2FiNDQ5MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUxZDY0OGEwLTY5MDYtNDEx
+        ZC1iMGRhLTQzZWFkZDNhNWZlOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab00a2f8488b4a28b05c1b47b1f99171
+      - 91ec81200f9b4c65aeedb2b5203d6054
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNGQ3ODMyODMtNjZiNi00ZWQ5LWFiNTItN2IyOGUyODVjYjg4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6NDguNDQ2MDY1WiIsIm5h
+        cG0vNGZlNzNkZGQtMDMxNy00YzZmLTgxOTAtNjJjMjI2MGVjOGRmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NDYuNDYyNzQ3WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzozMDo0OS42NDI5MDFaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMTo0Ny45NjQ4MjZaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/4d783283-66b6-4ed9-ab52-7b28e285cb88/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/4fe73ddd-0317-4c6f-8190-62c2260ec8df/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 022d733985844ef989cb006087a4710b
+      - c3f684489c1c44fc9a625627f95d6e9d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UwZTVjODlmLTVlYzktNGRi
-        OC04NzY5LWY4MWZlMDdlNjE0MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5OWUzMzhjLWYxZWEtNDJk
+        Mi05MTliLTgwZmE0MGYyYmIyNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7b67f173-a3ed-41d4-92de-d90c97ab4491/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/51d648a0-6906-411d-b0da-43eadd3a5fe8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a258d86b3974a4cb1596b4ec0b6e61f
+      - 980c15c8fd794c3d9034acfbb015396b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2I2N2YxNzMtYTNl
-        ZC00MWQ0LTkyZGUtZDkwYzk3YWI0NDkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTUuMTI2NjE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTFkNjQ4YTAtNjkw
+        Ni00MTFkLWIwZGEtNDNlYWRkM2E1ZmU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTcuNTQ4NjI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NDM2ZmFmMjMwNDg0ZjIyYjg1NzM1Zjhh
-        MGE4NGZiNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjU1LjE1
-        ODI4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NTUuMjE3
-        ODQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMTIxMWUwNDk2NjQ0YTM2YWNhY2JlNWFj
+        YzBhNzA3MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjU3LjYw
+        MTgwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NTcuNzEy
+        NjgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmEzMWZhNjQtZjRiZi00MjEw
-        LThiNWMtYmM1Mjc1ODQwNmY1LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmY3ZWVlMmEtNzc4ZS00MGZh
+        LTlmYzEtOTI0NjM0ZTg0OWQxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e0e5c89f-5ec9-4db8-8769-f81fe07e6140/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/799e338c-f1ea-42d2-919b-80fa40f2bb27/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1c4951b942e24555913e0188960d38f9
+      - deae23a812744014bef7981f0e95c69b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTBlNWM4OWYtNWVj
-        OS00ZGI4LTg3NjktZjgxZmUwN2U2MTQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTUuMjE0MjEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzk5ZTMzOGMtZjFl
+        YS00MmQyLTkxOWItODBmYTQwZjJiYjI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTcuNjY4MzQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMjJkNzMzOTg1ODQ0ZWY5ODljYjAwNjA4
-        N2E0NzEwYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjU1LjI0
-        NjU4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NTUuMjg5
-        ODE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjM2Y2ODQ0ODljMWM0NGZjOWE2MjU2Mjdm
+        OTVkNmU5ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjU3Ljcz
+        OTMwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NTcuODE5
+        MTk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkNzgzMjgzLTY2YjYtNGVkOS1hYjUy
-        LTdiMjhlMjg1Y2I4OC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmZTczZGRkLTAzMTctNGM2Zi04MTkw
+        LTYyYzIyNjBlYzhkZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cbca2bda017f499f85f8ccf494360eb8
+      - 6c0841a8a3b04c3cb6d2cebd49487b63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aefbbc8c9da2433dba22a8a00348c734
+      - 35ccb9f57e44419096d78696af071bf8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6a0e2c54155442dcafdf640eb9c94c58
+      - 9ebd00af107040c2848ad4e8ea0da5b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 708c4e45ec7f4a378bd75f2d979b60dc
+      - 760ed8ceb48c4770a787504e3d799eee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5957a5bde2254af7856505b49f388d0e
+      - 233bdc35b7d2444c8ab3e009dfdb5ef0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f1a1eb56db74e66bbc1ec84790677f5
+      - d1c3a8b590fe492e9c56219acbc531fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/"
+      - "/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 544d73c53f134dbab151cce3868999c3
+      - 8ee212f9456c405eb16fbfca142a291d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjM3YTU2N2YtOGMxMy00NGZiLWEyZmQtYjAwNDZhYTcxODM4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6NTUuNjYyNjMxWiIsInZl
+        cG0vZWZlNWQ3MDktMzMxZC00YTE3LWJmNTItODc2MzIwMjA5MzViLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDE6NTguNDEzNDAyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjM3YTU2N2YtOGMxMy00NGZiLWEyZmQtYjAwNDZhYTcxODM4L3ZlcnNp
+        cG0vZWZlNWQ3MDktMzMxZC00YTE3LWJmNTItODc2MzIwMjA5MzViL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MzdhNTY3Zi04
-        YzEzLTQ0ZmItYTJmZC1iMDA0NmFhNzE4MzgvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lZmU1ZDcwOS0z
+        MzFkLTRhMTctYmY1Mi04NzYzMjAyMDkzNWIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/2e77010b-07d4-4e55-b3c6-8b5f237f62d4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/04194ae9-54a5-4586-8bc0-c98aac6bbcdb/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:55 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cbad95ab21f64753b18973e84e6ad331
+      - eecfa031362640e493703c32fd61ab6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmMzU4MDM2LWFiOWUtNGNk
-        ZS1iZTEyLTE3ZmVjMGRkN2ZlNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmYmJmZDFlLWViYmEtNGUy
+        OC1hZTJiLTllMWI3NjEyMjQ4OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7f358036-ab9e-4cde-be12-17fec0dd7fe6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3fbbfd1e-ebba-4e28-ae2b-9e1b76122488/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:56 GMT
+      - Fri, 29 Jul 2022 09:01:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6958b8cfe5ce454f877c5a3bcd735617
+      - 22434825c3ce4d46862f1727f655d1df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2YzNTgwMzYtYWI5
-        ZS00Y2RlLWJlMTItMTdmZWMwZGQ3ZmU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTUuOTM0NTIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2ZiYmZkMWUtZWJi
+        YS00ZTI4LWFlMmItOWUxYjc2MTIyNDg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTguNzkxMDM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJjYmFkOTVhYjIxZjY0NzUzYjE4OTczZTg0
-        ZTZhZDMzMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjU1Ljk2
-        NDkxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NTUuOTg3
-        OTY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlZWNmYTAzMTM2MjY0MGU0OTM3MDNjMzJm
+        ZDYxYWI2YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAxOjU4Ljgz
+        NDcyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDE6NTguODY1
+        MzU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzJlNzcwMTBiLTA3ZDQtNGU1NS1iM2M2
-        LThiNWYyMzdmNjJkNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0MTk0YWU5LTU0YTUtNDU4Ni04YmMw
+        LWM5OGFhYzZiYmNkYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzJlNzcw
-        MTBiLTA3ZDQtNGU1NS1iM2M2LThiNWYyMzdmNjJkNC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0MTk0
+        YWU5LTU0YTUtNDU4Ni04YmMwLWM5OGFhYzZiYmNkYi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:56 GMT
+      - Fri, 29 Jul 2022 09:01:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 60e1ff46f1aa4310879ebfd022696427
+      - 1304a829667f42579a797c4faa3dbac9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0YWU4ZmE2LWI5NDktNGVj
-        Ny05OWE2LTMxZDU3YTBhMWExOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0N2Q1ZmI3LWM1ZjEtNDQy
+        ZC05M2RkLWRjZjQzOGJhZDNhYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:56 GMT
+  recorded_at: Fri, 29 Jul 2022 09:01:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/44ae8fa6-b949-4ec7-99a6-31d57a0a1a19/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a47d5fb7-c5f1-442d-93dd-dcf438bad3aa/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:57 GMT
+      - Fri, 29 Jul 2022 09:02:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5b43f0d101434c589fe3e4e03b82563b
+      - 9ea03931fecf4125a94456448665a7bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '652'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDRhZThmYTYtYjk0
-        OS00ZWM3LTk5YTYtMzFkNTdhMGExYTE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTYuMTEyMTMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQ3ZDVmYjctYzVm
+        MS00NDJkLTkzZGQtZGNmNDM4YmFkM2FhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDE6NTguOTk4NDQ3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI2MGUxZmY0NmYxYWE0MzEwODc5
-        ZWJmZDAyMjY5NjQyNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjU2LjE0MjQxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        NTYuODA4NzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxMzA0YTgyOTY2N2Y0MjU3OWE3
+        OTdjNGZhYTNkYmFjOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAx
+        OjU5LjA1MzgzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        MDAuMjUyMzM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2EzZDAxYWY5LWNkZWYtNDE2OC1hOWQ1LThmNzJl
-        YzU3ZjMzYS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hM2Qw
-        MWFmOS1jZGVmLTQxNjgtYTlkNS04ZjcyZWM1N2YzM2EvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMmU3NzAxMGItMDdkNC00ZTU1
-        LWIzYzYtOGI1ZjIzN2Y2MmQ0LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9iMzI4NzFkYy0zMDBlLTQwMGYtYmQ4Mi03ODllNWZi
+        MTY1N2QvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjMyODcx
+        ZGMtMzAwZS00MDBmLWJkODItNzg5ZTVmYjE2NTdkLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0MTk0YWU5LTU0YTUtNDU4Ni04
+        YmMwLWM5OGFhYzZiYmNkYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:00 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYTNkMDFhZjktY2RlZi00MTY4LWE5ZDUtOGY3MmVjNTdm
-        MzNhL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYjMyODcxZGMtMzAwZS00MDBmLWJkODItNzg5ZTVmYjE2
+        NTdkL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:57 GMT
+      - Fri, 29 Jul 2022 09:02:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8001082894b4de089a6f039e523ccd1
+      - 9f36dd0a4ce841869df6b6b1b693b0e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2MDkyYWMwLWE2YjQtNDI1
-        Ni1hMjgxLTY3MDgyODE5MjAzYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViNzQ0ZjllLWNjMjYtNDEx
+        OS04OTAwLWFmNGQ4NmQ3NWVjMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/96092ac0-a6b4-4256-a281-67082819203b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/eb744f9e-cc26-4119-8900-af4d86d75ec1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:57 GMT
+      - Fri, 29 Jul 2022 09:02:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c55c3c64ef054cc18968e433711b67d1
+      - bda6c364d52643b6ba0d2bfaa3c0527d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTYwOTJhYzAtYTZi
-        NC00MjU2LWEyODEtNjcwODI4MTkyMDNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTcuMjc0NzAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWI3NDRmOWUtY2My
+        Ni00MTE5LTg5MDAtYWY0ZDg2ZDc1ZWMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDAuNjYzNTcyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImM4MDAxMDgyODk0YjRkZTA4OWE2ZjAzOWU1
-        MjNjY2QxIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NTcuMzA1
-        NTc5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzozMDo1Ny41NTA5
-        MDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjlmMzZkZDBhNGNlODQxODY5ZGY2YjZiMWI2
+        OTNiMGU3Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MDAuNzE3
+        OTY4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMjowMS4yMDA3
+        NzdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDAwZTgx
-        MmItYjFmNy00NDZlLTg5N2YtOTc2ZmMyMTBlYjg4LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDYyYWI2
+        N2YtZWIzYi00NTM1LWI4MjktNDc2MGQ1Y2FjNjQ5LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYTNkMDFhZjktY2RlZi00MTY4LWE5ZDUtOGY3MmVj
-        NTdmMzNhLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYjMyODcxZGMtMzAwZS00MDBmLWJkODItNzg5ZTVm
+        YjE2NTdkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:57 GMT
+      - Fri, 29 Jul 2022 09:02:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dac46ee923014933bf0be7fe78cdca88
+      - 79d84e5de4674180bd9a9b6e3b796f5e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/462ab67f-eb3b-4535-b829-4760d5cac649/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 43cb1863681b482689c0dd2e6286f4bb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNDYyYWI2N2YtZWIzYi00NTM1LWI4MjktNDc2MGQ1Y2FjNjQ5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MDAuNzM5ODEyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9iMzI4NzFkYy0zMDBlLTQwMGYtYmQ4Mi03ODllNWZiMTY1N2Qv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2IzMjg3MWRjLTMwMGUtNDAwZi1iZDgyLTc4OWU1
+        ZmIxNjU3ZC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:01 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS80NjJhYjY3Zi1lYjNiLTQ1MzUtYjgyOS00NzYwZDVjYWM2NDkv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 806068d8e8014151bed51a4525d5dc75
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0OWQ0NDYwLWFlMjQtNGU1
+        Ni1iZTlmLWJiYTc5ZTE2NTFkMi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/449d4460-ae24-4e56-be9f-bba79e1651d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - edebc7efd7cd440f97ceea7a1ea99b89
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDQ5ZDQ0NjAtYWUy
+        NC00ZTU2LWJlOWYtYmJhNzllMTY1MWQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDEuNTM0MzU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4MDYwNjhkOGU4MDE0MTUxYmVkNTFhNDUy
+        NWQ1ZGM3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjAxLjU4
+        NzMyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MDEuOTEy
+        MTU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDBk
+        MzI1YzMtNGI5Ni00ODVmLWIzN2EtNTkxYWNjYzZiNzJjLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/00d325c3-4b96-485f-b37a-591accc6b72c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 95ca3cc4061845aa8a04f241311bd91d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzAwZDMyNWMzLTRiOTYtNDg1Zi1iMzdhLTU5MWFjY2M2YjcyYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjAxLjg5NTc2OFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNDYyYWI2N2YtZWIzYi00NTM1LWI4Mjkt
+        NDc2MGQ1Y2FjNjQ5LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:02 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5774020494f24d71ac4545e35a754bf9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea750422720345549b52e0d7b71a6dd1
+      - 772f028186e84536bdd7709ff6db95f5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d76a70ef90484a33a71abecfdbcec431
+      - ce0bd002b30946b6b089f99eae17ca1e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1f6a0d996e74808987109968559f184
+      - 1935883bb3714853bb8f7c6d12acc46a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f99fbeb566a4420ca1d364a40351fd67
+      - 2ee6941483de478781be5363625a9801
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a031f44f6329458cb2547483da9a6c8e
+      - c138f0e68b29440094cff152560578e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a939ba7357194f16a24254b7ebf36375
+      - 79a0d8f07c024f8aa12a97531abf41dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 878cd3d2fe464f45b0080bac828b42ac
+      - aee18b1a0b9c4f109e883e7c07b143d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8f15c572bce4ebfb12e284258ec23f4
+      - cbaa1677b7a4492289d947b542a89f88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - edfc107e322c401692be8fa30e3758c3
+      - 6557be4730cd4dd2bdc3bacba7525bd4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9cb193406c124556826c73b218663d36
+      - 6669a32d12eb443d9b41551ab75a4d92
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e6a3bffc237a4caba100bd1dc30ebd05
+      - 167639cf062b4af5a54677bc5f654340
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f64a0eda33284a3b9f74fd923b69aad8
+      - c7f82e08e06343328bada01d30cd7dc2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a3d01af9-cdef-4168-a9d5-8f72ec57f33a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b32871dc-300e-400f-bd82-789e5fb1657d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:58 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 654696edbf224fabb4ab8aa266bc87da
+      - dea3dd159c2646c2a358615ee7d70c16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:59 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,81 +3819,81 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a08ea119793846b9aa8ae8c12aebc5be
+      - 8dba3897b0dc420fa0feafe4fea65422
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjZDUzMGY5LTc5OGMtNDVl
-        Yi1iNDIxLWRiNzgzNzNlNmEyZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3MGZmYjI5LWRlNjgtNDE3
+        OS04NmNiLWVlMDBkYmFkZGY0Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8wMTJlMDA1OS0zZGE0LTRjNGUtOWVmNy1kMDhlMTM4
-        Njg0ZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        MjFhNDk3NzEtODJmMy00MWQ4LTk3YTgtZDQ5NDM5MTgxNzAzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUt
-        NDMzYy1hM2NkLTY0MWMxMDA5NTExMy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEw
-        NmE0Y2Y5NTAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQtZDcxNTNhZDc4NDIyLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQy
-        M2QtNDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1
-        ZC1iODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRk
-        NGFhYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vw
-        cy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvZWYxZTdjNGQt
-        MDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wNTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00
-        NjMzYTJjNzk5MGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZlNjdlNTkzZWQzMy8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFl
-        Mi00NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8yOWU2YTIxZC0yZjY5LTRjZDItYjcxMS02MWNj
-        ODljZjcwY2UvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzM3YzM4MGEwLWFhZmYtNDNmMi05YTZkLTdhMjUyYjA5YWE5Ni8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDk0M2QxOWQtYzU1Mi00
-        NWQyLTg1NjAtYzcwYWY5MTM3Y2NjLyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZj
-        ODBmOWUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2
-        NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYwOGNlMzctMWM3MS00YWQw
-        LTkwYWMtZWVkNzQ2MGM1NjFiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy85NjUyMjg4MC04YzVhLTQ4MDEtYjU2Ny0xZjJiMWRiNzNk
-        ZWMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ExOWU0
-        N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0MjQyZS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2JiMzg0ODctOTY3Ny00YTQzLTgz
-        ZTMtNDM5MGIzZDIwNWI0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YwNzc5MmMz
-        LWE0MmQtNDcwYy1hMjYwLWJlYmE2MjAwMzQ5Zi8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvZmMyYWU4MmUtYjdhMS00ZDZmLWI2M2Qt
-        Y2U3MWVmZTU2YzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBv
-        X21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQzMTI0
-        NDExYmQyNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVu
-        dmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2Zi1jOTUzMWMyNDlh
-        ZGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1
-        bHRzLzIxN2ZhOWVkLWJlYjYtNDEyNy1hMjk3LTM1M2E4Y2U1MTY4NS8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvOGRl
-        NmZlNzktYTE4MS00YTIxLWE3ZTUtMGYxZmI3NzY0ODZiLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03
-        MTRiLTQyZTktYWRjMy1hNGE4MGY3OWVkNzMvIl19
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzE1ZWE3ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5
+        MDc3NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vw
+        cy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvNWUxZDBkYjQt
+        ZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzEwODA0ODI3LTY0YzgtNDU5Mi04Mzg0LWIyNzZmZmE3ZTgyNi8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzViYmEwMGItNmYx
+        Ni00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1iNmFhLTQwOTAtOWFmZi03M2E0
+        NDZjYjZiMDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzY1ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00
+        MDFjLWFmZTUtNTg1YjI5OTM3YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy82OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFk
+        ODRhMjQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdj
+        ZjA1ZjJlLWIyYzEtNDhiMC04MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhkZS00ZTZl
+        LTk0MjctYmU3MDk2NTk0MjBlLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQyYi05MDMzNmRkMzBj
+        NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E3MjQw
+        ZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIwZS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjkxMmM5MDUtNjFmNS00NzJiLThl
+        OTEtMzZlYzhmYzM1MDQ4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9jMjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzc5OWE2
+        LWY3NjYtNDU4Ni1hMTliLTI0YzJmYmUzNzFmYy8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4ZGYt
+        ZmQ4NDNhN2VkNWE4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBv
+        X21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUxMzAz
+        YmZkZmE1Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVu
+        dmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRhOC02ZTcxOTU3Y2Ix
+        NzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1
+        bHRzLzQyYmFkZjhmLTEwMGUtNGE4ZC1hMDJkLWYyMDNjYTMwY2Y5NC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvYjE4
+        ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5ZjQ5YjgyMzIzLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0z
+        YWRkLTRmZDgtYmU2MC02NDE5Yjg2M2U1NzEvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3481,7 +3906,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:59 GMT
+      - Fri, 29 Jul 2022 09:02:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3499,21 +3924,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af06f9704ccc4e248cf916323e0be90c
+      - 4b0c573c26a5459a9f50f88a239f5006
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyOWU2ZmJmLTg1MDctNDUz
-        Zi05MGJmLTBkYmU4NTNkNDFlOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmYjI2YjIxLWQzYTEtNGRh
+        MC04YWRkLTVkZjg4NGY4Yjg3ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/229e6fbf-8507-453f-90bf-0dbe853d41e8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5fb26b21-d3a1-4da0-8add-5df884f8b87e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3534,53 +3959,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:59 GMT
+      - Fri, 29 Jul 2022 09:02:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0705de4d2b6948dfb3f3e9c275a26cb4
+      - 328bcb94da5148a78c69f6f5b074f99e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjI5ZTZmYmYtODUw
-        Ny00NTNmLTkwYmYtMGRiZTg1M2Q0MWU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTkuMDYyMDk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWZiMjZiMjEtZDNh
+        MS00ZGEwLThhZGQtNWRmODg0ZjhiODdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MDMuOTY2Mjk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZjA2Zjk3MDRjY2M0ZTI0OGNm
-        OTE2MzIzZTBiZTkwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjU5LjIxMzk1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        NTkuMzY1NDk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0YjBjNTczYzI2YTU0NTlhOWY1
+        MGY4OGEyMzlmNTAwNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjA0LjIwOTIwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        MDQuNDQ3NTEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82MzdhNTY3Zi04YzEzLTQ0ZmItYTJmZC1iMDA0NmFhNzE4MzgvdmVyc2lv
+        bS9lZmU1ZDcwOS0zMzFkLTRhMTctYmY1Mi04NzYzMjAyMDkzNWIvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjM3YTU2N2YtOGMxMy00NGZi
-        LWEyZmQtYjAwNDZhYTcxODM4LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWZlNWQ3MDktMzMxZC00YTE3
+        LWJmNTItODc2MzIwMjA5MzViLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3588,7 +4013,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3601,66 +4026,66 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:59 GMT
+      - Fri, 29 Jul 2022 09:02:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1284'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7789e9009c4243c096595222a29d1333
+      - 88ed8d8be9224a2d8a9ddd77953957a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '450'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNTBjODJlOWQtYWY4OS00MzEzLWJmZWQtZDRjNGE2YzgwZjll
+        cGFja2FnZXMvNjVmYmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZlNjdlNTkzZWQzMy8i
+        Y2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy82NjQ2NWZmYS05NTFlLTRlZDUtYjNjMy1hODA2ZWVkZmM4NWQvIn0s
+        YWdlcy85ZWNhMzhhMi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMDU2MWJjMzItZTBmNS00ZDdiLWJjYzMtNDYzM2EyYzc5OTBmLyJ9LHsi
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8y
-        OWU2YTIxZC0yZjY5LTRjZDItYjcxMS02MWNjODljZjcwY2UvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1
-        MjI4ODAtOGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM3YzM4
-        MGEwLWFhZmYtNDNmMi05YTZkLTdhMjUyYjA5YWE5Ni8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNGI5ZTFk
-        MS1mYWUyLTQ0NWQtYTg3Ny05Mzk5ZjhlNjVjMGQvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmMyYWU4MmUt
-        YjdhMS00ZDZmLWI2M2QtY2U3MWVmZTU2YzVhLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2MDhjZTM3LTFj
-        NzEtNGFkMC05MGFjLWVlZDc0NjBjNTYxYi8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTE5ZTQ3Y2ItZDZkNi00
-        MmVhLTk3MzItMzI4NTIxNjQyNDJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2
-        Ni1hZWFkLWZmODUwYjkyNmU1Yy8ifV19
+        LzM1YmJhMDBiLTZmMTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDgw
+        NjA4YzEtYjZhYS00MDkwLTlhZmYtNzNhNDQ2Y2I2YjA0LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1
+        ZjJlLWIyYzEtNDhiMC04MTMzLTFiZjc1ZmRkMjNlMS8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMjQ3NDI1
+        NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzIt
+        MTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3YzU2LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1N2IxLWM5
+        MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1
+        LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMDVlMzY4ZDctMjkxYS00
+        MzM2LWFkYmQtZDg5YjdiMDFkODQ2LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0YzgtNDU5
+        Mi04Mzg0LWIyNzZmZmE3ZTgyNi8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3668,7 +4093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3681,41 +4106,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:59 GMT
+      - Fri, 29 Jul 2022 09:02:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '140'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '03338127fbbf4935b6eb161a8b84a8a3'
+      - c564c1ff31d944c4a050f24f79e33211
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5NGQ0YWFj
+        b2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2ZTkwNzc1
         LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3723,7 +4148,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3736,37 +4161,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:59 GMT
+      - Fri, 29 Jul 2022 09:02:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '7483'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 65bcac25cc684db9847adea5f2c59c46
+      - b4cf176b0eda43a68868a1dfddb088e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1858'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3839,9 +4264,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3857,8 +4282,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -3876,9 +4301,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -3900,9 +4325,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -3918,9 +4343,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -3930,10 +4355,10 @@ http_interactions:
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3941,7 +4366,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3954,43 +4379,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:59 GMT
+      - Fri, 29 Jul 2022 09:02:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b1aad07017bd4d54a0df854514d03461
+      - 0bc1d2c7b55f444f84f4d5598043a11f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3998,7 +4423,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4011,41 +4436,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:59 GMT
+      - Fri, 29 Jul 2022 09:02:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7bba0baad2c34011a7bb5485a3be3ea0
+      - 524b2b4001604fdda133ca1e4e9ccf4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/637a567f-8c13-44fb-a2fd-b0046aa71838/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/efe5d709-331d-4a17-bf52-87632020935b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4053,7 +4478,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4066,36 +4491,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:31:00 GMT
+      - Fri, 29 Jul 2022 09:02:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d194692c2c242fc97e1fd18a3041668
+      - 5b66dd5dbe5e44019447867ab26ea22b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4117,5 +4542,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:31:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:05 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_module_stream_repository/module_streams_copied_with_modular_exclude_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_module_stream_repository/module_streams_copied_with_modular_exclude_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:47 GMT
+      - Fri, 29 Jul 2022 09:02:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ccc53f9c4b6741278c124d0e8bd6e788
+      - b05e82253d0c40b6a3964fc877c2b90f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82YzEyNjM4Ni1lMjY5LTQwNWEtOGYyNi0xMzQwNjYwMzY2N2Mv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzozMDo0Mi4wOTQ2ODRa
+        cnBtL3JwbS9hN2RkMDk4NS0zZTYxLTRmZDYtYTk0My05Njg0ZjlhYmVkZDcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjoxOC41NDg0NzFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82YzEyNjM4Ni1lMjY5LTQwNWEtOGYyNi0xMzQwNjYwMzY2N2Mv
+        cnBtL3JwbS9hN2RkMDk4NS0zZTYxLTRmZDYtYTk0My05Njg0ZjlhYmVkZDcv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZjMTI2
-        Mzg2LWUyNjktNDA1YS04ZjI2LTEzNDA2NjAzNjY3Yy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2E3ZGQw
+        OTg1LTNlNjEtNGZkNi1hOTQzLTk2ODRmOWFiZWRkNy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:27 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6c126386-e269-405a-8f26-13406603667c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a7dd0985-3e61-4fd6-a943-9684f9abedd7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:47 GMT
+      - Fri, 29 Jul 2022 09:02:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 829ff5a425bd4b60ad3227fca9c00a58
+      - de1d6f3dcce24a0384b58150a9776323
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwOTM5OTlhLTk1ZjMtNGM3
-        My05MTkxLTUxNmY0NWY0MmJmNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjNWRkOWRlLTkzODktNDQ2
+        My05ODEyLTM4NWM2MTE5NDc5ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:47 GMT
+      - Fri, 29 Jul 2022 09:02:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a7866289c2548c2aec9a5c38db70820
+      - 2423022235484328bab51c82ad8bdbb6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c093999a-95f3-4c73-9191-516f45f42bf4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0c5dd9de-9389-4463-9812-385c6119479d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d620cd2905e54fa8adc5274ba0c44129
+      - f60a0fe1de86409ca3a60b9aa646bfb5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzA5Mzk5OWEtOTVm
-        My00YzczLTkxOTEtNTE2ZjQ1ZjQyYmY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDcuODc3MjAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGM1ZGQ5ZGUtOTM4
+        OS00NDYzLTk4MTItMzg1YzYxMTk0NzlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MjcuNzIxNjc4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4MjlmZjVhNDI1YmQ0YjYwYWQzMjI3ZmNh
-        OWMwMGE1OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjQ3Ljkw
-        OTgxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDguMDQz
-        NzU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZTFkNmYzZGNjZTI0YTAzODRiNTgxNTBh
+        OTc3NjMyMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjI3Ljc2
+        NDAxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MjcuOTcx
+        Mzk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmMxMjYzODYtZTI2OS00MDVh
-        LThmMjYtMTM0MDY2MDM2NjdjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTdkZDA5ODUtM2U2MS00ZmQ2
+        LWE5NDMtOTY4NGY5YWJlZGQ3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c77772e32cee430d868bdc8dd0142407
+      - cbae62be506d4357a7edec91edfc79f5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8d61f479e24b4929add9e3a94cf68772
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNGVlZmIwNmUtNjIxYi00Yzc2LWFlNDUtM2NhYWQ0NzU1NDE3
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MjIuODAxOTYw
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4eefb06e-621b-4c76-ae45-3caad4755417/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b9a2eb2015fe4b14baa713a53674223e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzYjg1MWQ5LThmNGItNGNl
+        Yy05NTRjLTViYzJkYmI0NzdlMy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b3b851d9-8f4b-4cec-954c-5bc2dbb477e3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c50dc588cab04d7ca9100f68ae369fce
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjNiODUxZDktOGY0
+        Yi00Y2VjLTk1NGMtNWJjMmRiYjQ3N2UzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MjguMTY4MzgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiOWEyZWIyMDE1ZmU0YjE0YmFhNzEzYTUz
+        Njc0MjIzZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjI4LjIx
+        MjU5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MjguMjQ4
+        Nzg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fefe35d3878a4713a0716e9b2c93d2f7
+      - 81d1142280d84d95a60ab035b277fdd5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90096e53e4fd4939864f2c29bbfcbae1
+      - 39480bdf9a8e489295e5fde3406d5ac7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5b1167f7392c4f5a9418caf2da4b7f9e
+      - 23852103261d48058768823c5fab8e8c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68f7942d880c401c8691c7436e822217
+      - 41b8b098765145309474e7d16cbbd97e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:30:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 69ea55e4322143f593d0bbaec36fb636
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/4d783283-66b6-4ed9-ab52-7b28e285cb88/"
+      - "/pulp/api/v3/remotes/rpm/rpm/70ca5cec-4213-4c3b-9f46-5e6db8906222/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5b517b5b100a4c9e9ea1d7c5c1a08a45
+      - fa061b7a763c4b1c8c4f178b1f3da152
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRk
-        NzgzMjgzLTY2YjYtNGVkOS1hYjUyLTdiMjhlMjg1Y2I4OC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjMwOjQ4LjQ0NjA2NVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcw
+        Y2E1Y2VjLTQyMTMtNGMzYi05ZjQ2LTVlNmRiODkwNjIyMi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjI4LjY5MTM2MFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjMwOjQ4LjQ0NjA4NloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAyOjI4LjY5MTQwNFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/"
+      - "/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0511aa1bd4d942b3af9a5abbd91590b8
+      - 25a6c94ecddb4e77bb29390b97352fa5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzRiMTNjNTMtZWUwNC00NDRlLWI3MzItMDM5YzdkOWU3MDliLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6NDguNTgxNTA2WiIsInZl
+        cG0vMmFkOTlkMTYtZmYxYi00YjM5LWI0OGYtZTlmMGM5MzJkYzI5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MjguODM4Mzk3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzRiMTNjNTMtZWUwNC00NDRlLWI3MzItMDM5YzdkOWU3MDliL3ZlcnNp
+        cG0vMmFkOTlkMTYtZmYxYi00YjM5LWI0OGYtZTlmMGM5MzJkYzI5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNGIxM2M1My1l
-        ZTA0LTQ0NGUtYjczMi0wMzljN2Q5ZTcwOWIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yYWQ5OWQxNi1m
+        ZjFiLTRiMzktYjQ4Zi1lOWYwYzkzMmRjMjkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90107f2e9aa94b0bba67693d6b17e711
+      - 12b64c6ef915447abd7da15e008a1e50
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kY2QzN2ZhNS00Y2Y4LTRjYzctOWQ4Ny0wZmYzN2U3ZGJmY2Iv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzozMDo0Mi43ODQ5NTha
+        cnBtL3JwbS8wMjM4NGJiYi0zMjZiLTQ1YjItYTFjZC0xYzBlNDlmOTk4MGYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjoxOS41MDQ1MjVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kY2QzN2ZhNS00Y2Y4LTRjYzctOWQ4Ny0wZmYzN2U3ZGJmY2Iv
+        cnBtL3JwbS8wMjM4NGJiYi0zMjZiLTQ1YjItYTFjZC0xYzBlNDlmOTk4MGYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2RjZDM3
-        ZmE1LTRjZjgtNGNjNy05ZDg3LTBmZjM3ZTdkYmZjYi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAyMzg0
+        YmJiLTMyNmItNDViMi1hMWNkLTFjMGU0OWY5OTgwZi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/dcd37fa5-4cf8-4cc7-9d87-0ff37e7dbfcb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/02384bbb-326b-45b2-a1cd-1c0e49f9980f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 387640fb293f4d198d69d891e10ae31f
+      - 75bd5aa2d1d44d5e83ff5f3586a32669
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjNDNhMjIxLTZjNTItNDY0
-        NS1hOWU4LWRhM2RjZjU1YjkwNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwZTA3MDk0LTIyNDktNDcy
+        My1hZDk0LTljYmE2YjAxMGNmMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 80823287863047deaa1bad4f737dbdfc
+      - ec3f860bd5d242c4934b7542ddf49a19
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '365'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vOGFhZGNmNzAtYjcxZS00ZTY4LWFkMmYtZjhiMDZjZDUwZDRjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6NDEuOTg1MTgxWiIsIm5h
+        cG0vYjRhMWZhNDYtNTdmOC00MmM0LWI2NzYtMWIwMTg3NjhlZjFmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MTguNDA2NDI2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzozMDo0My4xMTA0ODFaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMjoxOS45MjE1MDZaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/8aadcf70-b71e-4e68-ad2f-f8b06cd50d4c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b4a1fa46-57f8-42c4-b676-1b018768ef1f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ab5a9fab58a420986ea8ea2616efb2b
+      - 66eb05cdbb0048c9af0daed519415d4d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4ZmRiYWY3LTNhZjAtNDRm
-        Yy05NDk2LWY0MTQxN2I1NDM4My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzllZjRlODI5LWZmODAtNDk3
+        ZS1iNGVlLTI0ZDk5YjEwY2IyOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3c43a221-6c52-4645-a9e8-da3dcf55b904/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/90e07094-2249-4723-ad94-9cba6b010cf2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31059c1d30bf484ab43ddac55610151d
+      - 0fcc4cab64554a2491af31f6bd7c101c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2M0M2EyMjEtNmM1
-        Mi00NjQ1LWE5ZTgtZGEzZGNmNTViOTA0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDguNzQxMDM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTBlMDcwOTQtMjI0
+        OS00NzIzLWFkOTQtOWNiYTZiMDEwY2YyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MjkuMDk5MzUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzODc2NDBmYjI5M2Y0ZDE5OGQ2OWQ4OTFl
-        MTBhZTMxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjQ4Ljc3
-        MTIyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDguODMx
-        MjU1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3NWJkNWFhMmQxZDQ0ZDVlODNmZjVmMzU4
+        NmEzMjY2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjI5LjE1
+        MjI2N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MjkuMjUx
+        Nzc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGNkMzdmYTUtNGNmOC00Y2M3
-        LTlkODctMGZmMzdlN2RiZmNiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDIzODRiYmItMzI2Yi00NWIy
+        LWExY2QtMWMwZTQ5Zjk5ODBmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/98fdbaf7-3af0-44fc-9496-f41417b54383/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9ef4e829-ff80-497e-b4ee-24d99b10cb29/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1714604b9d04007afbf1fb00e22f8c5
+      - 529b6518ff5541cb8413fded8371116e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOThmZGJhZjctM2Fm
-        MC00NGZjLTk0OTYtZjQxNDE3YjU0MzgzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDguODMwNjM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWVmNGU4MjktZmY4
+        MC00OTdlLWI0ZWUtMjRkOTliMTBjYjI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MjkuMjUyMTI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1YWI1YTlmYWI1OGE0MjA5ODZlYThlYTI2
-        MTZlZmIyYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjQ4Ljg2
-        MjM1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDguOTA1
-        OTUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NmViMDVjZGJiMDA0OGM5YWYwZGFlZDUx
+        OTQxNWQ0ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjI5LjI5
+        OTQ1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MjkuMzkx
+        Nzk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhhYWRjZjcwLWI3MWUtNGU2OC1hZDJm
-        LWY4YjA2Y2Q1MGQ0Yy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I0YTFmYTQ2LTU3ZjgtNDJjNC1iNjc2
+        LTFiMDE4NzY4ZWYxZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:48 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39e72098ead247d198e53bd81d90cdee
+      - 0ea6bce95d72482b9264325b70a3f630
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 34d6aaad869246b9a23ef5471053bbe1
+      - 48ee05ddb1414f0ca901f6421672bdf7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cdeed380988a4bf4b552997878e69a96
+      - 83d51504533043779944d5ef7c419826
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 274a26338efc4118bc474c1dcea5bafa
+      - 15f1fba1e71747c5ac672341839be638
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b0b679892d02465b9ebcd6e05aa7a8a6
+      - 1b8ca25633584952b75a5a6144cf041f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6336d1db855547838593be96edf35491
+      - ba607a44ba1244678e305ec692d94d16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/"
+      - "/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff3bbdecd2ac488d93797ca148687e10
+      - 98c811fa2d5e45d5a6cf9058e6c8fd5e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmEzMWZhNjQtZjRiZi00MjEwLThiNWMtYmM1Mjc1ODQwNmY1LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6NDkuMzA1NzgzWiIsInZl
+        cG0vNmVjNTk3OTMtZGM2ZC00ZjVlLTgwZDgtMGU1ZmM2NjJkYjAyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MjkuOTEzMTE1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmEzMWZhNjQtZjRiZi00MjEwLThiNWMtYmM1Mjc1ODQwNmY1L3ZlcnNp
+        cG0vNmVjNTk3OTMtZGM2ZC00ZjVlLTgwZDgtMGU1ZmM2NjJkYjAyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82YTMxZmE2NC1m
-        NGJmLTQyMTAtOGI1Yy1iYzUyNzU4NDA2ZjUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82ZWM1OTc5My1k
+        YzZkLTRmNWUtODBkOC0wZTVmYzY2MmRiMDIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:29 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/4d783283-66b6-4ed9-ab52-7b28e285cb88/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/70ca5cec-4213-4c3b-9f46-5e6db8906222/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ebf8ac5c2a834aa087580022fe2ef901
+      - 9cdcc6b3149a4bc7ad04197b385a33cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExNjM0ZmQ1LTQ0MGMtNDgz
-        OC1hNThiLThmNjNjYzQxYjE1ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViNGJjMzUyLTk4NDctNDBj
+        MC1hYTM1LWRlOWI0MjgwNGE0NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a1634fd5-440c-4838-a58b-8f63cc41b15d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5b4bc352-9847-40c0-aa35-de9b42804a45/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 32d0562ab20047339627aeee65eca349
+      - 1f71214ce67443779023c479d78bad80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTE2MzRmZDUtNDQw
-        Yy00ODM4LWE1OGItOGY2M2NjNDFiMTVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDkuNTkyNDAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWI0YmMzNTItOTg0
+        Ny00MGMwLWFhMzUtZGU5YjQyODA0YTQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzAuMzExMzg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJlYmY4YWM1YzJhODM0YWEwODc1ODAwMjJm
-        ZTJlZjkwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjQ5LjYy
-        NDExOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NDkuNjQ3
-        NTM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5Y2RjYzZiMzE0OWE0YmM3YWQwNDE5N2Iz
+        ODVhMzNjYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjMwLjM1
+        ODE5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MzAuMzg3
+        Njk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkNzgzMjgzLTY2YjYtNGVkOS1hYjUy
-        LTdiMjhlMjg1Y2I4OC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcwY2E1Y2VjLTQyMTMtNGMzYi05ZjQ2
+        LTVlNmRiODkwNjIyMi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:30 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkNzgz
-        MjgzLTY2YjYtNGVkOS1hYjUyLTdiMjhlMjg1Y2I4OC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcwY2E1
+        Y2VjLTQyMTMtNGMzYi05ZjQ2LTVlNmRiODkwNjIyMi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:49 GMT
+      - Fri, 29 Jul 2022 09:02:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ec95e62e49f412f9caaaa65e1175253
+      - a6dbbcaa5f6049fcb4cff893267bdf6d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzZmVmMmYwLTA2MmUtNGZh
-        MS1hZTFjLWY1ZjdjODNmNzEzMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzMjdmYjRjLTkxOTctNDQ4
+        Zi1iZDMwLWJjNjFkNTg3Yzk3YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c3fef2f0-062e-4fa1-ae1c-f5f7c83f7133/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f327fb4c-9197-448f-bd30-bc61d587c97a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:50 GMT
+      - Fri, 29 Jul 2022 09:02:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 97d2c192ac9e460b8681245070d1a56b
+      - be5da6dbe18847d8bee788c4292fa959
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzNmZWYyZjAtMDYy
-        ZS00ZmExLWFlMWMtZjVmN2M4M2Y3MTMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NDkuNzcxMzcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjMyN2ZiNGMtOTE5
+        Ny00NDhmLWJkMzAtYmM2MWQ1ODdjOTdhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzAuNDgzOTA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI2ZWM5NWU2MmU0OWY0MTJmOWNh
-        YWFhNjVlMTE3NTI1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjQ5LjgwMTI3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        NTAuNDYzODE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJhNmRiYmNhYTVmNjA0OWZjYjRj
+        ZmY4OTMyNjdiZGY2ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjMwLjUzNjM1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        MzEuOTgwNDMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzM0YjEzYzUzLWVlMDQtNDQ0ZS1iNzMyLTAzOWM3
-        ZDllNzA5Yi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNGIx
-        M2M1My1lZTA0LTQ0NGUtYjczMi0wMzljN2Q5ZTcwOWIvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNGQ3ODMyODMtNjZiNi00ZWQ5
-        LWFiNTItN2IyOGUyODVjYjg4LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS8yYWQ5OWQxNi1mZjFiLTRiMzktYjQ4Zi1lOWYwYzkz
+        MmRjMjkvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkOTlk
+        MTYtZmYxYi00YjM5LWI0OGYtZTlmMGM5MzJkYzI5LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcwY2E1Y2VjLTQyMTMtNGMzYi05
+        ZjQ2LTVlNmRiODkwNjIyMi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMzRiMTNjNTMtZWUwNC00NDRlLWI3MzItMDM5YzdkOWU3
-        MDliL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMmFkOTlkMTYtZmYxYi00YjM5LWI0OGYtZTlmMGM5MzJk
+        YzI5L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:50 GMT
+      - Fri, 29 Jul 2022 09:02:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 121e7a8f1f3146eca6b0a146a860fcb4
+      - 8ff24b06fcc64317a8aef107663cb450
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU3M2FjNzgxLTkyM2UtNDMy
-        NC1iMTAwLWE0M2U1NWMyNmIwNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0ZDdlZTRkLTU1NWYtNDcw
+        MC04ZWVjLWQzNmM3MTA1NzJlMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/573ac781-923e-4324-b100-a43e55c26b05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/84d7ee4d-555f-4700-8eec-d36c710572e2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:51 GMT
+      - Fri, 29 Jul 2022 09:02:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e722479eb3ac455da111571c7b9823e6
+      - edf0bd69e1e5492d958870d70a822a2d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '473'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTczYWM3ODEtOTIz
-        ZS00MzI0LWIxMDAtYTQzZTU1YzI2YjA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTAuNzIwMjcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODRkN2VlNGQtNTU1
+        Zi00NzAwLThlZWMtZDM2YzcxMDU3MmUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzIuMzkyNjgzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjEyMWU3YThmMWYzMTQ2ZWNhNmIwYTE0NmE4
-        NjBmY2I0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6NTAuNzU0
-        MDI1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzozMDo1MS4wMTUw
-        OTRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjhmZjI0YjA2ZmNjNjQzMTdhOGFlZjEwNzY2
+        M2NiNDUwIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MzIuNDMw
+        NDY1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMjozMi44NDA0
+        MDhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjU5MmRh
-        NTMtMjUyYy00OTc5LWI4ZTEtZmM2ZTg3MTBjYzk4LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMjQyMGJm
+        NmUtMTEzOC00NjY5LTg0ZjEtZTBjZmJjODI4OWYyLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMzRiMTNjNTMtZWUwNC00NDRlLWI3MzItMDM5Yzdk
-        OWU3MDliLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMmFkOTlkMTYtZmYxYi00YjM5LWI0OGYtZTlmMGM5
+        MzJkYzI5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:51 GMT
+      - Fri, 29 Jul 2022 09:02:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 333f05491d6b4d44abc1e9007e45aeaf
+      - 19bac6e7b21a4486b242d7926834ba05
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/2420bf6e-1138-4669-84f1-e0cfbc8289f2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5697b691b75f44ba8c6bd23affec79f2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMjQyMGJmNmUtMTEzOC00NjY5LTg0ZjEtZTBjZmJjODI4OWYyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MzIuNDUyNDE1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8yYWQ5OWQxNi1mZjFiLTRiMzktYjQ4Zi1lOWYwYzkzMmRjMjkv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzJhZDk5ZDE2LWZmMWItNGIzOS1iNDhmLWU5ZjBj
+        OTMyZGMyOS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:33 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8yNDIwYmY2ZS0xMTM4LTQ2NjktODRmMS1lMGNmYmM4Mjg5ZjIv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f2d87f704ea340c9afc5bbc5e4ab39aa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVkMGViNjFlLThjMjQtNGYw
+        Ny04YjM4LTZhYmQ2MWVkOWY2YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5d0eb61e-8c24-4f07-8b38-6abd61ed9f6a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a8dca82d91c64f6d9cbb4dbe37993c9f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWQwZWI2MWUtOGMy
+        NC00ZjA3LThiMzgtNmFiZDYxZWQ5ZjZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzMuMDg2ODMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmMmQ4N2Y3MDRlYTM0MGM5YWZjNWJiYzVl
+        NGFiMzlhYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjMzLjEz
+        MjQ4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MzMuNDY3
+        NDcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMGRm
+        MzY5YTMtMDE5Yy00OThkLWE3YWMtNzgxOGNkNGIzOWRjLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/0df369a3-019c-498d-a7ac-7818cd4b39dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ec91317f2bf54ef4bf9954c43f2b28d6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzBkZjM2OWEzLTAxOWMtNDk4ZC1hN2FjLTc4MThjZDRiMzlkYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjMzLjQ0NjU2OFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMjQyMGJmNmUtMTEzOC00NjY5LTg0ZjEt
+        ZTBjZmJjODI4OWYyLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 90329e6e7f5445ce903edb40753ce43f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:51 GMT
+      - Fri, 29 Jul 2022 09:02:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 374bc4e096404658956348f6ce00e257
+      - 434ca1215fe545b9852b1f6f6aa66987
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:51 GMT
+      - Fri, 29 Jul 2022 09:02:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f6b59aedcf7d48d6a39534a86504b54c
+      - 71f941e5175c4fb8b21cab4c18bc6f74
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:51 GMT
+      - Fri, 29 Jul 2022 09:02:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8c85efefc1a54bbbb9aa4cd420ea7cda
+      - 939eaf78181840238b457096b13058ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:51 GMT
+      - Fri, 29 Jul 2022 09:02:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ae6674c4bb64a5f9c471a41db4f1486
+      - 5195c179d8004933a2519afd029d2dac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:51 GMT
+      - Fri, 29 Jul 2022 09:02:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 159f4777837f463f849cb6cec7c1ca08
+      - c614448984bc4dfbb2426de5afbe7dd9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:51 GMT
+      - Fri, 29 Jul 2022 09:02:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db1791dc9b37499da2620fdd1a034922
+      - 39dda6b91855424aa4d7a8b1393b5fd7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d3cc863c617483ab84c48bd1bd69512
+      - 2178bf63509a4ae692b63c7b297a5705
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f37b35830b834a50842a3c05b93d1c5a
+      - ad05828c70a34bc28582f4cbb8f7d3d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e530f5a907d41e0ab678a80323de9a5
+      - 68d98e5346644f0d9d54b0ff9450a7ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11f4b098c6924f638f15b7b220444974
+      - fa2d62cae9c84af2b5e3d0fbf985776a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c7c0b5f4e116432c8c873824cf7c6602
+      - d6c5aca96fc64507b897bb1b9c342a57
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - adc87838b5d14956bf19201e4dbbeedf
+      - 494727dc943649ef9ac6d4b6519e9a1e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/34b13c53-ee04-444e-b732-039c7d9e709b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e58e3576cc454120bfe33e024efe37c3
+      - b735fc52d1c641108d1e107b8f980149
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,94 +3819,94 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa89549fda8a429b803cad124dc62e68
+      - cac5b0a3cd8444659b8ad23e85ecd67a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwZTljZjVlLTI2OTItNDBm
-        OS05M2EyLWFmZTNjNmJlM2ZkNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxNzAwZGNjLTNkYTctNGNm
+        NC1iNmU2LTRlZmM1NGRlOWFmYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8wMTJlMDA1OS0zZGE0LTRjNGUtOWVmNy1kMDhlMTM4
-        Njg0ZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        MjFhNDk3NzEtODJmMy00MWQ4LTk3YTgtZDQ5NDM5MTgxNzAzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUt
-        NDMzYy1hM2NkLTY0MWMxMDA5NTExMy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEw
-        NmE0Y2Y5NTAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQtZDcxNTNhZDc4NDIyLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQy
-        M2QtNDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1
-        ZC1iODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzRlNTYxMGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZm
-        Mzg3Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2
-        OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQx
-        Ny05NjA1LTc0OTY2ZTNlYzY5Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzL2M5YTY1ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0
-        YWNlZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0
-        ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2
-        LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2Vncm91cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYt
-        ZmQyZTcxYTZkYWEzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUw
-        ZjUtNGQ3Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2
-        N2U1OTNlZDMzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yOWU2YTIxZC0yZjY5LTRjZDItYjcxMS02MWNjODljZjcwY2UvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM3YzM4MGEwLWFhZmYt
-        NDNmMi05YTZkLTdhMjUyYjA5YWE5Ni8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkw
-        ZWZhN2VmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80
-        OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2MvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUwYzgyZTlkLWFmODktNDMx
-        My1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZj
-        ODVkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83NjA4
-        Y2UzNy0xYzcxLTRhZDAtOTBhYy1lZWQ3NDYwYzU2MWIvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1h
-        YjM5LTgwZDAyMTliZDQ4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvOGIyNTE3MzgtNmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZm
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThjNWEtNDgwMS1iNTY3
-        LTFmMmIxZGI3M2RlYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvYTE5ZTQ3Y2ItZDZkNi00MmVhLTk3MzItMzI4NTIxNjQyNDJlLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jYmIzODQ4Ny05
-        Njc3LTRhNDMtODNlMy00MzkwYjNkMjA1YjQvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZm
-        ODUwYjkyNmU1Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZjA3NzkyYzMtYTQyZC00NzBjLWEyNjAtYmViYTYyMDAzNDlmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2Ex
-        LTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZjQ3YTNmZTYtMmM0Ni00M2Vk
-        LWJlZjQtZDMxMjQ0MTFiZDI0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZm
-        LWM5NTMxYzI0OWFkYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUzYThj
-        ZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
-        ZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3NjQ4NmIv
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQy
+        OTI5My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNi
+        MDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3
+        OC1hZGMwLWVlODY3OGFkMTkxOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2
+        NWQ3NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Jj
+        Zjc5ZTI4LWNkNDAtNDgxNS04OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYx
+        LTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2Vncm91cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAt
+        MzllZTE5M2Y5MjBhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1kODliN2IwMWQ4NDYvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0
+        YzgtNDU5Mi04Mzg0LWIyNzZmZmE3ZTgyNi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMzViYmEwMGItNmYxNi00M2MxLTgxYTUtN2Vl
+        OTYyMWRjZTIyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy80NjAxOTJmYy03ZWZmLTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEt
+        NDA5MC05YWZmLTczYTQ0NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0
+        OTU0ZWVkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81
+        YTMyODQyNi0yYmFmLTQxODktOWNjNS02ZDhkYzM1YzEwZDQvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQtNGU0
+        Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNjVmYmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4
+        YWM3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4
+        M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04
+        MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNhMzhh
+        Mi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJi
+        LTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02
+        MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0
+        MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMx
+        LTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4
+        LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
+        dWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQtZjIwM2Nh
+        MzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
+        ZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDliODIzMjMv
         IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRz
-        L2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8iXX0=
+        L2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3494,7 +3919,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3512,21 +3937,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3cca12794472487ca2dbaf31ae92840d
+      - 30c4cc438304471e8e06cc20323db14c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4YzlhN2Y0LWI0ZTMtNGYx
-        Yy04OTZmLWZhMTE4MzNhM2QxNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZhNDI4NjZiLTBhODktNDk3
+        Yi04MzdhLWI5OTZlMDdmZmQ5ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/18c9a7f4-b4e3-4f1c-896f-fa11833a3d14/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6a42866b-0a89-497b-837a-b996e07ffd9d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3547,53 +3972,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:52 GMT
+      - Fri, 29 Jul 2022 09:02:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 888d5a8fe5ff4767848b9bf393d6fa73
+      - 492aee0c9d8b4ba0a2639b7c62081404
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMThjOWE3ZjQtYjRl
-        My00ZjFjLTg5NmYtZmExMTgzM2EzZDE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6NTIuNDQ2MDc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmE0Mjg2NmItMGE4
+        OS00OTdiLTgzN2EtYjk5NmUwN2ZmZDlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzUuNTMyMDE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzY2NhMTI3OTQ0NzI0ODdjYTJk
-        YmFmMzFhZTkyODQwZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjUyLjU4NjI0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        NTIuNzUzODU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMGM0Y2M0MzgzMDQ0NzFlOGUw
+        NmNjMjAzMjNkYjE0YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjM1Ljc5MTE1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        MzYuMDU5MTA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82YTMxZmE2NC1mNGJmLTQyMTAtOGI1Yy1iYzUyNzU4NDA2ZjUvdmVyc2lv
+        bS82ZWM1OTc5My1kYzZkLTRmNWUtODBkOC0wZTVmYzY2MmRiMDIvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmEzMWZhNjQtZjRiZi00MjEw
-        LThiNWMtYmM1Mjc1ODQwNmY1LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmVjNTk3OTMtZGM2ZC00ZjVl
+        LTgwZDgtMGU1ZmM2NjJkYjAyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3601,7 +4026,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3614,74 +4039,74 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:53 GMT
+      - Fri, 29 Jul 2022 09:02:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1636'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f3034f90efb44a25ae964f3d5775cdbc
+      - b936c590cf5845e3bb3fd3463259dd85
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '541'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTgsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
-        NTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2Ji
-        Mzg0ODctOTY3Ny00YTQzLTgzZTMtNDM5MGIzZDIwNWI0LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhiMjUx
-        NzM4LTZhNDgtNDNjYi1iNzlhLWYwYWM5NjYyNWRmZi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQt
-        MmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThj
-        NWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZm
-        LTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMDNmOGVlNGYtNWI3MS00
-        MTU1LWE0NzMtZjc5YzU1MDQzMWUzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZjMmFlODJlLWI3YTEtNGQ2
-        Zi1iNjNkLWNlNzFlZmU1NmM1YS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83NjA4Y2UzNy0xYzcxLTRhZDAt
-        OTBhYy1lZWQ3NDYwYzU2MWIvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvZjA3NzkyYzMtYTQyZC00NzBjLWEy
-        NjAtYmViYTYyMDAzNDlmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMy
-        LTMyODUyMTY0MjQyZS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1m
-        Zjg1MGI5MjZlNWMvIn1dfQ==
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMtNGFj
+        Yy05ZTE5LTg0YjljNDk1NGVlZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEyLTQxZDEt
+        YThkZi1mZDg0M2E3ZWQ1YTgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjkxMmM5MDUtNjFmNS00NzJiLThl
+        OTEtMzZlYzhmYzM1MDQ4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJk
+        LWQ4OWI3YjAxZDg0Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1i
+        Mjc2ZmZhN2U4MjYvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3689,7 +4114,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3702,49 +4127,49 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:53 GMT
+      - Fri, 29 Jul 2022 09:02:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '496'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9593a6076b34dd3be676a8ad5dd84ab
+      - c3bced6463be4688bc95aa92ef97e686
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '242'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy9kNGZiODc4MS0zOTAzLTQ1NzAtOTNkYy0xNzYzMWNjNGY0Y2IvIn1d
+        ZW1kcy82MjUxNWU4NS0wNTU1LTRiNTktODQzYy0wNWU4MDU1NjVkNzQvIn1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3752,7 +4177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3765,37 +4190,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:53 GMT
+      - Fri, 29 Jul 2022 09:02:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '7483'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 87884ec463ba41c5a4c99c53724d0ddd
+      - ac3674354b614231b95bac08dc46476a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1858'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3868,9 +4293,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3886,8 +4311,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -3905,9 +4330,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -3929,9 +4354,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -3947,9 +4372,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -3959,10 +4384,10 @@ http_interactions:
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3970,7 +4395,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3983,43 +4408,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:53 GMT
+      - Fri, 29 Jul 2022 09:02:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1c9d88a9acc34568b43188d15ebf95f7
+      - d37b27695f444dabb154a0d9ad02861b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4027,7 +4452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4040,41 +4465,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:53 GMT
+      - Fri, 29 Jul 2022 09:02:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7acd4e3dc74648aa978113174edf3df6
+      - df615d2a2ad94aa18c7ef4ffc432c3ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6a31fa64-f4bf-4210-8b5c-bc52758406f5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4082,7 +4507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4095,36 +4520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:53 GMT
+      - Fri, 29 Jul 2022 09:02:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25e180ab57444a35863f1c71c2031ef0
+      - b16c97e79a864df9ba4112dd2d035347
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4146,5 +4571,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:37 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_modulemd_defaults_repository/all_modulemd_defaults_are_copied_by_default.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_modulemd_defaults_repository/all_modulemd_defaults_are_copied_by_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:57 GMT
+      - Fri, 29 Jul 2022 09:02:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,27 +35,94 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0423fb37bb914b7dbf93438bd8b7460b
+      - 18a0fed665da401bad00c3ce26f06d95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8yYWQ5OWQxNi1mZjFiLTRiMzktYjQ4Zi1lOWYwYzkzMmRjMjkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjoyOC44MzgzOTda
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8yYWQ5OWQxNi1mZjFiLTRiMzktYjQ4Zi1lOWYwYzkzMmRjMjkv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJhZDk5
+        ZDE2LWZmMWItNGIzOS1iNDhmLWU5ZjBjOTMyZGMyOS92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
+        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
+        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
+        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
+        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
+        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
+        ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:38 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2ad99d16-ff1b-4b39-b48f-e9f0c932dc29/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6ed34db33ada49b4903e15bf77551f32
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3MGIwZWY0LTRjNzctNDk1
+        Mi04Nzc0LWIyNTE1ZWY1NGM4Ni8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:57 GMT
+      - Fri, 29 Jul 2022 09:02:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e7a8fe706ee414aaa2ad9a8b474afcb
+      - 0f12a8f5652a4ec28de72e09f44581ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/070b0ef4-4c77-4952-8774-b2515ef54c86/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:57 GMT
+      - Fri, 29 Jul 2022 09:02:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -137,31 +204,43 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 84755cc9ef874a1393437319e6f90ab1
+      - 7edd0c4bc1bc47ffa52cafd827ef8a84
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDcwYjBlZjQtNGM3
+        Ny00OTUyLTg3NzQtYjI1MTVlZjU0Yzg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzguNDgwMTYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZWQzNGRiMzNhZGE0OWI0OTAzZTE1YmY3
+        NzU1MWYzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjM4LjUy
+        NDgyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MzguNzM2
+        MTgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkOTlkMTYtZmYxYi00YjM5
+        LWI0OGYtZTlmMGM5MzJkYzI5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:57 GMT
+      - Fri, 29 Jul 2022 09:02:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d63ce2148034f1bb9a7cf22af8106ef
+      - 48bb109ec894481b879187aa57f589be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -222,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -235,7 +314,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:57 GMT
+      - Fri, 29 Jul 2022 09:02:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -247,27 +326,88 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '448'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 935885bcf7014631ab80b9c0350a76e8
+      - fbc38f44920b44a29652566f9a258ef4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMGRmMzY5YTMtMDE5Yy00OThkLWE3YWMtNzgxOGNkNGIzOWRj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MzMuNDQ2NTY4
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:38 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/0df369a3-019c-498d-a7ac-7818cd4b39dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ab552f756dc54ab1b964d07258e99597
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I0YTQ5ZThjLTZhNTMtNDJh
+        NC05MjJhLWI4NjcyODNkYjlhNy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b4a49e8c-6a53-42a4-922a-b867283db9a7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -275,7 +415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -288,7 +428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:57 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -296,31 +436,42 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c661ed10dbd14eda8fc8d05d575a8d7c
+      - b74ba0c43f3a4452b4cc61d056cd182b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjRhNDllOGMtNmE1
+        My00MmE0LTkyMmEtYjg2NzI4M2RiOWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzguOTI4MzUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhYjU1MmY3NTZkYzU0YWIxYjk2NGQwNzI1
+        OGU5OTU5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjM4Ljk3
+        MDcwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MzkuMDEy
+        MzA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -328,7 +479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -341,7 +492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:57 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -359,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95b34d88ee164912b82a6ca25cfe858c
+      - cf20cc039a4a4b308f544a65f167deb8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -381,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:57 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -412,21 +563,127 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6be7467c068e44079798eba14e9a14e5
+      - 4bd0486f9951482a9267bd38f1fd6928
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:57 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8fd7708c4d6b464a8397fe8e7f4f63ae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - '08825604430e4ffa89405cde471ed0aa'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -443,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -456,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/42f62ccf-34e7-4f18-84a8-1d1d34a627ee/"
+      - "/pulp/api/v3/remotes/rpm/rpm/c4038e25-d96a-44d5-8834-6178acebc610/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -476,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d5f8578554d42de88bf4d4d72a9a2d3
+      - e56f914870094f95937b3992025f1772
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQy
-        ZjYyY2NmLTM0ZTctNGYxOC04NGE4LTFkMWQzNGE2MjdlZS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjU4LjA0MzEzNVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M0
+        MDM4ZTI1LWQ5NmEtNDRkNS04ODM0LTYxNzhhY2ViYzYxMC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjM5LjM0ODM4NVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIzOjU4LjA0MzE1NVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAyOjM5LjM0ODQxMFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -511,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -524,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/"
+      - "/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -544,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f74b66da9e104e28be98706eb17c9e16
+      - da7c7a1d80824b508c970c60df4a0a58
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTg1MDczODktYzJkOC00OGI1LWI1ZjUtZWMyYTBkYmEwZTZjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NTguMjYxNjg1WiIsInZl
+        cG0vMzk3OTY2YjMtYzMzNi00MDk5LWE3OTctZjRiZDVmOWFhMTBlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MzkuNDg3ODA5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTg1MDczODktYzJkOC00OGI1LWI1ZjUtZWMyYTBkYmEwZTZjL3ZlcnNp
+        cG0vMzk3OTY2YjMtYzMzNi00MDk5LWE3OTctZjRiZDVmOWFhMTBlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ODUwNzM4OS1j
-        MmQ4LTQ4YjUtYjVmNS1lYzJhMGRiYTBlNmMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zOTc5NjZiMy1j
+        MzM2LTQwOTktYTc5Ny1mNGJkNWY5YWExMGUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -568,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -579,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -592,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce1642604ae44f139ad38cf2159e7dec
+      - e68a9cb8b3484bf5b856559bc8da3af8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '307'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzozOS4wMDA3Mjda
+        cnBtL3JwbS82ZWM1OTc5My1kYzZkLTRmNWUtODBkOC0wZTVmYzY2MmRiMDIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjoyOS45MTMxMTVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIv
+        cnBtL3JwbS82ZWM1OTc5My1kYzZkLTRmNWUtODBkOC0wZTVmYzY2MmRiMDIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzg3YWUx
-        YzA1LWYxNDYtNDE0Zi1iZmY2LWQxNDQ5YTQ4ZjBkMi92ZXJzaW9ucy82LyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZlYzU5
+        NzkzLWRjNmQtNGY1ZS04MGQ4LTBlNWZjNjYyZGIwMi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -634,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6ec59793-dc6d-4f5e-80d8-0e5fc662db02/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -645,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -658,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -676,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0cbd492fd600445680d8f076095887cd
+      - 0f488f514447401daed3c6e91d1269ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0YmFmYWUyLWFhNTYtNGRh
-        MC05MzY3LTNhYTVhYmY2ZWZlMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmYzg4MjBmLWQ4NWMtNGVj
+        ZS04ZWNlLTk2NWRjZGYyMjFmZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -698,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -711,7 +968,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -723,27 +980,92 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2dc7e7702c954fbc8fd0f5fadb245ffa
+      - 1c2a410a9016405e8576b51d6249cb3d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
+        cG0vNzBjYTVjZWMtNDIxMy00YzNiLTlmNDYtNWU2ZGI4OTA2MjIyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MjguNjkxMzYwWiIsIm5h
+        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
+        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
+        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
+        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        Mi0wNy0yOVQwOTowMjozMC4zODI0ODZaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
+        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
+        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
+        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/70ca5cec-4213-4c3b-9f46-5e6db8906222/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ca0ba7f777cd4f5e99f8c0f05b0dcc39
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlZTJkYzEzLTA0YzItNGE4
+        OC04NTA5LTBmOTc1NDBhYzU3NC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a4bafae2-aa56-4da0-9367-3aa5abf6efe1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4fc8820f-d85c-4ece-8ece-965dcdf221ff/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -764,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33c3cca39c334c86ad2882fa090f3a7a
+      - 1735a59944544687942783b7021a47a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTRiYWZhZTItYWE1
-        Ni00ZGEwLTkzNjctM2FhNWFiZjZlZmUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTguNDQxMzQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGZjODgyMGYtZDg1
+        Yy00ZWNlLThlY2UtOTY1ZGNkZjIyMWZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzkuNzAwMjA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwY2JkNDkyZmQ2MDA0NDU2ODBkOGYwNzYw
-        OTU4ODdjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjU4LjQ3
-        MzMzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NTguNTI5
-        ODY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZjQ4OGY1MTQ0NDc0MDFkYWVkM2M2ZTkx
+        ZDEyNjllZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjM5Ljcz
+        NjAwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MzkuODU0
+        NDM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmVjNTk3OTMtZGM2ZC00ZjVl
+        LTgwZDgtMGU1ZmM2NjJkYjAyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3ee2dc13-04c2-4a88-8509-0f97540ac574/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -816,7 +1138,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -829,7 +1151,72 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 24031b293d684dc1a27fe4cab3468ac7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2VlMmRjMTMtMDRj
+        Mi00YTg4LTg1MDktMGY5NzU0MGFjNTc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6MzkuODE1Njk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjYTBiYTdmNzc3Y2Q0ZjVlOTlmOGMwZjA1
+        YjBkY2MzOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjM5Ljg5
+        MjE0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6MzkuOTQ4
+        OTY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcwY2E1Y2VjLTQyMTMtNGMzYi05ZjQ2
+        LTVlNmRiODkwNjIyMi8iXX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -847,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d19ac4a931544644b190161bde3f5811
+      - 7595ed7c344b4ce4a5ada810355fe228
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -869,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -882,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -900,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 87b10067cb184aeeb9e28f78d6b3a0ed
+      - b2ef6013462a469099184eb9c1ff10c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -922,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -935,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -953,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96b03903a96d4715b4b335dd503c6d87
+      - '0503210673584f41a1e08e0062f3e902'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -975,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -988,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1006,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f63096294381424cae5fb99fd1f7e25b
+      - bd1550762d0646ea8717d7bc35800736
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1028,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1059,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a885a16ca0ae46d7b74f55a0932a0c8c
+      - 6a2ad56e6391450b977dddd742da2f58
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1081,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1094,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:58 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1112,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea6ecc07d6794d1f9da9b19cd14c1829
+      - af386f7436d94e85bd14a9433e4e2ec5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:58 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1136,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1149,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:59 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/ceca5ebe-5340-4716-9796-ede9092faaf3/"
+      - "/pulp/api/v3/repositories/rpm/rpm/a8670be1-33d1-479a-a1ef-27a0a932a251/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1169,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f742349913144242b824f11961f73261
+      - 265cd4c79f5543c08b9000831fdfc3ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vY2VjYTVlYmUtNTM0MC00NzE2LTk3OTYtZWRlOTA5MmZhYWYzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NTkuMDUxNzYzWiIsInZl
+        cG0vYTg2NzBiZTEtMzNkMS00NzlhLWExZWYtMjdhMGE5MzJhMjUxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NDAuMzkzOTAxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vY2VjYTVlYmUtNTM0MC00NzE2LTk3OTYtZWRlOTA5MmZhYWYzL3ZlcnNp
+        cG0vYTg2NzBiZTEtMzNkMS00NzlhLWExZWYtMjdhMGE5MzJhMjUxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jZWNhNWViZS01
-        MzQwLTQ3MTYtOTc5Ni1lZGU5MDkyZmFhZjMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hODY3MGJlMS0z
+        M2QxLTQ3OWEtYTFlZi0yN2EwYTkzMmEyNTEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1192,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/42f62ccf-34e7-4f18-84a8-1d1d34a627ee/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c4038e25-d96a-44d5-8834-6178acebc610/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1212,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1225,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:59 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1243,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f45339fb5254cfe9fc3e3a2867ab485
+      - ba4b0b78b04948cd83db4047928d3b33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3MzE1YWM1LTljYmEtNDNm
-        MS1hN2ZkLWEwNGU4YTlhMmVjMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyYmIyZTgyLTdhZGQtNDc0
+        OS05YjE3LWVjOWJkMjcwYzA0My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/37315ac5-9cba-43f1-a7fd-a04e8a9a2ec3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/42bb2e82-7add-4749-9b17-ec9bd270c043/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1278,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:59 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 666e103e5435482ca898ef595274f5a2
+      - b37b48cf515c49e39ff8b5c444c7c680
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzczMTVhYzUtOWNi
-        YS00M2YxLWE3ZmQtYTA0ZThhOWEyZWMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTkuNDAyMDg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDJiYjJlODItN2Fk
+        ZC00NzQ5LTliMTctZWM5YmQyNzBjMDQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NDAuNzQyMTIwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwZjQ1MzM5ZmI1MjU0Y2ZlOWZjM2UzYTI4
-        NjdhYjQ4NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjU5LjQz
-        MzYwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NTkuNDU3
-        MTEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiYTRiMGI3OGIwNDk0OGNkODNkYjQwNDc5
+        MjhkM2IzMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjQwLjc4
+        Nzc3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NDAuODEx
+        NjIzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQyZjYyY2NmLTM0ZTctNGYxOC04NGE4
-        LTFkMWQzNGE2MjdlZS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M0MDM4ZTI1LWQ5NmEtNDRkNS04ODM0
+        LTYxNzhhY2ViYzYxMC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQyZjYy
-        Y2NmLTM0ZTctNGYxOC04NGE4LTFkMWQzNGE2MjdlZS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M0MDM4
+        ZTI1LWQ5NmEtNDRkNS04ODM0LTYxNzhhY2ViYzYxMC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1347,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:59 GMT
+      - Fri, 29 Jul 2022 09:02:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1365,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f6ab1d21abb34418a0653df262ea7fd3
+      - 531732ddd93047abb2ae065c272a0498
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5ZWE0Zjk5LTg0M2MtNGY0
-        ZC05MjcyLTNhMWNkYjQ5ZjM2MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2Y2M4OTVkLTM2M2EtNGI1
+        ZS04M2I5LTk0N2ZkMDE3OGFkYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:59 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/09ea4f99-843c-4f4d-9272-3a1cdb49f360/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f6cc895d-363a-4b5e-83b9-947fd0178ada/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1400,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:00 GMT
+      - Fri, 29 Jul 2022 09:02:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7397859de9734508a3b16a08f3e83954
+      - ad98f2966d394e3aa902764f5d5a63d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '656'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDllYTRmOTktODQz
-        Yy00ZjRkLTkyNzItM2ExY2RiNDlmMzYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTkuNjE3NzAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjZjYzg5NWQtMzYz
+        YS00YjVlLTgzYjktOTQ3ZmQwMTc4YWRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NDAuOTA2MjkwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmNmFiMWQyMWFiYjM0NDE4YTA2
-        NTNkZjI2MmVhN2ZkMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjU5LjY0ODc2N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        MDAuNDMzOTczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI1MzE3MzJkZGQ5MzA0N2FiYjJh
+        ZTA2NWMyNzJhMDQ5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjQwLjk1MDcwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        NDIuMTI2NTI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
         IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
-        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
-        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
-        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
-        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzU4NTA3Mzg5LWMyZDgtNDhiNS1iNWY1LWVjMmEw
-        ZGJhMGU2Yy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ODUw
-        NzM4OS1jMmQ4LTQ4YjUtYjVmNS1lYzJhMGRiYTBlNmMvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNDJmNjJjY2YtMzRlNy00ZjE4
-        LTg0YTgtMWQxZDM0YTYyN2VlLyJdfQ==
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1v
+        ZHVsZW1kIiwiY29kZSI6InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNv
+        ZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9
+        LHsibWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBh
+        cnNpbmcucGFja2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoy
+        MCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2Vk
+        IENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoi
+        Y29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0s
+        eyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5w
+        YXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        Ijo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFz
+        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo0Miwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS8zOTc5NjZiMy1jMzM2LTQwOTktYTc5Ny1mNGJkNWY5
+        YWExMGUvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzk3OTY2
+        YjMtYzMzNi00MDk5LWE3OTctZjRiZDVmOWFhMTBlLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M0MDM4ZTI1LWQ5NmEtNDRkNS04
+        ODM0LTYxNzhhY2ViYzYxMC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNTg1MDczODktYzJkOC00OGI1LWI1ZjUtZWMyYTBkYmEw
-        ZTZjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMzk3OTY2YjMtYzMzNi00MDk5LWE3OTctZjRiZDVmOWFh
+        MTBlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1496,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:00 GMT
+      - Fri, 29 Jul 2022 09:02:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1514,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c71d1dd9cae74cbeb2bb1b1a1b6e61d0
+      - 544b1d80664c4b5f9416e4bb50f1050e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMzZDljMTRhLTI1NmUtNDM1
-        OS04OTQ4LWIwOGFhMmQ4Y2I1NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0YTA0NTE2LTVkYjQtNGU3
+        MS1hYjdlLTFmYzVlNDAxZGFkNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:00 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/33d9c14a-256e-4359-8948-b08aa2d8cb55/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/04a04516-5db4-4e71-ab7e-1fc5e401dad7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1549,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c97c29723c234f61b4aa3b9eb4cd0842
+      - 39c1eea4bdd24cf19fd2b748be51b968
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzNkOWMxNGEtMjU2
-        ZS00MzU5LTg5NDgtYjA4YWEyZDhjYjU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MDAuNzMyNjQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDRhMDQ1MTYtNWRi
+        NC00ZTcxLWFiN2UtMWZjNWU0MDFkYWQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NDIuODUwMzY0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImM3MWQxZGQ5Y2FlNzRjYmViMmJiMWIxYTFi
-        NmU2MWQwIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MDAuNzY2
-        MTc5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDowMS4wMTY1
-        NjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjU0NGIxZDgwNjY0YzRiNWY5NDE2ZTRiYjUw
+        ZjEwNTBlIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NDIuOTA3
+        OTk5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMjo0My4yOTMw
+        MDZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzc2Mjgz
-        ZTEtOTk1My00YzNjLTlkMTItOGMzNjE2NjJkYjM0LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMzI2YTAy
+        ZTQtNTU2My00ZGRiLTk0OGQtYTU4ZjUyYWVmNTQ3LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNTg1MDczODktYzJkOC00OGI1LWI1ZjUtZWMyYTBk
-        YmEwZTZjLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMzk3OTY2YjMtYzMzNi00MDk5LWE3OTctZjRiZDVm
+        OWFhMTBlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1606,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1619,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 60fae25727674730b9de26d8dac154ac
+      - cb2336a5f87e453d9806205fd93ac6d8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1945'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:43 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/326a02e4-5563-4ddb-948d-a58f52aef547/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fbae068a0966412a91b9c01f0b9c3eac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMzI2YTAyZTQtNTU2My00ZGRiLTk0OGQtYTU4ZjUyYWVmNTQ3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NDIuOTI4MjM1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8zOTc5NjZiMy1jMzM2LTQwOTktYTc5Ny1mNGJkNWY5YWExMGUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzM5Nzk2NmIzLWMzMzYtNDA5OS1hNzk3LWY0YmQ1
+        ZjlhYTEwZS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:43 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8zMjZhMDJlNC01NTYzLTRkZGItOTQ4ZC1hNThmNTJhZWY1NDcv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c6ce74060427464eb03096a28be3d2c5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU3ZTgzYzc0LTgwYjEtNGU2
+        Mi04NDJkLThiNTZkYjE3Y2EwNi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:43 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/57e83c74-80b1-4e62-842d-8b56db17ca06/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - '0844053a63fe453ead8982bc3b8e5133'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTdlODNjNzQtODBi
+        MS00ZTYyLTg0MmQtOGI1NmRiMTdjYTA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NDMuNTc1OTY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJjNmNlNzQwNjA0Mjc0NjRlYjAzMDk2YTI4
+        YmUzZDJjNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjQzLjYx
+        NDI0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NDMuOTQ5
+        NTMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vOTA3
+        MGQ0ZjYtMTcyYi00NmRjLWIxMDAtOWQ0NGUxNzkzOGNiLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:43 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/9070d4f6-172b-46dc-b100-9d44e17938cb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 01a1143a26574efc9d0c4b1aac775187
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzkwNzBkNGY2LTE3MmItNDZkYy1iMTAwLTlkNDRlMTc5MzhjYi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjQzLjkzMjUxNVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMzI2YTAyZTQtNTU2My00ZGRiLTk0OGQt
+        YTU4ZjUyYWVmNTQ3LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:44 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7f7111a60f2e4a98808dfc2288f83d67
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNDFjODA3ZDgtMzE5Yi00OGY5LWE1MTAtYTRlMTVkMjBmYjM3
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1655,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNTZhZDg0NC04NzU2LTQ5OTYt
-        YTY4MC1lOGEyNDc0YzJlMjMvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNi
-        OGYwNjg4LTI2ODMtNGJlOS05NjRlLTlkYmU3YjFlZjNmZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1672,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2E0Y2EyNDhiLTA5OGYtNDE2Yi04MzVlLTJk
-        ZWVhYjU5OTVkZS8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvODRhZGIyYmMtZjZmNi00NzM3LTllNDgtNjJjNzYyZGU0OTAwLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFiMDJmY2NmLTc1MjUtNDc0
-        Zi1iYzQ2LWE5YWNjYmUwNDZkNy8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2JiMjAwNDk1LTg0ZjItNGUxOS1iYzE0LWIyMWJhZWVhMTY2OC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hOTY2MDc2MC1mMzE0LTQ3ZDItODkwYS0yNjA0
-        MDVlYjM4N2QvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        YzkxNjRlOS05ZTYxLTQ0NDctYmJkOC1iZDgxMGZlNTU1NzMvIiwibmFtZSI6
-        ImdpcmFmZmUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlk
-        YTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIy
-        MDA5ZjlmMTQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFm
-        ZmUiLCJsb2NhdGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzBjYjE1YWEtZTg1Yi00MzFkLThi
-        ZDgtYTM2NzFiNTIwNjQxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2
-        MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVm
-        IjoiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
-        bHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8xMzE2YjFhZS0yZGU0LTQzZDgtODJkNS05YmI1YjU1OGRiODQv
-        IiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMz
-        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
-        YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTFlMmU0ZTgtODcyYy00
-        MmY2LWEwMDItNjlmZWU4NTYxZjIzLyIsIm5hbWUiOiJkdWNrIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4
-        MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hyZWYiOiJk
-        dWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZHVjay0w
-        LjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMDE1OTE1MTkt
-        YjY4NS00NDg4LWJiYTMtYjMwMzhmZTgzOGQ2LyIsIm5hbWUiOiJjaGVldGFo
-        IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0MjJkMGJhYTBjZDlkNzcxM2Fl
-        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwibG9j
-        YXRpb25faHJlZiI6ImNoZWV0YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6ImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2ZhNTczZmNmLWM5MWYtNGRjMS04YzBlLWZmYjM1
-        NDU4ZGIzOS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjIuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiYWJmNjkxZWU1YjQ4ZTQ0NjMyNjg1OWI4ZDhhOGRmMmEyNDExYjdl
-        ZGEyYzA4ZDA1ODllNmYzZDhkMWZmMzk5ZiIsInN1bW1hcnkiOiJGYWtlIHBy
-        b3ZpZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRp
-        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRp
-        bGxvLTIuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjUz
-        ZTY4MzgtNDgwNC00OWU0LWIwNTYtNzVjZDA1MTNhODQ4LyIsIm5hbWUiOiJh
-        cm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4ZDMxOTkwNWVlZGI1
-        YTUyNDdlM2EzNTI1ODg5YTI4ZDVkNjRlODIyMDA3NDEzZDAyNTg3YjZmNTFh
-        YjNiNjVhIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxv
-        LiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMC4yLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMzU5MjEzNy1mOTYwLTRiYzAtODA4
-        MS1lMjRlN2Q0MzcyNDMvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6ImFmNDc4MTMyZjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3
-        YzQ4ZjJkMjliN2M2ZTliYmE4OThhNjFkZGMyN2I1ODkiLCJzdW1tYXJ5Ijoi
-        RmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6
-        ImFybWFkaWxsby0wLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
-        ImFybWFkaWxsby0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZmODUwYjkyNmU1Yy8iLCJu
-        YW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWVhOTFkNzNk
-        OGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5MzlkNTdm
-        Yzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgdHJv
-        dXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4xMi0xLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0xLnNyYy5ycG0iLCJpc19t
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
         b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvOTNmMjgyYzMtMmQ5Mi00ZDRiLWFhNWUtMjcy
-        Yjk3MzNkNzhkLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjgzM2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQx
-        YTg5YjBjNWE5YmY2MTBkZDYxMDNjZTRjYzgiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdh
-        cm9vLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fy
-        b28tMC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kNjYx
-        ZWU5Zi1lZWQ4LTQzNTAtOTFjMy1mY2ZiYjliNGI3MGMvIiwibmFtZSI6ImR1
-        Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC43IiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1YmQzNjNiODYwYWQ2NzgzMjE3
-        Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEy
-        Iiwic3VtbWFyeSI6IlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIs
-        ImxvY2F0aW9uX2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
-        ZmFsc2V9XX0=
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1820,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1833,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2e1e2d52e08488fafd9452c95689dd2
+      - ed12f1e444184719bea12b3b60a7f3a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2328'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNTQ5MTIwZjItNjZhZS00ZjczLWIzYjEtMjdhNjNlMjZjZTI5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNzAzMzU1
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -1873,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mYjA0
-        M2VlNi04NDI4LTQyNDItYjEyOC01YTVhZTA0NjQwNmYvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDFjODA3ZDgtMzE5
-        Yi00OGY5LWE1MTAtYTRlMTVkMjBmYjM3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMjMxNmU1NGItMTUz
-        OC00MTBmLTk2NTMtMjUxMGI1ODU4ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDQuNjk2NjEzWiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -1894,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy80Y2U0ODgyZC04YzI0LTQzZTAtOTBjZC04
-        YjZjMDEwNTNiNDMvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMDU2YWQ4NDQtODc1Ni00OTk2LWE2ODAtZThhMjQ3NGMy
-        ZTIzLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvMzJhNDQyNWEtNGM5Ni00NzZiLWI3YmQtZWVjYTlmZGIx
-        ZGE4LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNjg2
-        MDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -1914,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        MGE3NjVhNy0wYTc4LTQ0NDctODBlNS0zZjJhMzAwMDUwMzQvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTk2NjA3NjAt
-        ZjMxNC00N2QyLTg5MGEtMjYwNDA1ZWIzODdkLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMjUxZTI0MmEt
-        ODEzMi00YTdkLTljYmUtNTcxOTM4NWM1NWQwLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjM6NDQuNjg0ODQxWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -1935,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mMmI3N2NlMC0xMTFmLTQxNzQtYTU2
-        ZC01MjQyYTg4MDA3MGYvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOTNmMjgyYzMtMmQ5Mi00ZDRiLWFhNWUtMjcyYjk3
-        MzNkNzhkLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvM2E1MjYxYzMtZTA2Yi00NjQyLTg3NmEtZWZmOWVi
-        MjMzM2MwLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQu
-        NjcyMTcxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -1956,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy9iYzFmYjEwZi0wY2ZlLTRjM2MtOTFjYy1hZTczNDYxZDVlYmEvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q2NjFlZTlmLWVlZDgt
-        NDM1MC05MWMzLWZjZmJiOWI0YjcwYy8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U0ZGIxZWJkLWM0MmUt
-        NGQ0Ni1iYzY4LTM3NzM3MWYyZTcyYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjIzOjQ0LjY2OTkyMVoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -1976,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvNTk2ZTE0NzUtYjZmZi00M2E5LThkZDQtZTlk
-        ZGE3ZjZkZGFlLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy9lMWUyZTRlOC04NzJjLTQyZjYtYTAwMi02OWZlZTg1NjFmMjMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1995,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2008,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11e38b1777e24d359aa909be9bf00a9d
+      - bdc484d4a7cf482a854b6c9b5cc794b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzI2OTA1MGRmLWQ5ZDEtNGUxOS04ZDcyLWVjZDI5N2I3OWEw
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3OTMx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2111,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvNGVmZTVlOGYtYTBhYy00MjZjLThkZjUt
-        ODQzZThlMjY3NGM2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjM6NDQuNjczNDEwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2129,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzI1Njc1ZDQzLTAzYzUtNGNjMi04MTYxLTc1NTBjZGNkNGI5OS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY2NTAxMloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2148,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8xMDA0ODg2ZS0xYWNhLTQ0ZDMtOTRlNC1iZTJhNTQ4
-        YzM2ZmQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42
-        NTQ5MTRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2172,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzJlNzkyMzNiLWVhMDAtNDgxMC05ZDliLTNhNWE5
-        NTdlODEwMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0
-        LjY1Mzc2OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2190,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvNTBjZmM1MDgtMWUwZC00Y2RhLTlmNGQt
-        NDEyMjJhMTgxOTc3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjM6NDQuNjQ3MDIwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2201,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy81MDlmY2E4YS00Mzk3LTRjYWYtODU0OC0yODZh
-        YzcxMmU0Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0
-        NC42NDQzMTRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2232,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2243,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2256,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 85dc99a04d73490dbdad119897dde57e
+      - 4738d32c3e3844348fd268fd67dff5a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzhmNDNmNTNjLWE5NTQtNGU0MS1iMDNhLWIwNWY1MTU4
-        YzAxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3
-        Nzg5NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2323,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9iNjI3NmJlMC0zYmRjLTQyNWUtYTA4YS05
-        ZDA3ZjljN2ViYWYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Mzo0NC42NTEzODNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2335,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2346,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2359,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae1ffff7eea445dd9492d08dfaed5392
+      - b6b5e6594a3a4727a1d8c71f722afd02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '282'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy81NzEyODVlNi1hZTM0LTRhYmEtYmMzNC03OTUzYjc1Y2EyODkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2395,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2406,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2419,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 72784fd362cb4fc7ab723da51a99efa2
+      - b1d5313ca3c247adae2c793ac56374f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNGI0M2E4ODMtOGMzNi00MDVlLWJkNTktZmVm
-        ZTNiYWE2NjIyLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2470,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/8f43f53c-a954-4e41-b03a-b05f5158c017/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2481,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2494,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 293673afe7e347d0b24d85c104fdbc10
+      - 0e00915fa0b043af9561615b9133bb6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy84ZjQzZjUzYy1hOTU0LTRlNDEtYjAzYS1iMDVmNTE1OGMwMTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42Nzc4OTRa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2561,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/8f43f53c-a954-4e41-b03a-b05f5158c017/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2572,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2585,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:01 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2f8de441d3442f792072c5721b801df
+      - c0d662d8c6fe4ca6be7de43aa59a5de1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy84ZjQzZjUzYy1hOTU0LTRlNDEtYjAzYS1iMDVmNTE1OGMwMTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42Nzc4OTRa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2652,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:01 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/b6276be0-3bdc-425e-a08a-9d07f9c7ebaf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2663,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2676,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 660977bb582b423e93e6755e92f807da
+      - 73b1e679f4af43908c2890229f23af47
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9iNjI3NmJlMC0zYmRjLTQyNWUtYTA4YS05ZDA3ZjljN2ViYWYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42NTEzODNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2715,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/b6276be0-3bdc-425e-a08a-9d07f9c7ebaf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2726,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2739,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a36ecca3ccc14d91b865383b11f585ac
+      - a8f368f5fc7e4950adc02567a32795ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9iNjI3NmJlMC0zYmRjLTQyNWUtYTA4YS05ZDA3ZjljN2ViYWYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42NTEzODNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2778,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2789,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2802,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eccf3ed4112b4cf589d79dcc28195ded
+      - a357835e81264831923824c59bd1eaed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYWNmY2U5LTJjM2EtNDQ5NS04MGNhLWFm
-        MTlkYzA5MjI5ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ0LjY5MTY4N1oiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -2843,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvNDY2MTE4YmEtMmY5NC00ZGIxLWEwNTctZTAxM2VmNGYwMDAwLyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -2851,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2862,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2875,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 45d1ad3b01f44f93a67eb1e0f894e4b4
+      - bc4d56e5cfbd4f3f8cc371780615a806
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNGI0M2E4ODMtOGMzNi00MDVlLWJkNTktZmVm
-        ZTNiYWE2NjIyLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2926,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2937,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2950,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a43f1474fe7b451d822a0c4d3199fcd2
+      - '016929e4cfcd4722ba30bfdfb775a3bb'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzA1YjBhMDMxLTVhNGMtNDgyYS05ZDgzLWVh
-        ZTc4MTI3NzIxZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ0LjY2Mzc3NloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2998,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3011,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 182944829af14641b2a568f005e86872
+      - 900b91bda62d4f0bb8f09f10f044a365
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy9mZTNhYzZkNS1lMGQyLTRmYTQtOGEwMy1lNWZi
-        NjA1YTE0OGUvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0
-        NC42NjI1MjhaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3052,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzLzFmNDc2YTNjLWViNDgtNGRlZi05NDE5LWU4MzVkNzIyYjA0Yy8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvY2Y0NWNmMDktZDhiZC00YzdmLWE0MmEtNGQz
-        YzgxYzA2NjZkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDQuNjUyNjA0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3068,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9kMjk4YmY1Ni0yNDcxLTQ1ZWUtOTNhOC0zZDU0YzJjYTVkZTYvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy84M2NkNDA0Ni1lYWM3LTQwZWEtOTc4
-        NC00OGEwNTdiY2FkNzQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyMzo0NC42NTAxMzVaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3084,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzlhYzcyMTk4LTc1NWMtNDQxZi05ZTc3LTM4YmUwYmQ0NWMy
-        Ni8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ceca5ebe-5340-4716-9796-ede9092faaf3/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a8670be1-33d1-479a-a1ef-27a0a932a251/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3101,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3114,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3132,99 +3819,99 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 599622612eed49439c25e556b42c3254
+      - 7c5a0580e8d840e4a0270842f36f00a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2NTRhNGE5LTNhMDktNGJm
-        Yi04Njc3LWM2N2NiMmQzZDYxOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UwMWYxMzdkLTBjMTAtNGE5
+        Ni05NDJmLTFlNzc0ZDc4NWQ2Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ceca5ebe-5340-4716-9796-ede9092faaf3/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a8670be1-33d1-479a-a1ef-27a0a932a251/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8xMDA0ODg2ZS0xYWNhLTQ0ZDMtOTRlNC1iZTJhNTQ4
-        YzM2ZmQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        MjU2NzVkNDMtMDNjNS00Y2MyLTgxNjEtNzU1MGNkY2Q0Yjk5LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzI2OTA1MGRmLWQ5ZDEt
-        NGUxOS04ZDcyLWVjZDI5N2I3OWEwOS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy8yZTc5MjMzYi1lYTAwLTQ4MTAtOWQ5Yi0zYTVh
-        OTU3ZTgxMDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvNGVmZTVlOGYtYTBhYy00MjZjLThkZjUtODQzZThlMjY3NGM2LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzUwOWZjYThhLTQz
-        OTctNGNhZi04NTQ4LTI4NmFjNzEyZTRjYy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vYWR2aXNvcmllcy81MGNmYzUwOC0xZTBkLTRjZGEtOWY0ZC00
-        MTIyMmExODE5NzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
-        aWJ1dGlvbl90cmVlcy80YjQzYTg4My04YzM2LTQwNWUtYmQ1OS1mZWZlM2Jh
-        YTY2MjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8y
-        MzE2ZTU0Yi0xNTM4LTQxMGYtOTY1My0yNTEwYjU4NTg4NGEvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8yNTFlMjQyYS04MTMyLTRh
-        N2QtOWNiZS01NzE5Mzg1YzU1ZDAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy8zMmE0NDI1YS00Yzk2LTQ3NmItYjdiZC1lZWNhOWZk
-        YjFkYTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8z
-        YTUyNjFjMy1lMDZiLTQ2NDItODc2YS1lZmY5ZWIyMzMzYzAvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy81NDkxMjBmMi02NmFlLTRm
-        NzMtYjNiMS0yN2E2M2UyNmNlMjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy9lNGRiMWViZC1jNDJlLTRkNDYtYmM2OC0zNzczNzFm
-        MmU3MmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvOGY0M2Y1M2MtYTk1NC00ZTQxLWIwM2EtYjA1ZjUxNThjMDE3LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2I2Mjc2YmUw
-        LTNiZGMtNDI1ZS1hMDhhLTlkMDdmOWM3ZWJhZi8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMDE1OTE1MTktYjY4NS00NDg4LWJiYTMt
-        YjMwMzhmZTgzOGQ2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8wNTZhZDg0NC04NzU2LTQ5OTYtYTY4MC1lOGEyNDc0YzJlMjMvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzMTZiMWFlLTJk
-        ZTQtNDNkOC04MmQ1LTliYjViNTU4ZGI4NC8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMWIwMmZjY2YtNzUyNS00NzRmLWJjNDYtYTlh
-        Y2NiZTA0NmQ3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yNTNlNjgzOC00ODA0LTQ5ZTQtYjA1Ni03NWNkMDUxM2E4NDgvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzMwY2IxNWFhLWU4NWIt
-        NDMxZC04YmQ4LWEzNjcxYjUyMDY0MS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2I4ZjA2ODgtMjY4My00YmU5LTk2NGUtOWRiZTdi
-        MWVmM2ZlLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80
-        MWM4MDdkOC0zMTliLTQ4ZjktYTUxMC1hNGUxNWQyMGZiMzcvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzU3MTI4NWU2LWFlMzQtNGFi
-        YS1iYzM0LTc5NTNiNzVjYTI4OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvODRhZGIyYmMtZjZmNi00NzM3LTllNDgtNjJjNzYyZGU0
-        OTAwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85M2Yy
-        ODJjMy0yZDkyLTRkNGItYWE1ZS0yNzJiOTczM2Q3OGQvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E0Y2EyNDhiLTA5OGYtNDE2Yi04
-        MzVlLTJkZWVhYjU5OTVkZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvYTk2NjA3NjAtZjMxNC00N2QyLTg5MGEtMjYwNDA1ZWIzODdk
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iYjIwMDQ5
-        NS04NGYyLTRlMTktYmMxNC1iMjFiYWVlYTE2NjgvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QzNTkyMTM3LWY5NjAtNGJjMC04MDgx
-        LWUyNGU3ZDQzNzI0My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZDY2MWVlOWYtZWVkOC00MzUwLTkxYzMtZmNmYmI5YjRiNzBjLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMWUyZTRlOC04
-        NzJjLTQyZjYtYTAwMi02OWZlZTg1NjFmMjMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZm
-        ODUwYjkyNmU1Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZWM5MTY0ZTktOWU2MS00NDQ3LWJiZDgtYmQ4MTBmZTU1NTczLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYTU3M2ZjZi1jOTFm
-        LTRkYzEtOGMwZS1mZmIzNTQ1OGRiMzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFhY2ZjZTktMmMzYS00NDk1
-        LTgwY2EtYWYxOWRjMDkyMjlkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzA1YjBhMDMxLTVhNGMtNDgyYS05ZDgz
-        LWVhZTc4MTI3NzIxZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRfZGVmYXVsdHMvODNjZDQwNDYtZWFjNy00MGVhLTk3ODQtNDhhMDU3
-        YmNhZDc0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
-        ZWZhdWx0cy9jZjQ1Y2YwOS1kOGJkLTRjN2YtYTQyYS00ZDNjODFjMDY2NmQv
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1i
+        OTFkMDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
+        aWJ1dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRk
+        NTBhMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
+        Yzg0MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRl
+        OTktYmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3
+        YTExOTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8z
+        YjliOWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRi
+        NTktODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdh
+        YzAzODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0
+        LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvMDVlMzY4ZDctMjkxYS00MzM2LWFkYmQt
+        ZDg5YjdiMDFkODQ2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1iMjc2ZmZhN2U4MjYvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM1YmJhMDBiLTZm
+        MTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy80ODA2MDhjMS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMt
+        NGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1ZmJiOTc0LTE1MmMtNDk2
+        ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3
+        YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4
+        M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04
+        MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNhMzhh
+        Mi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJi
+        LTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02
+        MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0
+        MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMx
+        LTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4
+        LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
+        dWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQtZjIwM2Nh
+        MzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
+        ZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDliODIzMjMv
         IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRz
-        L2ZlM2FjNmQ1LWUwZDItNGZhNC04YTAzLWU1ZmI2MDVhMTQ4ZS8iXX0=
+        L2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3237,7 +3924,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3255,21 +3942,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 176fe8156b5d46c2ae9b38e0c1c55093
+      - 0bd29bbefccf4b149bd27b2ac721e284
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkMmMwM2E0LTg0YTgtNDkz
-        YS04YTRmLWQ5MzUyYzBjMzI0YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0ZjBiMzFjLWQ5ODgtNDg1
+        MS04Yjk5LWM3OTY2YTgzNDMyZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fd2c03a4-84a8-493a-8a4f-d9352c0c324a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a4f0b31c-d988-4851-8b99-c7966a83432d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3290,53 +3977,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:02 GMT
+      - Fri, 29 Jul 2022 09:02:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a7491fd09f748ea8939cec95f664e7b
+      - 801a01ba227d41e18f34e542463db796
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmQyYzAzYTQtODRh
-        OC00OTNhLThhNGYtZDkzNTJjMGMzMjRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MDIuMzkxMDAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTRmMGIzMWMtZDk4
+        OC00ODUxLThiOTktYzc5NjZhODM0MzJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NDUuOTQ1OTMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNzZmZTgxNTZiNWQ0NmMyYWU5
-        YjM4ZTBjMWM1NTA5MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjAyLjUzMzcxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        MDIuNzIwNDA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYmQyOWJiZWZjY2Y0YjE0OWJk
+        MjdiMmFjNzIxZTI4NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjQ2LjMxNzk2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        NDYuNzIxMzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9jZWNhNWViZS01MzQwLTQ3MTYtOTc5Ni1lZGU5MDkyZmFhZjMvdmVyc2lv
+        bS9hODY3MGJlMS0zM2QxLTQ3OWEtYTFlZi0yN2EwYTkzMmEyNTEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2VjYTVlYmUtNTM0MC00NzE2
-        LTk3OTYtZWRlOTA5MmZhYWYzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTg2NzBiZTEtMzNkMS00Nzlh
+        LWExZWYtMjdhMGE5MzJhMjUxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:02 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?repository_version=/pulp/api/v3/repositories/rpm/rpm/58507389-c2d8-48b5-b5f5-ec2a0dba0e6c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?repository_version=/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3344,7 +4031,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3357,37 +4044,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:03 GMT
+      - Fri, 29 Jul 2022 09:02:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b39bbed6d1064817a32fd6d582814d92
+      - bfdd697440ec4360a6c325f6e268968b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy9mZTNhYzZkNS1lMGQyLTRmYTQtOGEwMy1lNWZi
-        NjA1YTE0OGUvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0
-        NC42NjI1MjhaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3398,12 +4085,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzLzFmNDc2YTNjLWViNDgtNGRlZi05NDE5LWU4MzVkNzIyYjA0Yy8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvY2Y0NWNmMDktZDhiZC00YzdmLWE0MmEtNGQz
-        YzgxYzA2NjZkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDQuNjUyNjA0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3414,12 +4101,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9kMjk4YmY1Ni0yNDcxLTQ1ZWUtOTNhOC0zZDU0YzJjYTVkZTYvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy84M2NkNDA0Ni1lYWM3LTQwZWEtOTc4
-        NC00OGEwNTdiY2FkNzQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyMzo0NC42NTAxMzVaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3430,14 +4117,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzlhYzcyMTk4LTc1NWMtNDQxZi05ZTc3LTM4YmUwYmQ0NWMy
-        Ni8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:03 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ceca5ebe-5340-4716-9796-ede9092faaf3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a8670be1-33d1-479a-a1ef-27a0a932a251/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3445,7 +4132,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3458,37 +4145,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:03 GMT
+      - Fri, 29 Jul 2022 09:02:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f602f48726b14519b7defc6f3faa248a
+      - db166bad6a7a4e37979546ae61d6b137
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy9mZTNhYzZkNS1lMGQyLTRmYTQtOGEwMy1lNWZi
-        NjA1YTE0OGUvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0
-        NC42NjI1MjhaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3499,12 +4186,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzLzFmNDc2YTNjLWViNDgtNGRlZi05NDE5LWU4MzVkNzIyYjA0Yy8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvY2Y0NWNmMDktZDhiZC00YzdmLWE0MmEtNGQz
-        YzgxYzA2NjZkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDQuNjUyNjA0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3515,12 +4202,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9kMjk4YmY1Ni0yNDcxLTQ1ZWUtOTNhOC0zZDU0YzJjYTVkZTYvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy84M2NkNDA0Ni1lYWM3LTQwZWEtOTc4
-        NC00OGEwNTdiY2FkNzQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyMzo0NC42NTAxMzVaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3531,9 +4218,9 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzlhYzcyMTk4LTc1NWMtNDQxZi05ZTc3LTM4YmUwYmQ0NWMy
-        Ni8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:03 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:47 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_package_environment_repository/all_package_environments_are_copied_by_default.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_package_environment_repository/all_package_environments_are_copied_by_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ae2318c40c94715844f2d18c73326df
+      - 578bdc3da1ef4c269ddce656b97ff831
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jMDQyOWY2OC1kZmFjLTQzNzItYTgyMC0zOWJjNDI3ZWYyODQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMDo1Ni41MTQ0NDla
+        cnBtL3JwbS81NTdlNTk3MS05YjI3LTRjNTUtOWI1MS0zZjY0YmY4YjBjMWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDoyMy4zMDI0OTha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jMDQyOWY2OC1kZmFjLTQzNzItYTgyMC0zOWJjNDI3ZWYyODQv
+        cnBtL3JwbS81NTdlNTk3MS05YjI3LTRjNTUtOWI1MS0zZjY0YmY4YjBjMWQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2MwNDI5
-        ZjY4LWRmYWMtNDM3Mi1hODIwLTM5YmM0MjdlZjI4NC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU1N2U1
+        OTcxLTliMjctNGM1NS05YjUxLTNmNjRiZjhiMGMxZC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:34 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/c0429f68-dfac-4372-a820-39bc427ef284/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 532a932f02e44359b110fb88ec25acd9
+      - 54866a0324b74e81b6ccd7484bd9d76e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhNDFlYzk0LThkZGUtNDM2
-        Ni05YTExLThlZTY0MzlmZWFiZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3YjUxYzdhLWFmMWYtNDAx
+        YS04YjJlLWZhMzEzYjQwZWI1Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d4a29c92ef547e58bf30f91e780bc1c
+      - 4ed7d02208594502a5c1c2beee450c5f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ba41ec94-8dde-4366-9a11-8ee6439feabf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d7b51c7a-af1f-401a-8b2e-fa313b40eb52/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc3296d6485d4011b2e4279ca7d585a8
+      - a47d685c8d614e358dcd23be0ad0cdfe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmE0MWVjOTQtOGRk
-        ZS00MzY2LTlhMTEtOGVlNjQzOWZlYWJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDEuNDg5MTkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDdiNTFjN2EtYWYx
+        Zi00MDFhLThiMmUtZmEzMTNiNDBlYjUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzQuNTEzMDk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MzJhOTMyZjAyZTQ0MzU5YjExMGZiODhl
-        YzI1YWNkOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQxLjUy
-        OTgzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDEuNjUw
-        ODk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NDg2NmEwMzI0Yjc0ZTgxYjZjY2Q3NDg0
+        YmQ5ZDc2ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjM0LjU0
+        OTczOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MzQuNzMw
+        MzI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzA0MjlmNjgtZGZhYy00Mzcy
-        LWE4MjAtMzliYzQyN2VmMjg0LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTU3ZTU5NzEtOWIyNy00YzU1
+        LTliNTEtM2Y2NGJmOGIwYzFkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ba1f8d0cb7124dc1991f50530f179465
+      - ee6cb0cbcd0843e4b93efb9776bffc04
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ecf4cff5721a4fce9cae44693c44ab4f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vYTA2NzlhOTgtN2I3NC00MTNkLTg1OWMtMTU5OTFiNTVjMDVh
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MzAuMjk2NzQ2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:34 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/a0679a98-7b74-413d-859c-15991b55c05a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 504c23244c6149e184e1055757a9ae87
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwZGU1MDJlLTE0Y2YtNDUz
+        Mi05MmUwLTk3ZGY5OTdkMjAxYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/30de502e-14cf-4532-92e0-97df997d201b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ac0775552b99421ea98417c2217ef139
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzBkZTUwMmUtMTRj
+        Zi00NTMyLTkyZTAtOTdkZjk5N2QyMDFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzQuOTMzOTY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MDRjMjMyNDRjNjE0OWUxODRlMTA1NTc1
+        N2E5YWU4NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjM0Ljk3
+        NTAzNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MzUuMDIw
+        MjQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f78ac59a01f847b6ac104eb24b5abe1b
+      - aa7c09ecaa004c52979ea60c603a4d70
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a22ebc9e4a9040afbde6ba435df4bb1e
+      - 7a05cdcd1f384beb8527bad3aa99e941
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 251a2c1c85554495bcf9adf95a6a6436
+      - bd281c6b0fcc478eab44f9eba9972d21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:41 GMT
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5b83c9d772c483d8464d9d06d1a8a8d
+      - b22bd8a95dac450abdce9c345719658b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:21:41 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 760839677874472a96ed133e747ee325
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:41 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/1dc2cfff-bf0e-41e5-bf79-7bc3d8293052/"
+      - "/pulp/api/v3/remotes/rpm/rpm/fa8b084f-8cb4-4405-9344-55aef06d89ef/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33da4495227f42b3a5a15718f4e99050
+      - a6aefa125d144ff4af137dbc7f71fc14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFk
-        YzJjZmZmLWJmMGUtNDFlNS1iZjc5LTdiYzNkODI5MzA1Mi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIxOjQyLjAzNDQ3NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Zh
+        OGIwODRmLThjYjQtNDQwNS05MzQ0LTU1YWVmMDZkODllZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjM1LjQ5MDk2NFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIxOjQyLjAzNDQ5NloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAwOjM1LjQ5MDk4OFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/"
+      - "/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 91f973cccb3d4894b3558e527f8971ee
+      - 9a9895e16eb443edb0538513cc07419c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTNlMDFkYzMtYTJiZC00MjI0LTgzNTAtNWI3YWMyOTY3ZjMxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6NDIuMTQ3MTkwWiIsInZl
+        cG0vN2YyMjgxNWYtN2U2NC00MGVhLTgwY2YtZGIwNjFjNjcxNTJlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MzUuNjYxOTA4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTNlMDFkYzMtYTJiZC00MjI0LTgzNTAtNWI3YWMyOTY3ZjMxL3ZlcnNp
+        cG0vN2YyMjgxNWYtN2U2NC00MGVhLTgwY2YtZGIwNjFjNjcxNTJlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85M2UwMWRjMy1h
-        MmJkLTQyMjQtODM1MC01YjdhYzI5NjdmMzEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83ZjIyODE1Zi03
+        ZTY0LTQwZWEtODBjZi1kYjA2MWM2NzE1MmUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b6f4de3b6c5a48918b934132cf107754
+      - 812dbf7f51e44f29b39c55c8afafd95e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xNDU4YjdjYS03Zjg4LTRhM2UtYTA5MS05NDE3ZWJjZGQwZWUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMTozNC41NDgzODNa
+        cnBtL3JwbS82ODZhMWI0OS04NjlkLTQ3YmEtYjQwZi1iYTU2Yzc0ZjYzYWMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDoyNC4yMDM4ODJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xNDU4YjdjYS03Zjg4LTRhM2UtYTA5MS05NDE3ZWJjZGQwZWUv
+        cnBtL3JwbS82ODZhMWI0OS04NjlkLTQ3YmEtYjQwZi1iYTU2Yzc0ZjYzYWMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzE0NThi
-        N2NhLTdmODgtNGEzZS1hMDkxLTk0MTdlYmNkZDBlZS92ZXJzaW9ucy8yLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY4NmEx
+        YjQ5LTg2OWQtNDdiYS1iNDBmLWJhNTZjNzRmNjNhYy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1458b7ca-7f88-4a3e-a091-9417ebcdd0ee/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6713eed6119844c5a16bac289f3ca2a2
+      - 808ea3575e4b49828f29c6a986264778
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5NjlmOWE4LTg2YTktNDFj
-        My1hMGMwLTQwMjQ2ZTZhMGExYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyNmI5NWYyLWUzNTktNGJk
+        MC1hYzI4LWIwMTY5ZjIzM2FmZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '608'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f6cec8723d8b44eda077ac0e086a3180
+      - 2cf48569a4af48e88e22697a89373815
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZDg2YmI4NTUtZWZhYi00MTdiLTgyNDUtOGIxMTQ5NGUxNjcyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6MzQuMzk2MjY4WiIsIm5h
+        cG0vNTljOGExZDEtNzM4Zi00ZWFjLTg4OWQtNzJjMWM5NDViYmQwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MjMuMTY0MTA2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5v
-        cmcvcnBtLXVuc2lnbmVkLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0
-        IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxs
-        LCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMi0w
-        NS0yM1QyMzoyMTozNi4wMTI0OTRaIiwiZG93bmxvYWRfY29uY3VycmVuY3ki
-        Om51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJvbl9kZW1hbmQi
-        LCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6NjAu
-        MCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90aW1l
-        b3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAsInNs
-        ZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+        cmcvc3JwbS11bnNpZ25lZC8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2Vy
+        dCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjIt
+        MDctMjlUMDk6MDA6MjQuNjM0Mjc0WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5
+        IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRl
+        IiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYw
+        LjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGlt
+        ZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJz
+        bGVzX2F1dGhfdG9rZW4iOm51bGx9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:35 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/d86bb855-efab-417b-8245-8b11494e1672/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/59c8a1d1-738f-4eac-889d-72c1c945bbd0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a62825bdd4d941afa88e49679fd21cca
+      - 225821efa9ff4d76bfb5ae1bee5be3ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkNGY4ZGZiLTljYjktNDlm
-        Mi04NzZkLTdiODQ1NGMyY2I0NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1MWM5ZGMwLTFjN2UtNGUx
+        Yy05Yjc4LTFlZmZiYzA4YmNmOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5969f9a8-86a9-41c3-a0c0-40246e6a0a1c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d26b95f2-e359-4bd0-ac28-b0169f233afd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3614523c2b394314986768109942d668
+      - 9781eba73605448ba3f69b7b487d1446
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTk2OWY5YTgtODZh
-        OS00MWMzLWEwYzAtNDAyNDZlNmEwYTFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDIuMzA4MDUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDI2Yjk1ZjItZTM1
+        OS00YmQwLWFjMjgtYjAxNjlmMjMzYWZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzUuODcyOTkyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NzEzZWVkNjExOTg0NGM1YTE2YmFjMjg5
-        ZjNjYTJhMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQyLjMz
-        OTExMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDIuNDgw
-        NjUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4MDhlYTM1NzVlNGI0OTgyOGYyOWM2YTk4
+        NjI2NDc3OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjM1Ljkz
+        MDIwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MzYuMDA4
+        MzQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTQ1OGI3Y2EtN2Y4OC00YTNl
-        LWEwOTEtOTQxN2ViY2RkMGVlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjg2YTFiNDktODY5ZC00N2Jh
+        LWI0MGYtYmE1NmM3NGY2M2FjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cd4f8dfb-9cb9-49f2-876d-7b8454c2cb44/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/251c9dc0-1c7e-4e1c-9b78-1effbc08bcf8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c68cc6fba3494169a74269923e9c5cc3
+      - b51d9f16cd2e4e3b930345fbb94c4379
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2Q0ZjhkZmItOWNi
-        OS00OWYyLTg3NmQtN2I4NDU0YzJjYjQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDIuMzk1MTY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjUxYzlkYzAtMWM3
+        ZS00ZTFjLTliNzgtMWVmZmJjMDhiY2Y4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzUuOTkyMjUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhNjI4MjViZGQ0ZDk0MWFmYTg4ZTQ5Njc5
-        ZmQyMWNjYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQyLjQy
-        NTQ4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDIuNDcy
-        OTEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMjU4MjFlZmE5ZmY0ZDc2YmZiNWFlMWJl
+        ZTViZTNjYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjM2LjAz
+        NzgwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MzYuMDkx
+        MzgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q4NmJiODU1LWVmYWItNDE3Yi04MjQ1
-        LThiMTE0OTRlMTY3Mi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU5YzhhMWQxLTczOGYtNGVhYy04ODlk
+        LTcyYzFjOTQ1YmJkMC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,299 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 7ef138bdc4314a60b6dfa9bdc84e69c3
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '300'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMWVmMWI1NGYtYmFhNC00OTNlLTkxMjYtZDU5NjM2NDM1MGNj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6MzUuNTQ4NTc4
-        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kZXZfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOC1rYXRl
-        bGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQv
-        QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2Rldl9sYWJlbC8iLCJj
-        b250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIy
-        IiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOm51bGx9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/1ef1b54f-baa4-493e-9126-d596364350cc/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:21:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 06cc2e824bb54ed8951570ca10b706d7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyODIwNDNkLWQwZTAtNGIz
-        NC1iNmEzLTZiOGMzMWUyZDNjMi8ifQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:21:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e1a22b612aba451e9a494380a4fcbaed
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '300'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMWVmMWI1NGYtYmFhNC00OTNlLTkxMjYtZDU5NjM2NDM1MGNj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6MzUuNTQ4NTc4
-        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kZXZfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOC1rYXRl
-        bGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQv
-        QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2Rldl9sYWJlbC8iLCJj
-        b250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIy
-        IiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOm51bGx9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/1ef1b54f-baa4-493e-9126-d596364350cc/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:21:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '23'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - fc506f64a0554233a95e2e8becdc0e10
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
-
-'
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3282043d-d0e0-4b34-b6a3-6b8c31e2d3c2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:21:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - a00faab96afb4dba820e083b4c7db4fe
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '346'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzI4MjA0M2QtZDBl
-        MC00YjM0LWI2YTMtNmI4YzMxZTJkM2MyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDIuNzcxMTk5WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNmNjMmU4MjRiYjU0ZWQ4OTUxNTcwY2Ex
-        MGI3MDZkNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQyLjgw
-        NDAwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDIuODM0
-        ODU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
-        L2Rpc3RyaWJ1dGlvbnMvIl19
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1401,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd5d1e55e210404ea30bcd8bac09a677
+      - 839c7a31a18c4f15b52c33515841d3b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1423,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1436,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:42 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1454,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2e80fa3a5e044e84aa949704fbd7f578
+      - 7b286f9e061144e18f6383ece32a2988
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:42 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1476,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1489,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:43 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1507,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8ef63b60c7794d51b7127125f773276d
+      - 0caf33d5fd08484db76f98cd2a7fc4af
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1529,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1542,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:43 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1560,21 +1393,127 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 78a6f50cce2e406fa939796a9bafeaae
+      - f9946a5fc16e491ebf4157f1fb1bbfcc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d40d74d7fc5641e1a494c7c28a589aa5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c63a47ee5db84dc6a92f69d40fdc29c3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1584,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1597,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:43 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/a1dd23c0-df6b-4b26-9d46-9a8298998df1/"
+      - "/pulp/api/v3/repositories/rpm/rpm/6b295bcb-01d8-47d4-8d23-48ed7ecd8d66/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1617,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b45a17fab0643dfab88759b4be6a9c0
+      - eb1683a65d1b4384bd9f189745207a48
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTFkZDIzYzAtZGY2Yi00YjI2LTlkNDYtOWE4Mjk4OTk4ZGYxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6NDMuMTc0MTEwWiIsInZl
+        cG0vNmIyOTViY2ItMDFkOC00N2Q0LThkMjMtNDhlZDdlY2Q4ZDY2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MzYuNTg1NTUxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTFkZDIzYzAtZGY2Yi00YjI2LTlkNDYtOWE4Mjk4OTk4ZGYxL3ZlcnNp
+        cG0vNmIyOTViY2ItMDFkOC00N2Q0LThkMjMtNDhlZDdlY2Q4ZDY2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hMWRkMjNjMC1k
-        ZjZiLTRiMjYtOWQ0Ni05YTgyOTg5OThkZjEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82YjI5NWJjYi0w
+        MWQ4LTQ3ZDQtOGQyMy00OGVkN2VjZDhkNjYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1640,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/1dc2cfff-bf0e-41e5-bf79-7bc3d8293052/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/fa8b084f-8cb4-4405-9344-55aef06d89ef/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1660,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1673,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:43 GMT
+      - Fri, 29 Jul 2022 09:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1691,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 19a652812a3a404390a820890686683e
+      - 63fad473cf1c4a5994f43537556662bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5NzYxNTRlLThmMmYtNGIw
-        OC1iNDQ2LWZlOTc5N2UyZDY4YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg3MjQ2MzcwLTM2MjktNDc3
+        Mi1hZmFjLTNhNzlhYjA4MWEzNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3976154e-8f2f-4b08-b446-fe9797e2d68a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/87246370-3629-4772-afac-3a79ab081a34/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1726,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:43 GMT
+      - Fri, 29 Jul 2022 09:00:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 403969357e354fbba9b29d32d60b6e23
+      - e28795d73ff04d7892c1391348c07163
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzk3NjE1NGUtOGYy
-        Zi00YjA4LWI0NDYtZmU5Nzk3ZTJkNjhhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDMuNDQ0NTkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODcyNDYzNzAtMzYy
+        OS00NzcyLWFmYWMtM2E3OWFiMDgxYTM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzYuOTU2MTE5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIxOWE2NTI4MTJhM2E0MDQzOTBhODIwODkw
-        Njg2NjgzZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQzLjUw
-        MzQ2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDMuNTI3
-        OTE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2M2ZhZDQ3M2NmMWM0YTU5OTRmNDM1Mzc1
+        NTY2NjJiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjM2Ljk5
+        MzM0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MzcuMDMy
+        MzU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFkYzJjZmZmLWJmMGUtNDFlNS1iZjc5
-        LTdiYzNkODI5MzA1Mi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZhOGIwODRmLThjYjQtNDQwNS05MzQ0
+        LTU1YWVmMDZkODllZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:37 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFkYzJj
-        ZmZmLWJmMGUtNDFlNS1iZjc5LTdiYzNkODI5MzA1Mi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZhOGIw
+        ODRmLThjYjQtNDQwNS05MzQ0LTU1YWVmMDZkODllZi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1795,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:43 GMT
+      - Fri, 29 Jul 2022 09:00:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1813,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49ab151553974b3aaa61d75f2099fbe1
+      - 3a7e9337041b46fd80c18b0477a5f61b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiZjdhNGQwLTMwYzMtNDkw
-        MC1hNjY5LWQzNjdhOGNjZTg4Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyYTMzM2RkLTM4OGItNGRk
+        NS04MGM3LWU3OTQzZGJmNzgxOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:43 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3bf7a4d0-30c3-4900-a669-d367a8cce88f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f2a333dd-388b-4dd5-80c7-e7943dbf7818/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1848,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:44 GMT
+      - Fri, 29 Jul 2022 09:00:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4a35556f9505408ea0c1c629dd98a1dc
+      - 7928848e9fff4930aa60f21a24946b39
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '653'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2JmN2E0ZDAtMzBj
-        My00OTAwLWE2NjktZDM2N2E4Y2NlODhmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDMuNjUwMDEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjJhMzMzZGQtMzg4
+        Yi00ZGQ1LTgwYzctZTc5NDNkYmY3ODE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzcuMjEwMDExWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI0OWFiMTUxNTUzOTc0YjNhYWE2
-        MWQ3NWYyMDk5ZmJlMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIx
-        OjQzLjY4MzE5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6
-        NDQuNDUzMDYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzYTdlOTMzNzA0MWI0NmZkODBj
+        MThiMDQ3N2E1ZjYxYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjM3LjI3MzA1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        MzguNDAyNTQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1900,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzkzZTAxZGMzLWEyYmQtNDIyNC04MzUwLTViN2Fj
-        Mjk2N2YzMS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85M2Uw
-        MWRjMy1hMmJkLTQyMjQtODM1MC01YjdhYzI5NjdmMzEvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMWRjMmNmZmYtYmYwZS00MWU1
-        LWJmNzktN2JjM2Q4MjkzMDUyLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS83ZjIyODE1Zi03ZTY0LTQwZWEtODBjZi1kYjA2MWM2
+        NzE1MmUvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2YyMjgx
+        NWYtN2U2NC00MGVhLTgwY2YtZGIwNjFjNjcxNTJlLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZhOGIwODRmLThjYjQtNDQwNS05
+        MzQ0LTU1YWVmMDZkODllZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:44 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:38 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOTNlMDFkYzMtYTJiZC00MjI0LTgzNTAtNWI3YWMyOTY3
-        ZjMxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vN2YyMjgxNWYtN2U2NC00MGVhLTgwY2YtZGIwNjFjNjcx
+        NTJlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1944,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:44 GMT
+      - Fri, 29 Jul 2022 09:00:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1962,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4c21f3415dc4b4f8197b624c51ce5c8
+      - bac0c50343534b7a8e64667c25dccc7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU1NGNkMDE5LTFkMzMtNGE4
-        YS05NDEyLTI1NWMyNTUzZjVkNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxMWQyZmY5LTFlYTktNDFi
+        My1hYTllLTZiODc1ZTdjN2NmMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:44 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/554cd019-1d33-4a8a-9412-255c2553f5d6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/911d2ff9-1ea9-41b3-aa9e-6b875e7c7cf3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1997,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:45 GMT
+      - Fri, 29 Jul 2022 09:00:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b7c16dc07814b78920ca644f33fe434
+      - 23747354ce2b425883195599346403a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTU0Y2QwMTktMWQz
-        My00YThhLTk0MTItMjU1YzI1NTNmNWQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDQuNzQwNDIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTExZDJmZjktMWVh
+        OS00MWIzLWFhOWUtNmI4NzVlN2M3Y2YzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzguODEyNzEyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImE0YzIxZjM0MTVkYzRiNGY4MTk3YjYyNGM1
-        MWNlNWM4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDQuNzcy
-        MTc1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMTo0NS4wMzU5
-        NTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImJhYzBjNTAzNDM1MzRiN2E4ZTY0NjY3YzI1
+        ZGNjYzdjIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MzguODUw
+        MzQ1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMDozOS4yOTI2
+        ODRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYmFiMjc2
-        NDYtMDUwOS00NDk2LWE3OWYtM2EwYjI0YmZmZjk4LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGI1ODgx
+        MDMtNzc1ZC00NWFlLTgwZDItZTI0MGEyYzg2YjNkLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOTNlMDFkYzMtYTJiZC00MjI0LTgzNTAtNWI3YWMy
-        OTY3ZjMxLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vN2YyMjgxNWYtN2U2NC00MGVhLTgwY2YtZGIwNjFj
+        NjcxNTJlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2054,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2067,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:45 GMT
+      - Fri, 29 Jul 2022 09:00:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d09149e7164d42b78623c32b2411f1c0
+      - 7618030bd86546a8b07b4adad9433c00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/8b588103-775d-45ae-80d2-e240a2c86b3d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fd84cb1ce093489b9cfe106ee7185848
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vOGI1ODgxMDMtNzc1ZC00NWFlLTgwZDItZTI0MGEyYzg2YjNkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MzguODczNDQ4WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZjIyODE1Zi03ZTY0LTQwZWEtODBjZi1kYjA2MWM2NzE1MmUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzdmMjI4MTVmLTdlNjQtNDBlYS04MGNmLWRiMDYx
+        YzY3MTUyZS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:39 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS84YjU4ODEwMy03NzVkLTQ1YWUtODBkMi1lMjQwYTJjODZiM2Qv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - dcaeb630be2144aab1a61054ad7b429e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2YzIzZmMxLTJhNTItNDRj
+        MC1iYzI1LWNiMzk3YzFmNjQwOS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c6c23fc1-2a52-44c0-bc25-cb397c1f6409/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2578b2049a924df6b4f62eb332b19316
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzZjMjNmYzEtMmE1
+        Mi00NGMwLWJjMjUtY2IzOTdjMWY2NDA5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzkuNTYwNTQwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkY2FlYjYzMGJlMjE0NGFhYjFhNjEwNTRh
+        ZDdiNDI5ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjM5LjYw
+        NTE3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MzkuODE4
+        ODg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMmYz
+        ZjdkYzQtODIwNC00MmEzLTg2YzEtMGNjZjg5MzFlMTYwLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/2f3f7dc4-8204-42a3-86c1-0ccf8931e160/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2c564a9589bf4200a5aabef86157932e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzJmM2Y3ZGM0LTgyMDQtNDJhMy04NmMxLTBjY2Y4OTMxZTE2MC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjM5Ljc5OTAxMVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vOGI1ODgxMDMtNzc1ZC00NWFlLTgwZDIt
+        ZTI0MGEyYzg2YjNkLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d9c11c41bf5a44878c67831615fc7f8e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2268,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2281,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:45 GMT
+      - Fri, 29 Jul 2022 09:00:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa9f4f1223854c429e58d9b8547a9453
+      - 1ed22df0b0844700b44d07c80086a7f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2321,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2342,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2362,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2383,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2404,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2424,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2443,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2456,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:45 GMT
+      - Fri, 29 Jul 2022 09:00:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ad617ee6e22470db0160efbed97f8f4
+      - 671ebcd2bb8b497283b75c4d3e3fb664
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2559,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2577,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2596,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2620,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2638,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2649,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2680,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2691,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2704,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:45 GMT
+      - Fri, 29 Jul 2022 09:00:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 97929674e2b44749bed57af59c56f7b6
+      - d02ec7f5de84474dad3610dc01b50d25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2771,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2783,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2794,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2807,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:45 GMT
+      - Fri, 29 Jul 2022 09:00:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 861ee5c2bc804200935a2db1efe04eb1
+      - 6e6ef7f0446f42ebaa056760ae901a6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2843,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2854,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2867,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:45 GMT
+      - Fri, 29 Jul 2022 09:00:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7cb590e89c143c18bfde1228a3d109e
+      - 9cebc3de00f94020bd1a8f2db3d29425
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2918,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:45 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2929,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2942,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9f4fe7b78264424589a400bd50a1781b
+      - 54e6b07dbcba4ac384d9fca86ea79331
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -3009,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3020,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3033,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab47edd5e4fe430092e15d09eb6bc119
+      - 15326f9947bf48d6882048cdf6dcc0ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -3100,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3111,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3124,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b386daa9666d458983702d4415c279d2
+      - e3272b413f664b0aaf624b833dc958d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3163,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3174,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3187,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 615c8a78b1ab4565b85b8f481990d08f
+      - 88f77c87ac8c42ed9d8c80fc831707c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3226,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3237,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3250,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c109339402b145bf9c8e055176fed5c6
+      - 5fc67077f36748a2b5bedd43103f8b17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3291,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3299,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3310,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3323,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 60ece1619c1c43eaa8657e935891075b
+      - 2dc4401fe457474fbeda28f28f1cbf7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3374,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3385,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3398,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 18ecd18f475a464d8e9bcb345c476d2d
+      - ce2e5b4bc3ba45f3bd0665beba6eeb8e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3446,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3459,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ebdc31826c84660af37963a34c26183
+      - 2a5d60c0497a41ae996162ba0761686b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3500,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3516,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3532,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a1dd23c0-df6b-4b26-9d46-9a8298998df1/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6b295bcb-01d8-47d4-8d23-48ed7ecd8d66/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3549,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3562,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3580,99 +3819,99 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f548aa8eaf7844a78453e34b24b424b1
+      - 4972384b3830410daaa2cd1f57e6911c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzNGY0NDhiLTI2OTEtNDAy
-        Ny1iMmIzLTA3MzVhZGExZGIwMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMxMTUxYWIwLTc5YWYtNGRj
+        NS1hODhjLWQ5NDllMjQwZjAyMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a1dd23c0-df6b-4b26-9d46-9a8298998df1/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6b295bcb-01d8-47d4-8d23-48ed7ecd8d66/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80NjRmNzQ1Mi04ODhiLTQyZjctODMyMi03YTlkZGQ1
-        YThhNzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NmExMGJiYmYtNTFlMS00MTVhLWEwMGYtNzliNzFhZTFkM2Q0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzdmZmQ2MDc2LWY3ZGQt
-        NDVkMy04ZjE3LTdmYzQxOGQxYWRmMy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYtZTRkNzNhOGFiMGJlLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VlNzJhOWU2LTNh
-        ZmYtNDI3Ny1iMzJiLWFiOTIwNGE1NTliOS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vYWR2aXNvcmllcy9lZjgyN2RkNy1hMmE5LTQzODUtODAyMS1i
-        ZTJjZDk4ZmU4YzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
-        aWJ1dGlvbl90cmVlcy9jN2UzNTQxNy05ZDg3LTQ4ZGUtOThkOC01MmQ2MzVi
-        M2VlYmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
-        ODc3NjQyNi0zZjNmLTRhNjItYmIxYy05ODRjNTZmYjMwNDMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82OGRjNGJlNC04MzdmLTRm
-        NmItOWY4OC01MWRlYTMwMGRlODcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy84MDBiNTVjNi05NzUzLTQzODEtOWQ3OC0wZmRlMmRk
-        ZmVlNDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9i
-        MTJhMjE2Zi01ZTU2LTQ4ODEtYWZhZi02OWFjNWU1ZmRjMDIvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4
-        YjItODE0My1hNjE5MGRiZWI4YzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy9lNzQxM2ZlMC0zMDY3LTQ1NmQtOTVmYy0wNmIyYmRh
-        MjcyYWMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvNjgwZGFhYjItYWE1Yy00NGJkLTg2NjctZTBhZmNhOWY4OTBiLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2E5ODk4ZmE5
-        LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2MwZmUwNS8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQt
-        ZGNlZWUyZWY3OGMyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8xM2EyNGRmNC03Y2MyLTQ1ZjMtYjViMC01NjhlNmVkMjYzZjUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzIzOTI4Yzg2LTYy
-        YWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMjg0MDQ3ZDgtNWFjNi00NmFiLTk1ZTgtYjI1
-        MDljMjhlMjlhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yYWU3YjhjMy05OWU3LTQ5YjAtOThiZS03MjIzYjY5ODVlMjgvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMt
-        NGQxZC1hZjU0LTRmMTFhZDBjZjRlNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00YTEyLWI2NzktNWNkM2Rk
-        ZGE5YTU3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81
-        ZTI0MGY3My03MWU4LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVmMzFkOWRkLTY5NzgtNDBh
-        Yi1hMjhkLTEzNWUwMjgwNzIyOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0OC00ZWM2LWIyMjEtN2U5N2MzNjg5
-        MWI3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZDYw
-        ZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04
-        ZDgxLWNlNjBkMTY2ZDIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvOTZmOTlkOTItMzc1MC00YTQ5LTk4ZmUtNDY2YTE1MjE3OTcx
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85YWQwN2U2
-        MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1MzI2ZmZlLTZiZTEtNDUyMy04YTY3
-        LWE5Y2RmZDZlNWJmMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvYmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMWMyOTIwNi00
-        MTEwLTQyMDgtYTIwYy1jMzg1NWNkNGY0MGMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2Q1YTJmMWFkLTA0MmEtNDA1ZS1hYzQ0LTBj
-        NGIxNGRiYmVjYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNjZmYzg0Ni0zNDhj
-        LTQzNTAtODZlMS1jMzJiZGNhNDFkM2UvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZDI0NDFlYWEtM2ZjMS00Nzc1
-        LTkyMGUtYTZkNzY4ZDZjMjE3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRh
-        LTg3YmNhOGViMzllMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5N2QtOTkyMTM4
-        NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
-        ZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2ZTE4NGQ5MmIv
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1i
+        OTFkMDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
+        aWJ1dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRk
+        NTBhMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
+        Yzg0MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRl
+        OTktYmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3
+        YTExOTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8z
+        YjliOWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRi
+        NTktODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdh
+        YzAzODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0
+        LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvMDVlMzY4ZDctMjkxYS00MzM2LWFkYmQt
+        ZDg5YjdiMDFkODQ2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1iMjc2ZmZhN2U4MjYvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM1YmJhMDBiLTZm
+        MTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy80ODA2MDhjMS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMt
+        NGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1ZmJiOTc0LTE1MmMtNDk2
+        ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3
+        YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4
+        M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04
+        MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNhMzhh
+        Mi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJi
+        LTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02
+        MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0
+        MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMx
+        LTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4
+        LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
+        dWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQtZjIwM2Nh
+        MzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
+        ZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDliODIzMjMv
         IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRz
-        LzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0YS8iXX0=
+        L2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3685,7 +3924,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:46 GMT
+      - Fri, 29 Jul 2022 09:00:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3703,21 +3942,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a55e4bcff5341ef9d25b4adcf831984
+      - 6a339096635e4c729fbad2fd4c1a5e98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzMzljYjkxLWFlNmUtNDdm
-        ZS1hMGUzLWUxMDcwOTQyYWMxNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3ZmZkMzQ2LWFkMTItNDFl
+        NS1hYjVkLWEwMWJiOWU5MTNjMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5339cb91-ae6e-47fe-a0e3-e1070942ac17/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/77ffd346-ad12-41e5-ab5d-a01bb9e913c0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3738,53 +3977,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:47 GMT
+      - Fri, 29 Jul 2022 09:00:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4220d0a5ab2c47588b7d3616d17fad10
+      - f8e5536debc74e439e2eeb14e86f4a21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTMzOWNiOTEtYWU2
-        ZS00N2ZlLWEwZTMtZTEwNzA5NDJhYzE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDYuNjg0NjEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzdmZmQzNDYtYWQx
+        Mi00MWU1LWFiNWQtYTAxYmI5ZTkxM2MwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDEuOTAzNTU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYTU1ZTRiY2ZmNTM0MWVmOWQy
-        NWI0YWRjZjgzMTk4NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIx
-        OjQ2LjgxNjA0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6
-        NDYuOTg3NzgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2YTMzOTA5NjYzNWU0YzcyOWZi
+        YWQyZmQ0YzFhNWU5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjQyLjE2MTY4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        NDIuNDQ2NDEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hMWRkMjNjMC1kZjZiLTRiMjYtOWQ0Ni05YTgyOTg5OThkZjEvdmVyc2lv
+        bS82YjI5NWJjYi0wMWQ4LTQ3ZDQtOGQyMy00OGVkN2VjZDhkNjYvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTFkZDIzYzAtZGY2Yi00YjI2
-        LTlkNDYtOWE4Mjk4OTk4ZGYxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmIyOTViY2ItMDFkOC00N2Q0
+        LThkMjMtNDhlZDdlY2Q4ZDY2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3792,7 +4031,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3805,47 +4044,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:47 GMT
+      - Fri, 29 Jul 2022 09:00:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb51103f01f244d48a7d5a5417c7f330
+      - 95c85b87d12b432b993da3774c6fd4bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a1dd23c0-df6b-4b26-9d46-9a8298998df1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6b295bcb-01d8-47d4-8d23-48ed7ecd8d66/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3853,7 +4092,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3866,42 +4105,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:47 GMT
+      - Fri, 29 Jul 2022 09:00:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf447cee0224495986c9b437f521f1b2
+      - 9eca9b6e5041493da8aa81f5f38c0d70
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:42 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_package_environment_repository/all_package_environments_are_copied_even_if_no_groups_match.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_package_environment_repository/all_package_environments_are_copied_even_if_no_groups_match.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1f92450ea124ca4a120b37312af0df4
+      - e32d831131d446ef91d0da919b32e5ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85M2UwMWRjMy1hMmJkLTQyMjQtODM1MC01YjdhYzI5NjdmMzEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMTo0Mi4xNDcxOTBa
+        cnBtL3JwbS83ZjIyODE1Zi03ZTY0LTQwZWEtODBjZi1kYjA2MWM2NzE1MmUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDozNS42NjE5MDha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85M2UwMWRjMy1hMmJkLTQyMjQtODM1MC01YjdhYzI5NjdmMzEv
+        cnBtL3JwbS83ZjIyODE1Zi03ZTY0LTQwZWEtODBjZi1kYjA2MWM2NzE1MmUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzkzZTAx
-        ZGMzLWEyYmQtNDIyNC04MzUwLTViN2FjMjk2N2YzMS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdmMjI4
+        MTVmLTdlNjQtNDBlYS04MGNmLWRiMDYxYzY3MTUyZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/93e01dc3-a2bd-4224-8350-5b7ac2967f31/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7f22815f-7e64-40ea-80cf-db061c67152e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a833749a721146a4b1a329ea97d57072
+      - 5f6e022186644ed393b0a64e6fa64e49
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4YWM1ZDY1LTJkM2UtNGYz
-        MS1iOTc5LTVlZGEzNjczNjA0MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzMWE4NTE2LWFmNDgtNDMy
+        YS04MGY5LWVkMzc1ZjZiY2FmMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41841e868a1c43a893dfbc0c2a7ad547
+      - a973570a4570489e91f238276260de30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/48ac5d65-2d3e-4f31-b979-5eda36736040/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/931a8516-af48-432a-80f9-ed375f6bcaf3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e57b9180ba944daaa883a7f1e76bcf4b
+      - f9212f2f479749b5b1fa5849e4cdff82
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDhhYzVkNjUtMmQz
-        ZS00ZjMxLWI5NzktNWVkYTM2NzM2MDQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDguMTQwODQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTMxYTg1MTYtYWY0
+        OC00MzJhLTgwZjktZWQzNzVmNmJjYWYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDQuMzA2NzU1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhODMzNzQ5YTcyMTE0NmE0YjFhMzI5ZWE5
-        N2Q1NzA3MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQ4LjE3
-        MjU5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDguMjk5
-        MTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1ZjZlMDIyMTg2NjQ0ZWQzOTNiMGE2NGU2
+        ZmE2NGU0OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjQ0LjM3
+        MDE0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NDQuNTYx
+        OTA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTNlMDFkYzMtYTJiZC00MjI0
-        LTgzNTAtNWI3YWMyOTY3ZjMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2YyMjgxNWYtN2U2NC00MGVh
+        LTgwY2YtZGIwNjFjNjcxNTJlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 810207c0209f4801a63f9ae465fbacda
+      - f626b891c33b414781efd329a23cdd89
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1fa5a39be70d42b8b4db2be046466dc9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMmYzZjdkYzQtODIwNC00MmEzLTg2YzEtMGNjZjg5MzFlMTYw
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MzkuNzk5MDEx
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/2f3f7dc4-8204-42a3-86c1-0ccf8931e160/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - eddb04c5417142809475050628c47266
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2ZGM0M2UzLWI3YjctNDYz
+        Mi05NTNiLTU5NDc0OGIyMWJjOC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/66dc43e3-b7b7-4632-953b-594748b21bc8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4a4f1496a5e04eef92b336e11b4429ce
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjZkYzQzZTMtYjdi
+        Ny00NjMyLTk1M2ItNTk0NzQ4YjIxYmM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDQuNzI4NzQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlZGRiMDRjNTQxNzE0MjgwOTQ3NTA1MDYy
+        OGM0NzI2NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjQ0Ljc2
+        ODAyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NDQuNzk5
+        MDY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 299d6d2f98294fc8b6e5246c091513e2
+      - 83944092db4a408f844f36c75935a8d6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5dd6be76221442dcb0ec8da6910549ca
+      - 6e5853be450c4127a9e44105eeef0ef1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4a4b01a823b24ba98f4b4b3288e85947
+      - 53e25b856b614bc99e896785bc70328e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d43536cab373445c9de8f451b7c1512a
+      - b4c218a0830b4f82a85dd2168d6587e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:21:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 03afc36526a448a0b0cb921bfe721b8e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:44 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/a8373559-08c8-4f39-a66d-250523d363a0/"
+      - "/pulp/api/v3/remotes/rpm/rpm/39e96a73-03d2-41a7-b753-58e2c6088058/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ef6e2506d924fd5b1bd07c3bd34de13
+      - 232914e807dc4e7da3446caa38b0cfab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E4
-        MzczNTU5LTA4YzgtNGYzOS1hNjZkLTI1MDUyM2QzNjNhMC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIxOjQ4LjY4MTEyMFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM5
+        ZTk2YTczLTAzZDItNDFhNy1iNzUzLTU4ZTJjNjA4ODA1OC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjQ1LjA5NjM0OVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjIxOjQ4LjY4MTEzOVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAwOjQ1LjA5NjM3NloiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/"
+      - "/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e6d2fc2a34794b7082741fbfe54f8b20
+      - 69a9237bade34f03953b37ae970fb347
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjM3YThhY2UtYWUxOS00YzIyLTgyM2QtN2E3MGQxZTJmNWFlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6NDguNzk3ODkwWiIsInZl
+        cG0vZGY4Y2Q4ZjMtYTgzNS00NTgxLTkzMGEtYTVlZWE2NWYyYWNiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NDUuMjM1NzI2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjM3YThhY2UtYWUxOS00YzIyLTgyM2QtN2E3MGQxZTJmNWFlL3ZlcnNp
+        cG0vZGY4Y2Q4ZjMtYTgzNS00NTgxLTkzMGEtYTVlZWE2NWYyYWNiL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMzdhOGFjZS1h
-        ZTE5LTRjMjItODIzZC03YTcwZDFlMmY1YWUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZjhjZDhmMy1h
+        ODM1LTQ1ODEtOTMwYS1hNWVlYTY1ZjJhY2IvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e76b9f5a79dc4851b70043a8704e0b22
+      - 8b0fccfb7c77410685cf027098fdd324
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hMWRkMjNjMC1kZjZiLTRiMjYtOWQ0Ni05YTgyOTg5OThkZjEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMTo0My4xNzQxMTBa
+        cnBtL3JwbS82YjI5NWJjYi0wMWQ4LTQ3ZDQtOGQyMy00OGVkN2VjZDhkNjYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDozNi41ODU1NTFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hMWRkMjNjMC1kZjZiLTRiMjYtOWQ0Ni05YTgyOTg5OThkZjEv
+        cnBtL3JwbS82YjI5NWJjYi0wMWQ4LTQ3ZDQtOGQyMy00OGVkN2VjZDhkNjYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ExZGQy
-        M2MwLWRmNmItNGIyNi05ZDQ2LTlhODI5ODk5OGRmMS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZiMjk1
+        YmNiLTAxZDgtNDdkNC04ZDIzLTQ4ZWQ3ZWNkOGQ2Ni92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a1dd23c0-df6b-4b26-9d46-9a8298998df1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6b295bcb-01d8-47d4-8d23-48ed7ecd8d66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:48 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7631baaef89842688f87c834d4a00cdc
+      - e79cd899e978433c897de8bfc57cc238
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2NWU5NDE3LTZkMTgtNDU5
-        Yy1hYTMxLTI4MWJiNzNiNmViYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkZmEyNmNiLTk5YzktNDEw
+        MS04N2FjLWY3ZWRlNzJkZDZjOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 24f9d921e2dc47fe9995f4b71544ee86
+      - 8cd2b514530541738bc6a4f3c729e269
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '366'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMWRjMmNmZmYtYmYwZS00MWU1LWJmNzktN2JjM2Q4MjkzMDUyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6NDIuMDM0NDc2WiIsIm5h
+        cG0vZmE4YjA4NGYtOGNiNC00NDA1LTkzNDQtNTVhZWYwNmQ4OWVmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MzUuNDkwOTY0WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyMTo0My41MjI3NTRaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMDozNy4wMjczNDhaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/1dc2cfff-bf0e-41e5-bf79-7bc3d8293052/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/fa8b084f-8cb4-4405-9344-55aef06d89ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab263de9090f49bcbc0c809c0b988d89
+      - 9f12540cdeb843ff840b9d3f0476ef0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhNWZhYjY2LThhMDgtNDE2
-        MS1iOThhLTM0NWUyNDNhY2M1Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViYWUzZjIzLTdjNzItNDZk
+        MS04ZmY0LWFiYzNmYjA0OWUxZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/265e9417-6d18-459c-aa31-281bb73b6eba/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8dfa26cb-99c9-4101-87ac-f7ede72dd6c9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e49b4bfb3c34425bdffc5086b49d993
+      - a9d8ed0de7d54ea0bef048f496180f36
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjY1ZTk0MTctNmQx
-        OC00NTljLWFhMzEtMjgxYmI3M2I2ZWJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDguOTUyNDcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGRmYTI2Y2ItOTlj
+        OS00MTAxLTg3YWMtZjdlZGU3MmRkNmM5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDUuNDUxODQ4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3NjMxYmFhZWY4OTg0MjY4OGY4N2M4MzRk
-        NGEwMGNkYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQ4Ljk4
-        MTQ5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDkuMDQ0
-        MDM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNzljZDg5OWU5Nzg0MzNjODk3ZGU4YmZj
+        NTdjYzIzOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjQ1LjQ5
+        MDg2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NDUuNTk1
+        MzQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTFkZDIzYzAtZGY2Yi00YjI2
-        LTlkNDYtOWE4Mjk4OTk4ZGYxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmIyOTViY2ItMDFkOC00N2Q0
+        LThkMjMtNDhlZDdlY2Q4ZDY2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4a5fab66-8a08-4161-b98a-345e243acc5b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5bae3f23-7c72-46d1-8ff4-abc3fb049e1e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b76612c1d5442c78f02235aab72400f
+      - 9f82d7750aba438b885b9201274b27f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGE1ZmFiNjYtOGEw
-        OC00MTYxLWI5OGEtMzQ1ZTI0M2FjYzViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDkuMDM4NTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWJhZTNmMjMtN2M3
+        Mi00NmQxLThmZjQtYWJjM2ZiMDQ5ZTFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDUuNTcwODE1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhYjI2M2RlOTA5MGY0OWJjYmMwYzgwOWMw
-        Yjk4OGQ4OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQ5LjA2
-        OTg4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDkuMTEz
-        ODQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5ZjEyNTQwY2RlYjg0M2ZmODQwYjlkM2Yw
+        NDc2ZWYwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjQ1LjYy
+        NDgwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NDUuNjky
+        NTczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFkYzJjZmZmLWJmMGUtNDFlNS1iZjc5
-        LTdiYzNkODI5MzA1Mi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZhOGIwODRmLThjYjQtNDQwNS05MzQ0
+        LTU1YWVmMDZkODllZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ca272f8b8fe484688aa50e076aad40a
+      - 516de7f25c5a46af8bed87c8321484e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21f2a654a248495b84ae44c281c72164
+      - f790d7037b2c4adcb8adac62eb6af9d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e00ea48b2d94e9cace333aa78300043
+      - db01164594ef4f1995cdd5cd8f209ada
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08aadf4c3dd447719641c5c5e7c1d1c0'
+      - 7e43ef81c3fc4f7695c417bc46df5113
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a982364854a5498c99e5622c01ba2e31
+      - bf93eec2463245c1a2219b8cc8e99ee3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a8e0a49a72f449dda1650ccd261ceb4c
+      - 5b785ef426a447278c0c1ad23d015b46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/31e77e0e-5d38-45ca-96aa-9424a19ba5fc/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e0d3c39b-7abe-42f2-956a-0749b7b9a457/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aeba9c1d00ca4ec499c10612a3b41c78
+      - 9417636b22df43709ef1da96c768e0df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzFlNzdlMGUtNWQzOC00NWNhLTk2YWEtOTQyNGExOWJhNWZjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6NDkuNDg2OTE3WiIsInZl
+        cG0vZTBkM2MzOWItN2FiZS00MmYyLTk1NmEtMDc0OWI3YjlhNDU3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NDYuMjQ0MDU0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzFlNzdlMGUtNWQzOC00NWNhLTk2YWEtOTQyNGExOWJhNWZjL3ZlcnNp
+        cG0vZTBkM2MzOWItN2FiZS00MmYyLTk1NmEtMDc0OWI3YjlhNDU3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMWU3N2UwZS01
-        ZDM4LTQ1Y2EtOTZhYS05NDI0YTE5YmE1ZmMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGQzYzM5Yi03
+        YWJlLTQyZjItOTU2YS0wNzQ5YjdiOWE0NTcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:46 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a8373559-08c8-4f39-a66d-250523d363a0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/39e96a73-03d2-41a7-b753-58e2c6088058/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e81032fe43a9462cb55f8d350141d2cb
+      - 75e3f95cd7ac4826b23967288685974e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q0ZTAzODFiLTUzOGUtNGRh
-        NC05MDhmLWUzNTMyZWY5ODQ2ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5MzZhYzljLTc2ZmYtNGIz
+        OS1iNjk2LTA4MDgwNjk5YzI1Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d4e0381b-538e-4da4-908f-e3532ef9846e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6936ac9c-76ff-4b39-b696-08080699c25b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c4d982585d064856aa4fbe3483b146a1
+      - 11859e90b3f54eb9a4744dcc8c999e13
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDRlMDM4MWItNTM4
-        ZS00ZGE0LTkwOGYtZTM1MzJlZjk4NDZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDkuNzg3NTI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjkzNmFjOWMtNzZm
+        Zi00YjM5LWI2OTYtMDgwODA2OTljMjViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDYuNzI0NTI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJlODEwMzJmZTQzYTk0NjJjYjU1ZjhkMzUw
-        MTQxZDJjYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIxOjQ5Ljgy
-        NjMyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NDkuODUw
-        NjA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3NWUzZjk1Y2Q3YWM0ODI2YjIzOTY3Mjg4
+        Njg1OTc0ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjQ2Ljc2
+        NjY1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NDYuNzg5
+        ODIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E4MzczNTU5LTA4YzgtNGYzOS1hNjZk
-        LTI1MDUyM2QzNjNhMC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM5ZTk2YTczLTAzZDItNDFhNy1iNzUz
+        LTU4ZTJjNjA4ODA1OC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E4Mzcz
-        NTU5LTA4YzgtNGYzOS1hNjZkLTI1MDUyM2QzNjNhMC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM5ZTk2
+        YTczLTAzZDItNDFhNy1iNzUzLTU4ZTJjNjA4ODA1OC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:49 GMT
+      - Fri, 29 Jul 2022 09:00:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d66ef1cf53646c9bc4b22d9ec186bcd
+      - d67e0caed39f48548674e960c897f334
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5Y2FmZGYzLThjNWItNDFm
-        MC1hNjgxLTY0NDUwNTZiYTdiNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlYjI1ZTIyLWVmN2QtNDJk
+        NS1hZjJjLWE0ZDEwZWQ5ZmY4OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a9cafdf3-8c5b-41f0-a681-6445056ba7b7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0eb25e22-ef7d-42d5-af2c-a4d10ed9ff88/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:50 GMT
+      - Fri, 29 Jul 2022 09:00:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4241964e086548d99ad6404b163d6803
+      - 8c3bc697f6364326a6c26d78337c88f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTljYWZkZjMtOGM1
-        Yi00MWYwLWE2ODEtNjQ0NTA1NmJhN2I3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NDkuOTcyODkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGViMjVlMjItZWY3
+        ZC00MmQ1LWFmMmMtYTRkMTBlZDlmZjg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDYuODg1MTc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwZDY2ZWYxY2Y1MzY0NmM5YmM0
-        YjIyZDllYzE4NmJjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIx
-        OjUwLjAwMjc3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6
-        NTAuNzc3NTE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkNjdlMGNhZWQzOWY0ODU0ODY3
+        NGU5NjBjODk3ZjMzNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjQ2LjkzMjI2N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        NDguMTEwNDIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
         IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1v
-        ZHVsZW1kIiwiY29kZSI6InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51
-        bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNv
-        ZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9
-        LHsibWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBh
-        cnNpbmcucGFja2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
-        dWxsLCJkb25lIjoyMCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJz
-        ZWQgQ29tcHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxs
-        fSx7Im1lc3NhZ2UiOiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5j
-        LnBhcnNpbmcuYWR2aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
-        YWwiOjcsImRvbmUiOjcsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4t
-        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNv
-        bnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
-        IjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQyLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2IzN2E4YWNlLWFlMTktNGMyMi04MjNkLTdhNzBk
-        MWUyZjVhZS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMzdh
-        OGFjZS1hZTE5LTRjMjItODIzZC03YTcwZDFlMmY1YWUvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYTgzNzM1NTktMDhjOC00ZjM5
-        LWE2NmQtMjUwNTIzZDM2M2EwLyJdfQ==
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9kZjhjZDhmMy1hODM1LTQ1ODEtOTMwYS1hNWVlYTY1
+        ZjJhY2IvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGY4Y2Q4
+        ZjMtYTgzNS00NTgxLTkzMGEtYTVlZWE2NWYyYWNiLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM5ZTk2YTczLTAzZDItNDFhNy1i
+        NzUzLTU4ZTJjNjA4ODA1OC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:48 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYjM3YThhY2UtYWUxOS00YzIyLTgyM2QtN2E3MGQxZTJm
-        NWFlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZGY4Y2Q4ZjMtYTgzNS00NTgxLTkzMGEtYTVlZWE2NWYy
+        YWNiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:51 GMT
+      - Fri, 29 Jul 2022 09:00:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3fc5edf9a0054611a72f58867771825a
+      - 8532644991cc4f0ab80f31b3a55f8f6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5NzY0YjYwLTI0MjUtNDky
-        MS1hMzkzLTFjZDA4ZmY3OTBjMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UwYWUzMmZkLTI4YmItNDcw
+        NS1hMjA1LWQyNWRhOWIwNDQ5ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/99764b60-2425-4921-a393-1cd08ff790c2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e0ae32fd-28bb-4705-a205-d25da9b0449d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:51 GMT
+      - Fri, 29 Jul 2022 09:00:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0607f1eeb2594386b1f474069181e935
+      - 1336f2d50c3547769d58daf613967a4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTk3NjRiNjAtMjQy
-        NS00OTIxLWEzOTMtMWNkMDhmZjc5MGMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NTEuMDU5ODIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTBhZTMyZmQtMjhi
+        Yi00NzA1LWEyMDUtZDI1ZGE5YjA0NDlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDguNjI2MDk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjNmYzVlZGY5YTAwNTQ2MTFhNzJmNTg4Njc3
-        NzE4MjVhIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6NTEuMDky
-        MTI4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMTo1MS4zMzU5
-        MTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6Ijg1MzI2NDQ5OTFjYzRmMGFiODBmMzFiM2E1
+        NWY4ZjZiIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NDguNjY1
+        ODU0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMDo0OS4wODg1
+        MDFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzYzZDZi
-        MmUtZTNkYS00NWJiLThjNjAtNDk2MGRhZGVhYzdlLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjMyOWNl
+        YWEtNTQ0NC00ZjlmLTkxZWYtY2JiNmJlNjYzYjEwLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYjM3YThhY2UtYWUxOS00YzIyLTgyM2QtN2E3MGQx
-        ZTJmNWFlLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZGY4Y2Q4ZjMtYTgzNS00NTgxLTkzMGEtYTVlZWE2
+        NWYyYWNiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:51 GMT
+      - Fri, 29 Jul 2022 09:00:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f33e3602ac1d4a96a861ca1d40e1ec5d
+      - 5fc4c155696f45bf99ff780164502d3c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/6329ceaa-5444-4f9f-91ef-cbb6be663b10/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 39f3ad45fe7b4e8b9632679d4d15e149
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNjMyOWNlYWEtNTQ0NC00ZjlmLTkxZWYtY2JiNmJlNjYzYjEwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6NDguNjg2MzA3WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kZjhjZDhmMy1hODM1LTQ1ODEtOTMwYS1hNWVlYTY1ZjJhY2Iv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2RmOGNkOGYzLWE4MzUtNDU4MS05MzBhLWE1ZWVh
+        NjVmMmFjYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:49 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS82MzI5Y2VhYS01NDQ0LTRmOWYtOTFlZi1jYmI2YmU2NjNiMTAv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - be04bcc212e44fbe8d9afc74eb2ac545
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5MmM5ZDc4LTVmMGQtNDMw
+        Yy1iODFhLWU5N2FhY2VhZGQyNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d92c9d78-5f0d-430c-b81a-e97aaceadd24/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4c11cfee3eb243d1807d5ae5e3b97662
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDkyYzlkNzgtNWYw
+        ZC00MzBjLWI4MWEtZTk3YWFjZWFkZDI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NDkuMzg2NTgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiZTA0YmNjMjEyZTQ0ZmJlOGQ5YWZjNzRl
+        YjJhYzU0NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjQ5LjQ0
+        NDcxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6NDkuNzY4
+        MTAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNGZm
+        ZDVkODMtNzVjMy00ZjI2LTgwMTQtNzM2ZjMwOTY2MDA2LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4ffd5d83-75c3-4f26-8014-736f30966006/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7795d1ded2fd43afa5a369861603db12
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzRmZmQ1ZDgzLTc1YzMtNGYyNi04MDE0LTczNmYzMDk2NjAwNi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjQ5Ljc0OTQ1OFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNjMyOWNlYWEtNTQ0NC00ZjlmLTkxZWYt
+        Y2JiNmJlNjYzYjEwLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 48ac98bd2ac347a9b3a899559d15875c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:51 GMT
+      - Fri, 29 Jul 2022 09:00:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 97c8f79ec0924f15bd1bc85fd1cb1a65
+      - cb36807c21cf41539cc4fb551018678e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:51 GMT
+      - Fri, 29 Jul 2022 09:00:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c0f2fdfd10c94a78bbcab3638b122107
+      - 151abdceb4e549b3b0646c93214b1942
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:51 GMT
+      - Fri, 29 Jul 2022 09:00:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7c165692f837438e817ffd6c4860272b
+      - 79a762dfc3764da8afdd85dc67f4f354
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:51 GMT
+      - Fri, 29 Jul 2022 09:00:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9beacc8df0441b3a43e89bfb45df23b
+      - da172ea0b9494bb5ae44760cf94248d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a59f4cf7d6c3420dab6489a58a50b47e
+      - ee801b28f3384a6ca3a23397a88a7640
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d376495bbdd4befb896c08d281c8155
+      - a9154fd08306452cbdef763c2b2d17cb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21fc7bf2d6784aaca270c5b01fae4c50
+      - f772078d59a74d38a4e03f3aba03eaca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a5a3b40049bf4cb6875f0e07d0d3a93d
+      - 5acd2b3ab47a4f96bef2958b06e0dbca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 36ac558e00e048afb39cacb80332108a
+      - e3b6cd0e9d7b4bb5bd8f336931c0a150
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e07125a3bb8544c6a7a58be0a628f7a3
+      - e1057280ce0c46368f720e1ffb15686f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1449c9576a57406fa83ca281ae9f7417
+      - c0fdf98c9447434c93b54f56cfa86155
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 92f8cbf5b6df46cb8dc09851841006c7
+      - 56897f17d4bb4ba1a4ac3c2cc200dd21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6932184d5a3047a9a2dce3244eb21c24
+      - 1d36aa72f748460cbb1ede3906a499ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/31e77e0e-5d38-45ca-96aa-9424a19ba5fc/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e0d3c39b-7abe-42f2-956a-0749b7b9a457/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,75 +3819,75 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 624059aef8f04140baaa9481e4a242df
+      - 5bcf466825914fe9a6ae154068274cc7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwMzcyZGNkLWMxYzItNGFj
-        YS04ZDNiLTU2NzEzNGM1Yjc2Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2ZDhkNTY1LWZmZjMtNDI2
+        YS05Nzk1LTliODE2ODZmNjY3YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/31e77e0e-5d38-45ca-96aa-9424a19ba5fc/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e0d3c39b-7abe-42f2-956a-0749b7b9a457/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80NjRmNzQ1Mi04ODhiLTQyZjctODMyMi03YTlkZGQ1
-        YThhNzkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NmExMGJiYmYtNTFlMS00MTVhLWEwMGYtNzliNzFhZTFkM2Q0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzhhYTU1NzE0LTFmOTYt
-        NGRiMy04YTMxLTM1MzI1ZmQ3N2NjMC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9iM2QzNTBiMS1mMDcxLTRkYTAtOWI5Zi1lNGQ3
-        M2E4YWIwYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3RyaWJ1
-        dGlvbl90cmVlcy9jN2UzNTQxNy05ZDg3LTQ4ZGUtOThkOC01MmQ2MzViM2Vl
-        YmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8wODc3
-        NjQyNi0zZjNmLTRhNjItYmIxYy05ODRjNTZmYjMwNDMvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmIt
-        OWY4OC01MWRlYTMwMGRlODcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L21vZHVsZW1kcy84MDBiNTVjNi05NzUzLTQzODEtOWQ3OC0wZmRlMmRkZmVl
-        NDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9iMTJh
-        MjE2Zi01ZTU2LTQ4ODEtYWZhZi02OWFjNWU1ZmRjMDIvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4YjIt
-        ODE0My1hNjE5MGRiZWI4YzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L21vZHVsZW1kcy9lNzQxM2ZlMC0zMDY3LTQ1NmQtOTVmYy0wNmIyYmRhMjcy
-        YWMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
-        NjgwZGFhYjItYWE1Yy00NGJkLTg2NjctZTBhZmNhOWY4OTBiLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4
-        Y2MtNGEzOS05OWJmLTQ5NjJiY2MwZmUwNS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNl
-        ZWUyZWY3OGMyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xM2EyNGRmNC03Y2MyLTQ1ZjMtYjViMC01NjhlNmVkMjYzZjUvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMt
-        NGQxZC1hZjU0LTRmMTFhZDBjZjRlNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00YTEyLWI2NzktNWNkM2Rk
-        ZGE5YTU3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkNjBkYTJmLTBhYTctNDZh
-        Zi1iZjZmLWE5YTNkODZlZTE0OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kZmJl
-        NjJhYi04Nzg5LTQ2MjAtYTUyYy03ZmE2YjQ0MDNiYmYvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZDI0NDFlYWEt
-        M2ZjMS00Nzc1LTkyMGUtYTZkNzY4ZDZjMjE3LyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYt
-        NGI3My1hZTRhLTg3YmNhOGViMzllMS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5
-        N2QtOTkyMTM4NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2
-        ZTE4NGQ5MmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1k
-        X2RlZmF1bHRzLzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0
-        YS8iXX0=
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMt
+        NGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3RyaWJ1
+        dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRkNTBh
+        MjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8wYzg0
+        MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTkt
+        YmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3YTEx
+        OTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8zYjli
+        OWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRiNTkt
+        ODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAz
+        ODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
+        NDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQx
+        MGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYt
+        NDE4OS05Y2M1LTZkOGRjMzVjMTBkNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNjJhNDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5
+        OWZiNjFmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        NmQwMjRjMi0xMGZjLTQwMWMtYWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNj
+        NS05MzZmLTlhYTAzNTYzOWYwNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMw
+        YzRjLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNzI0
+        MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2Yt
+        YjljMC00MjMxLTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUt
+        NGVhZi1hNGE4LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEw
+        MmQtZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
+        b2R1bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlm
+        NDliODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1k
+        X2RlZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3
+        MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3475,7 +3900,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:52 GMT
+      - Fri, 29 Jul 2022 09:00:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3493,21 +3918,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb5b0b931d3a4f5883ecba983998cfe8
+      - 647532e5d22a4032b61b06ccb5c01967
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyOWE0OTE5LWMyMTgtNGVi
-        MC04MjZkLTlhMGJhMzk5YzcxZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3NmI4MzlkLTU5OGQtNGVj
+        YS1hNmRhLTc4ZTgzZmYwZmM5OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/429a4919-c218-4eb0-826d-9a0ba399c71f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a76b839d-598d-4eca-a6da-78e83ff0fc98/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3528,53 +3953,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:53 GMT
+      - Fri, 29 Jul 2022 09:00:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b7eb256c81f74f67aa01a94f0aea853a
+      - 43f287f2e42949d28b8d4009552fb10a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDI5YTQ5MTktYzIx
-        OC00ZWIwLTgyNmQtOWEwYmEzOTljNzFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjE6NTIuODI5NzM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTc2YjgzOWQtNTk4
+        ZC00ZWNhLWE2ZGEtNzhlODNmZjBmYzk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6NTEuODc1Mjk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiYjViMGI5MzFkM2E0ZjU4ODNl
-        Y2JhOTgzOTk4Y2ZlOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIx
-        OjUyLjk2ODE2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjE6
-        NTMuMTI2NTcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2NDc1MzJlNWQyMmE0MDMyYjYx
+        YjA2Y2NiNWMwMTk2NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjUyLjA5NjM0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        NTIuMzcwNDA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8zMWU3N2UwZS01ZDM4LTQ1Y2EtOTZhYS05NDI0YTE5YmE1ZmMvdmVyc2lv
+        bS9lMGQzYzM5Yi03YWJlLTQyZjItOTU2YS0wNzQ5YjdiOWE0NTcvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzFlNzdlMGUtNWQzOC00NWNh
-        LTk2YWEtOTQyNGExOWJhNWZjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBkM2MzOWItN2FiZS00MmYy
+        LTk1NmEtMDc0OWI3YjlhNDU3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/df8cd8f3-a835-4581-930a-a5eea65f2acb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3582,7 +4007,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3595,47 +4020,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:53 GMT
+      - Fri, 29 Jul 2022 09:00:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 808c35d35eba406094d3573befe005ac
+      - 61c38913e27e4095bd78c78632aa61fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/31e77e0e-5d38-45ca-96aa-9424a19ba5fc/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e0d3c39b-7abe-42f2-956a-0749b7b9a457/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3643,7 +4068,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3656,42 +4081,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:21:53 GMT
+      - Fri, 29 Jul 2022 09:00:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7420a75937064121860fdf494be0fe31
+      - 5527c8dc6f0e4b9f91c70f47e338b442
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:21:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:52 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_package_groups_repository/all_package_groups_copied_with_no_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_package_groups_repository/all_package_groups_copied_with_no_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:26 GMT
+      - Fri, 29 Jul 2022 09:02:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a7cb13b415444ca9657fc50aaea9f3d
+      - '0339663f3e804dbabb2a4989c5d990cd'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85ZTA2NDVlYS0xN2MxLTRjMmItOGIzYy0xMjc0MTc4MzE1YmEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOToxOS44MTIxMjVa
+        cnBtL3JwbS8zOTc5NjZiMy1jMzM2LTQwOTktYTc5Ny1mNGJkNWY5YWExMGUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjozOS40ODc4MDla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85ZTA2NDVlYS0xN2MxLTRjMmItOGIzYy0xMjc0MTc4MzE1YmEv
+        cnBtL3JwbS8zOTc5NjZiMy1jMzM2LTQwOTktYTc5Ny1mNGJkNWY5YWExMGUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzllMDY0
-        NWVhLTE3YzEtNGMyYi04YjNjLTEyNzQxNzgzMTViYS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM5Nzk2
+        NmIzLWMzMzYtNDA5OS1hNzk3LWY0YmQ1ZjlhYTEwZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:48 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/397966b3-c336-4099-a797-f4bd5f9aa10e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 213374fdfaa3478098b8c3f0a89ff2fa
+      - 2195de5ba5d94e7ea1358e91f5706dc0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1MDk5MWQwLWNjZTktNDZi
-        OS1iMWJjLTdkNWE5YjllNTkzMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzNjgxYTYwLWU5NmYtNDVm
+        OS1iMzdlLWJlMWZiNjA1N2YyYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f598b48f35024871acebddf553474402
+      - c86a4fb0f6644bf4be690296b4b13acd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/650991d0-cce9-46b9-b1bc-7d5a9b9e5930/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f3681a60-e96f-45f9-b37e-be1fb6057f2a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fc60abe646c34242a16aad73a381755c
+      - 2089490bf52c4101bee9d7a9452c2a87
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjUwOTkxZDAtY2Nl
-        OS00NmI5LWIxYmMtN2Q1YTliOWU1OTMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjcuMDIxNjY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjM2ODFhNjAtZTk2
+        Zi00NWY5LWIzN2UtYmUxZmI2MDU3ZjJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NDguNjc3NDY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMTMzNzRmZGZhYTM0NzgwOThiOGMzZjBh
-        ODlmZjJmYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjI3LjA1
-        MzYwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MjcuMjg2
-        MzE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMTk1ZGU1YmE1ZDk0ZTdlYTEzNThlOTFm
+        NTcwNmRjMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjQ4Ljcx
+        OTM0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NDguOTQx
+        NDc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWUwNjQ1ZWEtMTdjMS00YzJi
-        LThiM2MtMTI3NDE3ODMxNWJhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzk3OTY2YjMtYzMzNi00MDk5
+        LWE3OTctZjRiZDVmOWFhMTBlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b94e8f77c0894bba87fb18045854d815
+      - d1e734b9a6cd42438c1436067175d46b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 69136a7db97f4325aec21bf7390d29eb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vOTA3MGQ0ZjYtMTcyYi00NmRjLWIxMDAtOWQ0NGUxNzkzOGNi
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NDMuOTMyNTE1
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/9070d4f6-172b-46dc-b100-9d44e17938cb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c25ac8fc44ba4068a66d633a47dcc495
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFhZjBhZmExLTgxZjEtNDYx
+        OS1iYzliLTI4Y2Q0NDRjMGMxNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1af0afa1-81f1-4619-bc9b-28cd444c0c14/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - dc6b195447bf4e36963f716b84260bd6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWFmMGFmYTEtODFm
+        MS00NjE5LWJjOWItMjhjZDQ0NGMwYzE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NDkuMTMwMTI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMjVhYzhmYzQ0YmE0MDY4YTY2ZDYzM2E0
+        N2RjYzQ5NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjQ5LjE4
+        MjE5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NDkuMjI4
+        NjUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58b2736777c845b3b6d3cb001a0ee6ea
+      - 681133460c9f464f97e95ed6abc0a5d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5aeaee977074c20af4e78f078ab9eae
+      - 299a55136dd44ef8b251423e2d89acd3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 00e75263ce8741f5be2e00b434b1dc93
+      - b3230c9379104d428bd17da50f9a52a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 144b8ce957854f4e9eb2f86d7f791baa
+      - baefd59c68fd4af8b04d3c556b24232f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:29:27 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - ee8a653b8c6a45959e656e101b0229eb
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/7b09870b-a870-49ad-b215-0f7b7f29431c/"
+      - "/pulp/api/v3/remotes/rpm/rpm/609dec35-e4b1-469c-b4ee-91018f25ad69/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0abf7fba158d4a8d86aaf994ef9b1dff
+      - e1bdaa8fc25540c7b6bca4a87aa47ded
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdi
-        MDk4NzBiLWE4NzAtNDlhZC1iMjE1LTBmN2I3ZjI5NDMxYy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI5OjI3LjcyNzk4MloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYw
+        OWRlYzM1LWU0YjEtNDY5Yy1iNGVlLTkxMDE4ZjI1YWQ2OS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjQ5LjY1MzA1N1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI5OjI3LjcyODAwMVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAyOjQ5LjY1MzA4MVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:27 GMT
+      - Fri, 29 Jul 2022 09:02:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/"
+      - "/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4383bb8a5a084f1aa73542913a3742e8
+      - f8bbba406eb14f0ca90367c39043e04c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTkxOTk0NDUtY2RjMi00MTQzLTkyNGMtMzE1MWYyZTMzZGVlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MjcuODk2OTgxWiIsInZl
+        cG0vMjc5M2E3NWYtNTgzNS00YjYwLTk4OTgtNjdjNWU1ZDAxMTdlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NDkuODAwMTM5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTkxOTk0NDUtY2RjMi00MTQzLTkyNGMtMzE1MWYyZTMzZGVlL3ZlcnNp
+        cG0vMjc5M2E3NWYtNTgzNS00YjYwLTk4OTgtNjdjNWU1ZDAxMTdlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85OTE5OTQ0NS1j
-        ZGMyLTQxNDMtOTI0Yy0zMTUxZjJlMzNkZWUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yNzkzYTc1Zi01
+        ODM1LTRiNjAtOTg5OC02N2M1ZTVkMDExN2UvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d8b100b3a5c4e828981568d29e69475
+      - ab25a907e05d4ff49022d9c2a17fac28
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOToyMC41MjQ4NDBa
+        cnBtL3JwbS9hODY3MGJlMS0zM2QxLTQ3OWEtYTFlZi0yN2EwYTkzMmEyNTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjo0MC4zOTM5MDFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYv
+        cnBtL3JwbS9hODY3MGJlMS0zM2QxLTQ3OWEtYTFlZi0yN2EwYTkzMmEyNTEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ZiZWJj
-        YTNlLTA0OGItNDIzOC04MmViLTc0ZWZkNWM3MjQxNi92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2E4Njcw
+        YmUxLTMzZDEtNDc5YS1hMWVmLTI3YTBhOTMyYTI1MS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:49 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a8670be1-33d1-479a-a1ef-27a0a932a251/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ac6abb3b904c4672ab19d892574ace8c
+      - f45ce66411554a3c9bae92b2f73c1f75
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmODI5N2UyLWRiZDktNDQ4
-        ZS1iNzMzLWIyNTMzOWQ1YmUzMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgwMzQ1MTA5LTYxYjUtNDg2
+        NC1hZDJjLWEyZGQzMjVhNDNjOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5da127612e2f45e39efca59be36b70b1
+      - '08e0c31bb4ba473a9addb6cc565ea828'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNDc0NDNjODQtNmY5OC00YzJmLThiYzUtZjRmODBlMDVhNWNjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MTkuNjk1OTczWiIsIm5h
+        cG0vYzQwMzhlMjUtZDk2YS00NGQ1LTg4MzQtNjE3OGFjZWJjNjEwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6MzkuMzQ4Mzg1WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyOToyMC44NDc3NjBaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMjo0MC44MDY0NTFaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/47443c84-6f98-4c2f-8bc5-f4f80e05a5cc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c4038e25-d96a-44d5-8834-6178acebc610/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 919d589964f546beb6b18cf0f61326dc
+      - 046ea1a2a0884f9d9548f943fc66adf8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMxZGM3ZjM4LWNjN2QtNGQz
-        OS04YzQxLTQ5ZjBlMzUxZWJmMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhMGY0OWVkLTQyNjMtNDE0
+        NS1hZmVlLTY2ZjlhYjdkNWUyMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6f8297e2-dbd9-448e-b733-b25339d5be32/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/80345109-61b5-4864-ad2c-a2dd325a43c8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 14749fba1cfd4f7a85256b8e5f5ac297
+      - ebf821d1dbc9445fb1ce56c65aeb6675
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmY4Mjk3ZTItZGJk
-        OS00NDhlLWI3MzMtYjI1MzM5ZDViZTMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjguMDUzMjI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODAzNDUxMDktNjFi
+        NS00ODY0LWFkMmMtYTJkZDMyNWE0M2M4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTAuMDM0MzA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhYzZhYmIzYjkwNGM0NjcyYWIxOWQ4OTI1
-        NzRhY2U4YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjI4LjA4
-        NjY2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MjguMjQ1
-        Mjk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmNDVjZTY2NDExNTU0YTNjOWJhZTkyYjJm
+        NzNjMWY3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjUwLjA5
+        MDk0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NTAuMTk3
+        NDEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4Yi00MjM4
-        LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTg2NzBiZTEtMzNkMS00Nzlh
+        LWExZWYtMjdhMGE5MzJhMjUxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/31dc7f38-cc7d-4d39-8c41-49f0e351ebf3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4a0f49ed-4263-4145-afee-66f9ab7d5e21/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e243b0bd15da43cb962e838a89520406
+      - a783803a64294a1b90b7ca2b7c87117a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzFkYzdmMzgtY2M3
-        ZC00ZDM5LThjNDEtNDlmMGUzNTFlYmYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjguMTQzNjAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGEwZjQ5ZWQtNDI2
+        My00MTQ1LWFmZWUtNjZmOWFiN2Q1ZTIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTAuMTU2NDU3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5MTlkNTg5OTY0ZjU0NmJlYjZiMThjZjBm
-        NjEzMjZkYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjI4LjE3
-        NzYzMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MjguMjI3
-        MzY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNDZlYTFhMmEwODg0ZjlkOTU0OGY5NDNm
+        YzY2YWRmOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjUwLjIx
+        Mjg5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NTAuMjk0
+        MzM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ3NDQzYzg0LTZmOTgtNGMyZi04YmM1
-        LWY0ZjgwZTA1YTVjYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M0MDM4ZTI1LWQ5NmEtNDRkNS04ODM0
+        LTYxNzhhY2ViYzYxMC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b54e56a1b47f461598f381d0ca0502c9
+      - '03095e7176d8493d972aff691abfc567'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eacdb9d3043a4aad8b9da3fae84d07bc
+      - 7d743bbfb1c14692a19771f1a091d42d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8bb44473420a42a583ff10c34f6fff70
+      - 1f977c8af6e24e65b07231b4cdb18e57
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2bf29d338c66456d8112599285133ba2
+      - 3d0339c5dc7d45fd8bfd426dba5a6206
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ec3c89dc44fb4c1aac9ed51fd8bd247c
+      - 4b47035748fc40d484bc2e70ef6944e2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '080f6f5383314b45be0744358e920332'
+      - 0f7815cb6e24429e819a8b69c8de8dda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:28 GMT
+      - Fri, 29 Jul 2022 09:02:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/7ddce089-dafc-4451-9c2b-08fbd5276fa7/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d8113cd8-09f1-4475-a751-0515622fb5a6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 440945df632344d18d80eb8f0cb2133c
+      - 2bf425eade2e4e1fa215f7945fa6842e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2RkY2UwODktZGFmYy00NDUxLTljMmItMDhmYmQ1Mjc2ZmE3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MjguODE0NjI1WiIsInZl
+        cG0vZDgxMTNjZDgtMDlmMS00NDc1LWE3NTEtMDUxNTYyMmZiNWE2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NTAuNzc3MjY5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2RkY2UwODktZGFmYy00NDUxLTljMmItMDhmYmQ1Mjc2ZmE3L3ZlcnNp
+        cG0vZDgxMTNjZDgtMDlmMS00NDc1LWE3NTEtMDUxNTYyMmZiNWE2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83ZGRjZTA4OS1k
-        YWZjLTQ0NTEtOWMyYi0wOGZiZDUyNzZmYTcvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kODExM2NkOC0w
+        OWYxLTQ0NzUtYTc1MS0wNTE1NjIyZmI1YTYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:28 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:50 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/7b09870b-a870-49ad-b215-0f7b7f29431c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/609dec35-e4b1-469c-b4ee-91018f25ad69/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:29 GMT
+      - Fri, 29 Jul 2022 09:02:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aef18e02e1c14458937f7b465bba606e
+      - 0f2183b5130b4e13b87e02cbb1f9dbff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3ZTIzNTYzLTk5MGQtNDM3
-        Ny1iOTg2LTM1NDc5OTExOWQ3ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5ZDFmOTUxLWQ1NWEtNDcz
+        Zi04MmFlLWZhMjQwZjBkYzM0Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b7e23563-990d-4377-b986-354799119d7e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/29d1f951-d55a-473f-82ae-fa240f0dc342/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:29 GMT
+      - Fri, 29 Jul 2022 09:02:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab3cd633c7ad4d3ab86f471e1b00cb85
+      - 540edac7c65247d3b3c93af0a4f6ff40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjdlMjM1NjMtOTkw
-        ZC00Mzc3LWI5ODYtMzU0Nzk5MTE5ZDdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjkuMTE5OTMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjlkMWY5NTEtZDU1
+        YS00NzNmLTgyYWUtZmEyNDBmMGRjMzQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTEuMTM3ODE5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJhZWYxOGUwMmUxYzE0NDU4OTM3ZjdiNDY1
-        YmJhNjA2ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjI5LjE1
-        MDE4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MjkuMTcz
-        NzQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwZjIxODNiNTEzMGI0ZTEzYjg3ZTAyY2Ji
+        MWY5ZGJmZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjUxLjE4
+        MzQ5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NTEuMjA4
+        MjQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdiMDk4NzBiLWE4NzAtNDlhZC1iMjE1
-        LTBmN2I3ZjI5NDMxYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYwOWRlYzM1LWU0YjEtNDY5Yy1iNGVl
+        LTkxMDE4ZjI1YWQ2OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdiMDk4
-        NzBiLWE4NzAtNDlhZC1iMjE1LTBmN2I3ZjI5NDMxYy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYwOWRl
+        YzM1LWU0YjEtNDY5Yy1iNGVlLTkxMDE4ZjI1YWQ2OS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:29 GMT
+      - Fri, 29 Jul 2022 09:02:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ac7f7a379d94abe87cf590e5a80fecf
+      - f8994764f5ef4122b19cc84779691ce6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwNjIyMTMzLWU2ZjYtNDMw
-        Mi1hNDQzLTNkM2Y0YmYxMTdlOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjMmU0MWMwLTc1OTUtNGYy
+        My04MzU0LTAwMjkzZjhjOWEyNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:29 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/30622133-e6f6-4302-a443-3d3f4bf117e9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4c2e41c0-7595-4f23-8354-00293f8c9a26/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:30 GMT
+      - Fri, 29 Jul 2022 09:02:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 59123147fb5943daa2338db0dbeb0317
+      - 1c132a6bede146dd91e5db9509f52760
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '653'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzA2MjIxMzMtZTZm
-        Ni00MzAyLWE0NDMtM2QzZjRiZjExN2U5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjkuMjkxMTMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGMyZTQxYzAtNzU5
+        NS00ZjIzLTgzNTQtMDAyOTNmOGM5YTI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTEuMzAzNjk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI0YWM3ZjdhMzc5ZDk0YWJlODdj
-        ZjU5MGU1YTgwZmVjZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjI5LjMyMDkwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MzAuMDc5NTEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmODk5NDc2NGY1ZWY0MTIyYjE5
+        Y2M4NDc3OTY5MWNlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjUxLjM1MzM5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        NTIuNDg2MTY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzk5MTk5NDQ1LWNkYzItNDE0My05MjRjLTMxNTFm
-        MmUzM2RlZS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85OTE5
-        OTQ0NS1jZGMyLTQxNDMtOTI0Yy0zMTUxZjJlMzNkZWUvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vN2IwOTg3MGItYTg3MC00OWFk
-        LWIyMTUtMGY3YjdmMjk0MzFjLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS8yNzkzYTc1Zi01ODM1LTRiNjAtOTg5OC02N2M1ZTVk
+        MDExN2UvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjc5M2E3
+        NWYtNTgzNS00YjYwLTk4OTgtNjdjNWU1ZDAxMTdlLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYwOWRlYzM1LWU0YjEtNDY5Yy1i
+        NGVlLTkxMDE4ZjI1YWQ2OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:52 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOTkxOTk0NDUtY2RjMi00MTQzLTkyNGMtMzE1MWYyZTMz
-        ZGVlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMjc5M2E3NWYtNTgzNS00YjYwLTk4OTgtNjdjNWU1ZDAx
+        MTdlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:30 GMT
+      - Fri, 29 Jul 2022 09:02:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 796f13de02654dcbaddef0fa84ab12b4
+      - 2b525394348841ea97f45c691969edb0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RhYjE5OWVjLWNjMWUtNGNm
-        ZS05MGIwLWVjZmE3YjcyNWRhNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2OWU0YmQ4LWQyOWUtNDgz
+        Yy04MzEyLWRkZWRmNWFlMjQ3Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dab199ec-cc1e-4cfe-90b0-ecfa7b725da7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/169e4bd8-d29e-483c-8312-ddedf5ae2476/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:30 GMT
+      - Fri, 29 Jul 2022 09:02:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 409003eaf7d14db58f8fdd7c93e06b18
+      - 89adf7a4326144e88b0a4d5e718cb58c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGFiMTk5ZWMtY2Mx
-        ZS00Y2ZlLTkwYjAtZWNmYTdiNzI1ZGE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzAuMzg3NDkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTY5ZTRiZDgtZDI5
+        ZS00ODNjLTgzMTItZGRlZGY1YWUyNDc2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTIuOTE5MDI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6Ijc5NmYxM2RlMDI2NTRkY2JhZGRlZjBmYTg0
-        YWIxMmI0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MzAuNDE2
-        NzQ2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOTozMC43NjAx
-        NDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjJiNTI1Mzk0MzQ4ODQxZWE5N2Y0NWM2OTE5
+        NjllZGIwIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NTIuOTU5
+        NDYyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMjo1My4zODEx
+        MjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMWQ1NmFk
-        NDYtOWZiYi00NmZjLWE0ODUtOWQzMmUzZTViYzNjLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNGVkZTc3
+        MzUtNWFmYi00ZmY2LTg2OTYtY2E5NGMzMjg1OWVmLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOTkxOTk0NDUtY2RjMi00MTQzLTkyNGMtMzE1MWYy
-        ZTMzZGVlLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMjc5M2E3NWYtNTgzNS00YjYwLTk4OTgtNjdjNWU1
+        ZDAxMTdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:30 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 288039344dc2450ab3e17e8f537c156c
+      - ef7753f356e24ab68a095560b31a7463
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/4ede7735-5afb-4ff6-8696-ca94c32859ef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 88128ddab8ff44dea792f94d45b3bc3b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNGVkZTc3MzUtNWFmYi00ZmY2LTg2OTYtY2E5NGMzMjg1OWVmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NTIuOTgyNDQwWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8yNzkzYTc1Zi01ODM1LTRiNjAtOTg5OC02N2M1ZTVkMDExN2Uv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzI3OTNhNzVmLTU4MzUtNGI2MC05ODk4LTY3YzVl
+        NWQwMTE3ZS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:53 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS80ZWRlNzczNS01YWZiLTRmZjYtODY5Ni1jYTk0YzMyODU5ZWYv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 94bff3e2239648d680958b4cef2cad07
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhYmFlODA1LTFkOWEtNDcz
+        MS1hOTZkLTFkMWZlNTM1OTZmZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/babae805-1d9a-4731-a96d-1d1fe53596ff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 99b9dccbbb704abe98d0c48c55340261
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmFiYWU4MDUtMWQ5
+        YS00NzMxLWE5NmQtMWQxZmU1MzU5NmZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTMuNjg4NTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5NGJmZjNlMjIzOTY0OGQ2ODA5NThiNGNl
+        ZjJjYWQwNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjUzLjcy
+        OTU2N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NTQuMDYx
+        NTIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYWU0
+        MmFlNTctODY4OC00YTA2LWFmNmMtYTdlNzFiNzkyYzFlLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/ae42ae57-8688-4a06-af6c-a7e71b792c1e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a96f769e3acc461a8f2285f8b3b4bf81
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2FlNDJhZTU3LTg2ODgtNGEwNi1hZjZjLWE3ZTcxYjc5MmMxZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjU0LjA0Mzg4M1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNGVkZTc3MzUtNWFmYi00ZmY2LTg2OTYt
+        Y2E5NGMzMjg1OWVmLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 166f1e343ed24218b93dc84297aeba68
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 381a245aa43f4658b388aa84da0b85de
+      - c779559ba2f9414bb6f24d3f8fcc9391
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d30f55eefac34d5cbd0f9de60d4ee1d4
+      - 3c5227fb99544d6182a979753cbf5d9a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f39f9808617349839305a41889dec893
+      - 6c15ef5a8cb647079f30a5c85fd073ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fed440d93bd24a6685decc3070f302cc
+      - 954e337c58464dc28283c48b3c159fb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 34b1004619bf4b11a8b3e5b25e75748f
+      - 03466db8ca3142bb951548eaf6ace9d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3cd8277d55324c1b8eaef99d9046229d
+      - 10549fbd830c48338d0d9cd334b5857a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c55ed0b8f33425982e81fc8b33b1c8f
+      - 8ceb46a3e88241be8ba41f9bc3a857a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 669a1019122f4c389c6850cb6affddfd
+      - 36d3bfd60e25406495cce95731816c0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ee53d51e40624531a88f48a01dce96b4
+      - f9e4277817d74e60bbe577a0e6cfaa3b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 807ead8d4e3145c09096956891e6e9c3
+      - 3060df19b26f476b8d51f6c64c474d1b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6bd4783ca96c4dc192ee2e37f24a3386
+      - 9f8d438fa0ae465380d74aa70f0c281f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,47 +3637,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:31 GMT
+      - Fri, 29 Jul 2022 09:02:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 13d7fa85f54e42d38022bf54c55e5a01
+      - 2f8ca15485484d2fbbe090b5677f76e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:31 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3260,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3273,37 +3698,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:32 GMT
+      - Fri, 29 Jul 2022 09:02:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f631bb0fb2645e593103e0645740def
+      - bad037a37a9145f8b33d3e86f2c3ca09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3314,12 +3739,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3330,12 +3755,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3346,14 +3771,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7ddce089-dafc-4451-9c2b-08fbd5276fa7/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d8113cd8-09f1-4475-a751-0515622fb5a6/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:32 GMT
+      - Fri, 29 Jul 2022 09:02:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,99 +3819,99 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3a2bd7a2c7541b78e70dd4fba2c8f20
+      - 2313545592c4461a8dfac64868bf8615
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE0YTdiNDdmLWMwNWEtNDM4
-        OC04MDdjLWM1MTM1YmVlMDJjMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2YzM5ZmE0LTQ0Y2QtNGJm
+        NS1hNzNjLWU0NmYyNGQ0ZGZhZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7ddce089-dafc-4451-9c2b-08fbd5276fa7/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d8113cd8-09f1-4475-a751-0515622fb5a6/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8wMTJlMDA1OS0zZGE0LTRjNGUtOWVmNy1kMDhlMTM4
-        Njg0ZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        MjFhNDk3NzEtODJmMy00MWQ4LTk3YTgtZDQ5NDM5MTgxNzAzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUt
-        NDMzYy1hM2NkLTY0MWMxMDA5NTExMy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEw
-        NmE0Y2Y5NTAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvNjNmYmYwMmEtNDI1OS00M2FlLTlhNzYtMTJiZmI4Nzg5NTZmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzdhYWQwMzA4LTE4
-        MmMtNGM0YS04ZTFkLWQ3MTUzYWQ3ODQyMi8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vYWR2aXNvcmllcy9mMTc4OTMwOC1kMjNkLTQ0ODAtOGYyMS0y
-        YzkyMDEwNzEzZjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
-        aWJ1dGlvbl90cmVlcy81ODk3OTA5OS01NmNlLTQxNWQtYjg3My0yMTRhNzM1
-        NmQxMDAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy80
-        ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy80ZTU2MTBlNy05MzQ3LTRi
-        MzgtODI1Zi0yMjRmOGE2ZjM4N2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy81NjhjN2EzMC02OTcwLTQ4ZGEtOGI4NS1mOTNiZGMx
-        MWY3NjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy84
-        YWFiODJhMy1kZDIwLTRkMTctOTYwNS03NDk2NmUzZWM2OWIvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2
-        MmEtYWIyMC0wNjJhYmNiNGFjZWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL21vZHVsZW1kcy9kNGZiODc4MS0zOTAzLTQ1NzAtOTNkYy0xNzYzMWNj
-        NGY0Y2IvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvMGZjYTEwM2MtMmVjNi00NDdiLWFjNzEtNmIyYzg2YWQ4ZGJiLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRk
-        LTAzZDctNDkwZC1hYjk2LWZkMmU3MWE2ZGFhMy8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMDNmOGVlNGYtNWI3MS00MTU1LWE0NzMt
-        Zjc5YzU1MDQzMWUzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8wNTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3
-        MzEtNGFjMy1iNGQ3LTZlNjdlNTkzZWQzMy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00NDVkLWE4NzctOTM5
-        OWY4ZTY1YzBkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yOWU2YTIxZC0yZjY5LTRjZDItYjcxMS02MWNjODljZjcwY2UvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM3YzM4MGEwLWFhZmYt
-        NDNmMi05YTZkLTdhMjUyYjA5YWE5Ni8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkw
-        ZWZhN2VmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80
-        OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2MvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUwYzgyZTlkLWFmODktNDMx
-        My1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZj
-        ODVkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83NjA4
-        Y2UzNy0xYzcxLTRhZDAtOTBhYy1lZWQ3NDYwYzU2MWIvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1h
-        YjM5LTgwZDAyMTliZDQ4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvOGIyNTE3MzgtNmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZm
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThjNWEtNDgwMS1iNTY3
-        LTFmMmIxZGI3M2RlYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvYTE5ZTQ3Y2ItZDZkNi00MmVhLTk3MzItMzI4NTIxNjQyNDJlLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jYmIzODQ4Ny05
-        Njc3LTRhNDMtODNlMy00MzkwYjNkMjA1YjQvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZm
-        ODUwYjkyNmU1Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZjA3NzkyYzMtYTQyZC00NzBjLWEyNjAtYmViYTYyMDAzNDlmLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2Ex
-        LTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZjQ3YTNmZTYtMmM0Ni00M2Vk
-        LWJlZjQtZDMxMjQ0MTFiZDI0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZm
-        LWM5NTMxYzI0OWFkYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUzYThj
-        ZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
-        ZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3NjQ4NmIv
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM5YjRlNGY3LWQ3N2Mt
+        NDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkz
+        MDA1ZmRmOTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkx
+        NGMtNGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1i
+        OTFkMDZjNDViNmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3Ry
+        aWJ1dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRk
+        NTBhMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8w
+        Yzg0MTgwZC05OGU2LTQ4MzktOWU3Zi0yY2IyNzU0MjkyOTMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8xNWVhNzgwMC05Y2RlLTRl
+        OTktYmFlMy03MGQ0YzZlOTA3NzUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy8zYjA2ZDI0Ni0yYTkyLTQwZTUtYWUwNS1lYjE0ZWY3
+        YTExOTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy8z
+        YjliOWI1OS0yNmVmLTRmNzgtYWRjMC1lZTg2NzhhZDE5MTkvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kcy82MjUxNWU4NS0wNTU1LTRi
+        NTktODQzYy0wNWU4MDU1NjVkNzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL21vZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdh
+        YzAzODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNDU4YzFkODQtNzVmMS00ZmFkLWI1NWYtMTRiZjIxY2JkYmU5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0
+        LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvMDVlMzY4ZDctMjkxYS00MzM2LWFkYmQt
+        ZDg5YjdiMDFkODQ2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1iMjc2ZmZhN2U4MjYvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzM1YmJhMDBiLTZm
+        MTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJh
+        YTQ4MzVhYzVhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy80ODA2MDhjMS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMt
+        NGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1ZmJiOTc0LTE1MmMtNDk2
+        ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3
+        YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4
+        M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04
+        MTMzLTFiZjc1ZmRkMjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNhMzhh
+        Mi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJi
+        LTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02
+        MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEyLTI0
+        MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMx
+        LTg3ZDItZTEzMDNiZmRmYTVmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4
+        LTZlNzE5NTdjYjE3Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
+        dWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQtZjIwM2Nh
+        MzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZF9k
+        ZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDliODIzMjMv
         IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRz
-        L2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8iXX0=
+        L2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3499,7 +3924,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:32 GMT
+      - Fri, 29 Jul 2022 09:02:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3517,21 +3942,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b07fcb025e60435f83508c470015d430
+      - 26fdba8b1972454ba962b9baef38db84
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5NWU3YjJhLWIzMWQtNDE2
-        My1hYTViLWY5Y2MxMjg5YWNjZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5YThhYjFhLTU4MTQtNDgw
+        Mi1hNmIxLWMwNThhZWYxYWM4OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a95e7b2a-b31d-4163-aa5b-f9cc1289acce/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/19a8ab1a-5814-4802-a6b1-c058aef1ac88/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3552,53 +3977,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:32 GMT
+      - Fri, 29 Jul 2022 09:02:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 545221f4706843058348b01156cefd57
+      - 4ac9f40201cc4e038d2f0e2bd7524870
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTk1ZTdiMmEtYjMx
-        ZC00MTYzLWFhNWItZjljYzEyODlhY2NlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzIuMTIyOTMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTlhOGFiMWEtNTgx
+        NC00ODAyLWE2YjEtYzA1OGFlZjFhYzg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTYuMzMxMTgzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiMDdmY2IwMjVlNjA0MzVmODM1
-        MDhjNDcwMDE1ZDQzMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjMyLjM1ODEyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MzIuNjMzMDUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyNmZkYmE4YjE5NzI0NTRiYTk2
+        MmI5YmFlZjM4ZGI4NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAy
+        OjU2LjU4OTY0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6
+        NTYuODc5NDAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83ZGRjZTA4OS1kYWZjLTQ0NTEtOWMyYi0wOGZiZDUyNzZmYTcvdmVyc2lv
+        bS9kODExM2NkOC0wOWYxLTQ0NzUtYTc1MS0wNTE1NjIyZmI1YTYvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2RkY2UwODktZGFmYy00NDUx
-        LTljMmItMDhmYmQ1Mjc2ZmE3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDgxMTNjZDgtMDlmMS00NDc1
+        LWE3NTEtMDUxNTYyMmZiNWE2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7ddce089-dafc-4451-9c2b-08fbd5276fa7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d8113cd8-09f1-4475-a751-0515622fb5a6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3606,7 +4031,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3619,38 +4044,38 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:32 GMT
+      - Fri, 29 Jul 2022 09:02:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b07f11bebb042948571cdb79cf84635
+      - c098c8b46d4f439bb7aef292bb695e5b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:32 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:57 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_package_groups_repository/package_groups_as_a_filter_rule.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_package_groups_repository/package_groups_as_a_filter_rule.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:33 GMT
+      - Fri, 29 Jul 2022 09:02:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f57090768ec4c529037136f1dfa69c9
+      - 0f1f7e49ee2b4e5787b916071b77efb6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85OTE5OTQ0NS1jZGMyLTQxNDMtOTI0Yy0zMTUxZjJlMzNkZWUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOToyNy44OTY5ODFa
+        cnBtL3JwbS8yNzkzYTc1Zi01ODM1LTRiNjAtOTg5OC02N2M1ZTVkMDExN2Uv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjo0OS44MDAxMzla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85OTE5OTQ0NS1jZGMyLTQxNDMtOTI0Yy0zMTUxZjJlMzNkZWUv
+        cnBtL3JwbS8yNzkzYTc1Zi01ODM1LTRiNjAtOTg5OC02N2M1ZTVkMDExN2Uv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk5MTk5
-        NDQ1LWNkYzItNDE0My05MjRjLTMxNTFmMmUzM2RlZS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI3OTNh
+        NzVmLTU4MzUtNGI2MC05ODk4LTY3YzVlNWQwMTE3ZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:33 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:58 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/99199445-cdc2-4143-924c-3151f2e33dee/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2793a75f-5835-4b60-9898-67c5e5d0117e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:33 GMT
+      - Fri, 29 Jul 2022 09:02:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7bfaf59307084e88a9d5c4e04eac5a79
+      - 38d6311118a449369679b313607106ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzMTRlYjljLTFhN2YtNDI3
-        Yi05NzVkLTI1ZTE1ZmFlZTlhMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc1NmE3NDlhLTQ4YmItNDQy
+        MC04OGE3LTY4MzYzYjBiYmY3NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:33 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:33 GMT
+      - Fri, 29 Jul 2022 09:02:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ffa3eb9530c419b992695b84201ad05
+      - 60754c65966c4f5191e17fb620c44245
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:33 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d314eb9c-1a7f-427b-975d-25e15faee9a0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/756a749a-48bb-4420-88a7-68363b0bbf75/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ac16c0436cc2474aadceb81ce1f21d33
+      - 0103d918ab2c44b6a03605fac2a34dcf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDMxNGViOWMtMWE3
-        Zi00MjdiLTk3NWQtMjVlMTVmYWVlOWEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzMuODMyMTE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzU2YTc0OWEtNDhi
+        Yi00NDIwLTg4YTctNjgzNjNiMGJiZjc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTguNjgwMDI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3YmZhZjU5MzA3MDg0ZTg4YTlkNWM0ZTA0
-        ZWFjNWE3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjMzLjg2
-        NDQyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MzQuMTA3
-        MzQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzOGQ2MzExMTE4YTQ0OTM2OTY3OWIzMTM2
+        MDcxMDZhZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjU4Ljcz
+        NDg2NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NTguOTgx
+        NzMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTkxOTk0NDUtY2RjMi00MTQz
-        LTkyNGMtMzE1MWYyZTMzZGVlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjc5M2E3NWYtNTgzNS00YjYw
+        LTk4OTgtNjdjNWU1ZDAxMTdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae2713d4a9dd427c9052c694195b294a
+      - f087f65c2ed2400cb6bf0d019dd8aa29
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e3225932fb1c4aa5be2d65d724e7442d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vYWU0MmFlNTctODY4OC00YTA2LWFmNmMtYTdlNzFiNzkyYzFl
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NTQuMDQzODgz
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/ae42ae57-8688-4a06-af6c-a7e71b792c1e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - dc1d2fa895374923b3231ffd46f70c9b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2MGEyMTRjLWIyZWItNDQw
+        OC1iMmNlLTRjN2JkZjI4MjAwNi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/560a214c-b2eb-4408-b2ce-4c7bdf282006/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - cc07f514e3ce49d489931218c4c00e87
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTYwYTIxNGMtYjJl
+        Yi00NDA4LWIyY2UtNGM3YmRmMjgyMDA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTkuMTY2OTU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkYzFkMmZhODk1Mzc0OTIzYjMyMzFmZmQ0
+        NmY3MGM5YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjU5LjIx
+        NTYzOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDI6NTkuMjU0
+        ODIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 26613c66d28240a096cc88bbdd89e38b
+      - 85b8df6e75134ca8936a5c8ceca7ddd6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 47b344d9e78546428e9bdaa94da96d1c
+      - 7db8f033c1c143198306c913600a6cd0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 65f61e803cdd4dca8db259cd7561fb43
+      - 841db07fc14448cb82a77b769811bd9a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3151f6513b594cf3be839aa2820c9355
+      - 4976c8da0ebf48ecbbd629f4a7b976fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:29:34 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 42143296452a44a58d7329fbf51e48d4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/4cd86df1-8972-4eae-b57c-47cd7afef695/"
+      - "/pulp/api/v3/remotes/rpm/rpm/4bb6b38e-7132-46e0-a900-f0e95f63318c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - de85a66bcce54c51a48dce01da6a4a33
+      - 20f4e314d4624a6898a1773903bb8acd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRj
-        ZDg2ZGYxLTg5NzItNGVhZS1iNTdjLTQ3Y2Q3YWZlZjY5NS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI5OjM0LjU2NDQ3NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRi
+        YjZiMzhlLTcxMzItNDZlMC1hOTAwLWYwZTk1ZjYzMzE4Yy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAyOjU5LjU1MjczMVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI5OjM0LjU2NDQ5NVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDA5OjAyOjU5LjU1Mjc1NVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/"
+      - "/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 89f47a60cdf04670a7fae6069cc6ad70
+      - 7b01dc8fb2094ee9ba03b0c8771e03ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzBlZjhkYTItNmQ1Zi00Yjg4LTk0ZmQtYWE5MWNiYjAxMmVjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MzQuNzA4ODQ0WiIsInZl
+        cG0vYWRjOGVjNTctNjUxOC00MDhjLThiNmItYzliODRjMzkzYzE3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NTkuNzAyNTQyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzBlZjhkYTItNmQ1Zi00Yjg4LTk0ZmQtYWE5MWNiYjAxMmVjL3ZlcnNp
+        cG0vYWRjOGVjNTctNjUxOC00MDhjLThiNmItYzliODRjMzkzYzE3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMGVmOGRhMi02
-        ZDVmLTRiODgtOTRmZC1hYTkxY2JiMDEyZWMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hZGM4ZWM1Ny02
+        NTE4LTQwOGMtOGI2Yi1jOWI4NGMzOTNjMTcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0b1f2326717f4f8889a3cf3fb0e285f4
+      - 174c3e4bde5c4c22bc5aed447c688c42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83ZGRjZTA4OS1kYWZjLTQ0NTEtOWMyYi0wOGZiZDUyNzZmYTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOToyOC44MTQ2MjVa
+        cnBtL3JwbS9kODExM2NkOC0wOWYxLTQ0NzUtYTc1MS0wNTE1NjIyZmI1YTYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMjo1MC43NzcyNjla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83ZGRjZTA4OS1kYWZjLTQ0NTEtOWMyYi0wOGZiZDUyNzZmYTcv
+        cnBtL3JwbS9kODExM2NkOC0wOWYxLTQ0NzUtYTc1MS0wNTE1NjIyZmI1YTYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdkZGNl
-        MDg5LWRhZmMtNDQ1MS05YzJiLTA4ZmJkNTI3NmZhNy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q4MTEz
+        Y2Q4LTA5ZjEtNDQ3NS1hNzUxLTA1MTU2MjJmYjVhNi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7ddce089-dafc-4451-9c2b-08fbd5276fa7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d8113cd8-09f1-4475-a751-0515622fb5a6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:02:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b5b0dc8c0ba4f9e901749c16265ce6d
+      - cb4c4db4430a464fb9d0ea06bbfba2f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlMzVkMmZiLWI4NTEtNDlk
-        My05NmQxLWJkZjA2ZjQ1ZGRiNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdkZDQ4ODk2LThkMDctNDgy
+        NC05OWQ4LTg0MGQxOGI3MWI1YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:02:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b11aa48a7f14f9888fa4e0295378011
+      - 81e97cc42f49493bb75455fe516f7a2b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '368'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vN2IwOTg3MGItYTg3MC00OWFkLWIyMTUtMGY3YjdmMjk0MzFjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MjcuNzI3OTgyWiIsIm5h
+        cG0vNjA5ZGVjMzUtZTRiMS00NjljLWI0ZWUtOTEwMThmMjVhZDY5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDI6NDkuNjUzMDU3WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyOToyOS4xNjkzMTJaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQwOTowMjo1MS4yMDM0NzFaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/7b09870b-a870-49ad-b215-0f7b7f29431c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/609dec35-e4b1-469c-b4ee-91018f25ad69/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:34 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 37cddd31fbf049adba1938bc2b3716ed
+      - 5667b4c73fe1435081df086075a07808
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3ZDlkZmM4LTA0OGMtNDBj
-        OC1iY2FlLTlkNmQxMGFiYzA0ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyMWNhZTZhLWQxZmEtNGI3
+        Ni04MWI3LTU0ZDU0MjAzMzQxMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:34 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/de35d2fb-b851-49d3-96d1-bdf06f45ddb4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7dd48896-8d07-4824-99d8-840d18b71b5a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '0128919ca4a14b54beb9b66d45db8fca'
+      - 258cc6f9511d4b16b5fbe8b7cd901542
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGUzNWQyZmItYjg1
-        MS00OWQzLTk2ZDEtYmRmMDZmNDVkZGI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzQuODcyMTkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2RkNDg4OTYtOGQw
+        Ny00ODI0LTk5ZDgtODQwZDE4YjcxYjVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDI6NTkuOTMyOTc4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxYjViMGRjOGMwYmE0ZjllOTAxNzQ5YzE2
-        MjY1Y2U2ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjM0Ljkw
-        MzI5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MzUuMDY3
-        ODg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjYjRjNGRiNDQzMGE0NjRmYjlkMGVhMDZi
+        YmZiYTJmMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAyOjU5Ljk4
+        MTI5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MDAuMDc2
+        NjM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2RkY2UwODktZGFmYy00NDUx
-        LTljMmItMDhmYmQ1Mjc2ZmE3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDgxMTNjZDgtMDlmMS00NDc1
+        LWE3NTEtMDUxNTYyMmZiNWE2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/47d9dfc8-048c-40c8-bcae-9d6d10abc04d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e21cae6a-d1fa-4b76-81b7-54d542033412/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf3f52163397484eb1a84dfa5f7bf51e
+      - 6b723553f83040c09a8e5832897d592d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDdkOWRmYzgtMDQ4
-        Yy00MGM4LWJjYWUtOWQ2ZDEwYWJjMDRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzQuOTYxMTE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTIxY2FlNmEtZDFm
+        YS00Yjc2LTgxYjctNTRkNTQyMDMzNDEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MDAuMDc2Mzg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzN2NkZGQzMWZiZjA0OWFkYmExOTM4YmMy
-        YjM3MTZlZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjM0Ljk5
-        NjcyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MzUuMTQ2
-        ODE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NjY3YjRjNzNmZTE0MzUwODFkZjA4NjA3
+        NWEwNzgwOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjAwLjEx
+        NjQ4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MDAuMTc0
+        ODg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdiMDk4NzBiLWE4NzAtNDlhZC1iMjE1
-        LTBmN2I3ZjI5NDMxYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYwOWRlYzM1LWU0YjEtNDY5Yy1iNGVl
+        LTkxMDE4ZjI1YWQ2OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab5c3f8c55874bb9b03cba1425432925
+      - 43ce771078d744878998860cd062af12
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5905979391fb42e68c0b04ad7f244b76
+      - 5a7fa2623e80494cbd30611c2e95df3a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1ff69b229fc4823a66c2d3cc9ca07ac
+      - 3ff5c877f55f46db92c0436df9a2a4d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f483e3d768ad42529ba764c2e5a56e7b
+      - 94940efc80604168819309cd1a7e9360
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 34c49fe03bcb4a75bba7dc5848384ab9
+      - b9623f3053e0486eb6fd150fa53f50f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 23791a465bb54bd895a3777ca27c7b82
+      - 545c41f378a94522ace32dfbf60e95b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/"
+      - "/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2731529a77345b9aa3107d5f5961e59
+      - 5d69d2bbbe5e4997858e4ffb41e41b5b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmY1MGYyM2MtZmVmYi00YTNmLTgxN2YtNjJhZDVlNDBhNTg0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MzUuNTY5MTY4WiIsInZl
+        cG0vYWZiNmFlOGItMzlhMC00ZmIwLTk3MzctMGVjZjhhYTYyMDQ2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MDAuNjQ0MzgzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmY1MGYyM2MtZmVmYi00YTNmLTgxN2YtNjJhZDVlNDBhNTg0L3ZlcnNp
+        cG0vYWZiNmFlOGItMzlhMC00ZmIwLTk3MzctMGVjZjhhYTYyMDQ2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82ZjUwZjIzYy1m
-        ZWZiLTRhM2YtODE3Zi02MmFkNWU0MGE1ODQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hZmI2YWU4Yi0z
+        OWEwLTRmYjAtOTczNy0wZWNmOGFhNjIwNDYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:00 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/4cd86df1-8972-4eae-b57c-47cd7afef695/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/4bb6b38e-7132-46e0-a900-f0e95f63318c/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:35 GMT
+      - Fri, 29 Jul 2022 09:03:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b81e9aba6c504175a9f151cf0306328c
+      - d583ee6d9a4e40578ddc87e712515924
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyNDk4ZDM3LTM1YWUtNDkz
-        YS04Y2QyLWU1MWE0MzUxZGY1ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlMzc1MjZjLWZkMWUtNDQ4
+        Ni1hOGU5LTUyNTA1MjRmMmMzNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:35 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c2498d37-35ae-493a-8cd2-e51a4351df5d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ee37526c-fd1e-4486-a8e9-5250524f2c35/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:36 GMT
+      - Fri, 29 Jul 2022 09:03:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 524fb591dc1a42bcbd65e383b68d73dc
+      - 8c0edf5a027b469dbe0af0c809d6be95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzI0OThkMzctMzVh
-        ZS00OTNhLThjZDItZTUxYTQzNTFkZjVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzUuODk5NTk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWUzNzUyNmMtZmQx
+        ZS00NDg2LWE4ZTktNTI1MDUyNGYyYzM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MDAuOTkyMTIxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJiODFlOWFiYTZjNTA0MTc1YTlmMTUxY2Yw
-        MzA2MzI4YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjM1Ljkz
-        NTQzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MzUuOTYy
-        MDIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkNTgzZWU2ZDlhNGU0MDU3OGRkYzg3ZTcx
+        MjUxNTkyNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjAxLjA0
+        NjUzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MDEuMTEy
+        MjA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRjZDg2ZGYxLTg5NzItNGVhZS1iNTdj
-        LTQ3Y2Q3YWZlZjY5NS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRiYjZiMzhlLTcxMzItNDZlMC1hOTAw
+        LWYwZTk1ZjYzMzE4Yy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:01 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRjZDg2
-        ZGYxLTg5NzItNGVhZS1iNTdjLTQ3Y2Q3YWZlZjY5NS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRiYjZi
+        MzhlLTcxMzItNDZlMC1hOTAwLWYwZTk1ZjYzMzE4Yy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:36 GMT
+      - Fri, 29 Jul 2022 09:03:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2b79764e7394579be52d8a036f94784
+      - b4f35a58e1604669888eb29fbca104b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzM2RhZmVmLTBhOTktNDUx
-        Yi1iYTcxLWM1NGIwM2FlMDg5ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE3ZDUwYjRhLTFmYTEtNGVj
+        Ny04NzAzLTJkZDM4YzIzZDc3OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:36 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/633dafef-0a99-451b-ba71-c54b03ae089e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/17d50b4a-1fa1-4ec7-8703-2dd38c23d778/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:37 GMT
+      - Fri, 29 Jul 2022 09:03:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd7c9b488f5d4791a29b491046c2df94
+      - 53f299c3ef654fa5b87d5a8f0ee89ad7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '653'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjMzZGFmZWYtMGE5
-        OS00NTFiLWJhNzEtYzU0YjAzYWUwODllLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzYuMDg0MTQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdkNTBiNGEtMWZh
+        MS00ZWM3LTg3MDMtMmRkMzhjMjNkNzc4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MDEuMzYzNjE4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJjMmI3OTc2NGU3Mzk0NTc5YmU1
-        MmQ4YTAzNmY5NDc4NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjM2LjEyNzg3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MzYuOTE0MjQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJiNGYzNWE1OGUxNjA0NjY5ODg4
+        ZWIyOWZiY2ExMDRiOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAz
+        OjAxLjQyNzY3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6
+        MDIuNTY5NzExWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzMwZWY4ZGEyLTZkNWYtNGI4OC05NGZkLWFhOTFj
-        YmIwMTJlYy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMGVm
-        OGRhMi02ZDVmLTRiODgtOTRmZC1hYTkxY2JiMDEyZWMvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNGNkODZkZjEtODk3Mi00ZWFl
-        LWI1N2MtNDdjZDdhZmVmNjk1LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9hZGM4ZWM1Ny02NTE4LTQwOGMtOGI2Yi1jOWI4NGMz
+        OTNjMTcvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRjOGVj
+        NTctNjUxOC00MDhjLThiNmItYzliODRjMzkzYzE3LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRiYjZiMzhlLTcxMzItNDZlMC1h
+        OTAwLWYwZTk1ZjYzMzE4Yy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:37 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:02 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMzBlZjhkYTItNmQ1Zi00Yjg4LTk0ZmQtYWE5MWNiYjAx
-        MmVjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYWRjOGVjNTctNjUxOC00MDhjLThiNmItYzliODRjMzkz
+        YzE3L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:37 GMT
+      - Fri, 29 Jul 2022 09:03:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66098483c7c34a2f95cd9f4da2b35562
+      - a9fbd1b8f4f2418ba5efe75102a4b88e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBkZDJiZTIzLWUzYTUtNDAw
-        Mi04MTc5LWU5MzE5MDFmZDZhMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhNzQyZWUzLWM2MmMtNDMw
+        Mi1hNGRmLWQ4MjFhZWE1MmJiOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:37 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0dd2be23-e3a5-4002-8179-e931901fd6a2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0a742ee3-c62c-4302-a4df-d821aea52bb8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:37 GMT
+      - Fri, 29 Jul 2022 09:03:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2252680272854501902bd84f051e7279
+      - 05acf002868748c78c6ecc8249fd7955
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGRkMmJlMjMtZTNh
-        NS00MDAyLTgxNzktZTkzMTkwMWZkNmEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzcuMTk4MzI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGE3NDJlZTMtYzYy
+        Yy00MzAyLWE0ZGYtZDgyMWFlYTUyYmI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MDIuOTg3OTk4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjY2MDk4NDgzYzdjMzRhMmY5NWNkOWY0ZGEy
-        YjM1NTYyIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MzcuMjI4
-        OTk0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOTozNy42MDYw
-        MjFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImE5ZmJkMWI4ZjRmMjQxOGJhNWVmZTc1MTAy
+        YTRiODhlIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MDMuMDMw
+        NzEwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMzowMy40MzY5
+        ODZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vODc1ODJk
-        MTAtZmZiMy00Y2RkLWFiOTUtY2QwMzBkYzgyOWM5LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYjBiNTI2
+        YjgtOGIyOS00OWRlLTk5MWMtNDcxZjA5MWQyMTU0LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMzBlZjhkYTItNmQ1Zi00Yjg4LTk0ZmQtYWE5MWNi
-        YjAxMmVjLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYWRjOGVjNTctNjUxOC00MDhjLThiNmItYzliODRj
+        MzkzYzE3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:37 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:37 GMT
+      - Fri, 29 Jul 2022 09:03:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3cc829f03c5f434ca5d304e34a51d4f2
+      - aa81b799fc174ba5be90fba42a0a8969
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/b0b526b8-8b29-49de-991c-471f091d2154/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 51112e37caf94249a1191cc47e81f661
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYjBiNTI2YjgtOGIyOS00OWRlLTk5MWMtNDcxZjA5MWQyMTU0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MDMuMDU1MzkyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hZGM4ZWM1Ny02NTE4LTQwOGMtOGI2Yi1jOWI4NGMzOTNjMTcv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2FkYzhlYzU3LTY1MTgtNDA4Yy04YjZiLWM5Yjg0
+        YzM5M2MxNy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:03 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9iMGI1MjZiOC04YjI5LTQ5ZGUtOTkxYy00NzFmMDkxZDIxNTQv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 99f6a752c7ef4f84ae9ee9621854dbd3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4YjYyNjkxLWI4YTktNDM2
+        Ny04NDZmLTFmMWI5ZDYxYTU1Mi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/88b62691-b8a9-4367-846f-1f1b9d61a552/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 67f4899d18e7413ab783fd4a120234b7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODhiNjI2OTEtYjhh
+        OS00MzY3LTg0NmYtMWYxYjlkNjFhNTUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MDMuNjcxODE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5OWY2YTc1MmM3ZWY0Zjg0YWU5ZWU5NjIx
+        ODU0ZGJkMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjAzLjcy
+        MDAxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MDQuMDcx
+        NjM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vOTNl
+        Y2NkYzUtNDJmMC00YzA2LWFmZTEtMGMyNzU1NDNkMmIwLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/93eccdc5-42f0-4c06-afe1-0c275543d2b0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 426beb076c4c4aa9bb49989643b4c20d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzkzZWNjZGM1LTQyZjAtNGMwNi1hZmUxLTBjMjc1NTQzZDJiMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAzOjA0LjA1MDI0NVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYjBiNTI2YjgtOGIyOS00OWRlLTk5MWMt
+        NDcxZjA5MWQyMTU0LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 077f648f1f0b491995772c46e41446bc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:37 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39a1d79d8dc04a599e687ac533004274
+      - 9fe632248c10481fb873840805ac1b4e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - de3978ef8dc74ee5bcc050896c69d992
+      - 9b6f29de950b4f0486d8052cd0b0b814
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c34030d9693844cba56b0a8c358069a6
+      - 7ba326adffa34f379bdbb28ea09fd604
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9b77d69342149e383930002e1aa2bf0
+      - 3d8a896cb4d34a2a91c4dc4d35877e85
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 16a9698a761841c99f158030fcf3fcac
+      - 8692d381336c4e1290ecd22c281508c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d518a72fa8b4dbc85d09a62016e7cab
+      - 4af14ce523ab4e3db9bbc26fd5b439b5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2795,10 +3220,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2806,7 +3231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2819,35 +3244,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc761cf2bbc241ee92500a515bf36a3b
+      - a570d8a482c44c91a29966a0b6332590
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2886,10 +3311,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2897,7 +3322,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2910,35 +3335,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7b2f91d2e624bb28e2ef11f712db526
+      - 51f8d6b988d5487c8ec49619df990d09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2977,10 +3402,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 731376df623a4db1af1e6e4c6758cf20
+      - b185048230a9400c92baf686a89db3fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,35 +3489,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 593bd6e6374848df99af7cd2139cc0c2
+      - ab4abeb1a1344ac5ae7574ccb3e4384f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3103,10 +3528,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3114,7 +3539,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3127,37 +3552,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b58c40b035f04817925502efed081ef6
+      - 5c4233a3e43c4056a06e22c38c02208a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3168,7 +3593,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3176,10 +3601,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3187,7 +3612,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3200,36 +3625,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8bbdab99adc84b8d8b09f0a8100f2fc8
+      - 84d42ff416e14c7da46f86486ef6781d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3251,10 +3676,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3262,7 +3687,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3275,47 +3700,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:38 GMT
+      - Fri, 29 Jul 2022 09:03:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3797925955434402a13319f8409b65bb
+      - f8b5f03118604ffbb7348000f2f4ca42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:38 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adc8ec57-6518-408c-8b6b-c9b84c393c17/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3323,7 +3748,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3336,37 +3761,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:39 GMT
+      - Fri, 29 Jul 2022 09:03:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 189c525e29554bc7a6cee7a6a4ccf7cc
+      - 4900d2acc4cc454a9a8c35aea8bbeebc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3377,12 +3802,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3393,12 +3818,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3409,14 +3834,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3426,7 +3851,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3439,7 +3864,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:39 GMT
+      - Fri, 29 Jul 2022 09:03:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3457,55 +3882,55 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b6f076f130bb4adfa493424530e25e89
+      - b12e4c819ab74787b3b14a7d10856e60
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjYzZmY2JkLWFlYTctNDlj
-        MS1iMDAzLTYxMGZlMGZjY2VhMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlYzA2Y2JlLTc4YzQtNGQ1
+        ZS1hMzRhLTBjNGI1NzRkZGE0Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8wMTJlMDA1OS0zZGE0LTRjNGUtOWVmNy1kMDhlMTM4
-        Njg0ZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        MjFhNDk3NzEtODJmMy00MWQ4LTk3YTgtZDQ5NDM5MTgxNzAzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2Qt
-        NDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1ZC1i
-        ODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFh
-        NmRhYTMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAz
-        ZjhlZTRmLTViNzEtNDE1NS1hNDczLWY3OWM1NTA0MzFlMy8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00NDVk
-        LWE4NzctOTM5OWY4ZTY1YzBkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdj
-        Y2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2NDY1
-        ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9mNDdhM2ZlNi0y
-        YzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VlbnZpcm9ubWVudHMvZTU4MGRlZmQtM2EwOC00
-        ZjYwLWE0NmYtYzk1MzFjMjQ5YWRjLyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8yMTdmYTllZC1iZWI2LTQxMjctYTI5
-        Ny0zNTNhOGNlNTE2ODUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kX2RlZmF1bHRzLzhkZTZmZTc5LWExODEtNGEyMS1hN2U1LTBmMWZi
-        Nzc2NDg2Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRf
-        ZGVmYXVsdHMvZjBhNzc1ZWYtNzE0Yi00MmU5LWFkYzMtYTRhODBmNzllZDcz
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMt
+        NGQ3NC05MjY2LWIwZTA3ODk2MzhkNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdhYi1h
+        NTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFj
+        YmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUy
+        ZDE4NWEyLWQxMTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFj
+        LWFmZTUtNTg1YjI5OTM3YzU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5Yzli
+        MGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzc5
+        OWE2LWY3NjYtNDU4Ni1hMTliLTI0YzJmYmUzNzFmYy8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJmNTM3Zi1i
+        OWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VlbnZpcm9ubWVudHMvMTIxNjc4NTktZGViZS00
+        ZWFmLWE0YTgtNmU3MTk1N2NiMTc3LyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAy
+        ZC1mMjAzY2EzMGNmOTQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
+        ZHVsZW1kX2RlZmF1bHRzL2IxOGRlNWI0LTRlM2YtNDYwZi05NGVmLTA2OWY0
+        OWI4MjMyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRf
+        ZGVmYXVsdHMvZjlkMDRkMmQtM2FkZC00ZmQ4LWJlNjAtNjQxOWI4NjNlNTcx
         LyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3518,7 +3943,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:39 GMT
+      - Fri, 29 Jul 2022 09:03:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3536,21 +3961,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0fecb04f367149d8bf01c8f3227b7785
+      - 9c3ac247fe0140d18320b07c71dacacf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkNWEyOTIxLWJlNDQtNDU3
-        My1iMzk5LTJlYTY2ZGExZDYzZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2Y2E0MmRkLWFhNTEtNDUy
+        Zi1hOTc4LTExYWQ3ZGM0MzM5ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3d5a2921-be44-4573-b399-2ea66da1d63e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c6ca42dd-aa51-452f-a978-11ad7dc4339d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3571,53 +3996,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:39 GMT
+      - Fri, 29 Jul 2022 09:03:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b0f27a3208c45589880e6cc4b33f7cb
+      - 42de773818ff43f78d65866a765383c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Q1YTI5MjEtYmU0
-        NC00NTczLWIzOTktMmVhNjZkYTFkNjNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MzkuMTExNzgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzZjYTQyZGQtYWE1
+        MS00NTJmLWE5NzgtMTFhZDdkYzQzMzlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MDYuMjIyMDc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwZmVjYjA0ZjM2NzE0OWQ4YmYw
-        MWM4ZjMyMjdiNzc4NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjM5LjM0MzI5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MzkuNTgyOTE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5YzNhYzI0N2ZlMDE0MGQxODMy
+        MGIwN2M3MWRhY2FjZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAz
+        OjA2LjUxNTgzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6
+        MDYuNzQ1NjE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZjUwZjIzYy1mZWZiLTRhM2YtODE3Zi02MmFkNWU0MGE1ODQvdmVyc2lv
+        bS9hZmI2YWU4Yi0zOWEwLTRmYjAtOTczNy0wZWNmOGFhNjIwNDYvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY1MGYyM2MtZmVmYi00YTNm
-        LTgxN2YtNjJhZDVlNDBhNTg0LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWZiNmFlOGItMzlhMC00ZmIw
+        LTk3MzctMGVjZjhhYTYyMDQ2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3625,7 +4050,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3638,44 +4063,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:39 GMT
+      - Fri, 29 Jul 2022 09:03:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c96ec31a74644b8ab2747097369dac9
+      - 6bcaf680b7084c13aeaacc10f083aba4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '193'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82NjQ2NWZmYS05NTFlLTRlZDUtYjNjMy1hODA2ZWVkZmM4NWQv
+        YWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvMTRiOWUxZDEtZmFlMi00NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9
+        a2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3YzU2LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzAzZjhlZTRmLTViNzEtNDE1NS1hNDczLWY3OWM1NTA0MzFlMy8ifV19
+        Z2VzLzUyZDE4NWEyLWQxMTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3683,7 +4108,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3696,7 +4121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:39 GMT
+      - Fri, 29 Jul 2022 09:03:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3714,21 +4139,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '0027098847444e3c9ab6d620f13d19bb'
+      - e71a02cdf6514223830fba20fea4920b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:39 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3736,7 +4161,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3749,37 +4174,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:40 GMT
+      - Fri, 29 Jul 2022 09:03:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4790'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 989d37dc6b694ef4914c7174f21648ba
+      - 7b3a2423ddbd466f9b893dcf3ca0fcad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1602'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3852,9 +4277,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -3871,9 +4296,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -3883,10 +4308,10 @@ http_interactions:
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3894,7 +4319,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3907,41 +4332,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:40 GMT
+      - Fri, 29 Jul 2022 09:03:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a1e4add2a9d446ebbbb3e9572263c51
+      - 313e51f9ee0d4b60b3083a91d5d77569
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3MWE2
-        ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYyMWNi
+        ZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3949,7 +4374,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3962,41 +4387,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:40 GMT
+      - Fri, 29 Jul 2022 09:03:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f810af39eeb842f2b6f118ff0de463c8
+      - c811fcdca1f84a27b62a691e008a1664
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6f50f23c-fefb-4a3f-817f-62ad5e40a584/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/afb6ae8b-39a0-4fb0-9737-0ecf8aa62046/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4004,7 +4429,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4017,36 +4442,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:40 GMT
+      - Fri, 29 Jul 2022 09:03:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9644d55c9762433398926965f21c9a43
+      - 200aee937e2c436987a8d4661ac9d532
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4068,5 +4493,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:40 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/copy_duplicated_errata.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/copy_duplicated_errata.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:37 GMT
+      - Fri, 29 Jul 2022 08:59:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce541452e2d64a528c0b4e70a45f42de
+      - 2f60da1f08514fdbaadb875164b0acb0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mNTlmNjEzYS0xMzQxLTQzNTItYTAyMS1jMTZjNzE1N2Q3YjAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzozMS43NjI3OTZa
+        cnBtL3JwbS8yNjBmMjdjOS05ZjI3LTRkZTEtYWMyMS0wOTFlMjZhYzM3MDIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODo1OC42NjkwMTla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mNTlmNjEzYS0xMzQxLTQzNTItYTAyMS1jMTZjNzE1N2Q3YjAv
+        cnBtL3JwbS8yNjBmMjdjOS05ZjI3LTRkZTEtYWMyMS0wOTFlMjZhYzM3MDIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Y1OWY2
-        MTNhLTEzNDEtNDM1Mi1hMDIxLWMxNmM3MTU3ZDdiMC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI2MGYy
+        N2M5LTlmMjctNGRlMS1hYzIxLTA5MWUyNmFjMzcwMi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:37 GMT
+      - Fri, 29 Jul 2022 08:59:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21a6c2bcc2d9430b9f7cfc51bedd29a4
+      - 1fdacd47977346a38388701eac57034e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiMGRmZTAyLTI5YTMtNDNl
-        Zi04OWFkLWQ3YzRiZWI3OTU1Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiNmY4ZjZjLWJkNmEtNDM4
+        Ni04YzE0LWZmMTQxNDkyMmNiOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:37 GMT
+      - Fri, 29 Jul 2022 08:59:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4f2ba3667dfc45faac61c977d5e2109d
+      - d1584b86b27d4da7b5bcb86187d17b96
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1b0dfe02-29a3-43ef-89ad-d7c4beb7955f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4b6f8f6c-bd6a-4386-8c14-ff1414922cb9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:37 GMT
+      - Fri, 29 Jul 2022 08:59:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 103c586408bf41d3863c9896468c0e32
+      - 8e610d5cf30e4db1b1797528769186d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWIwZGZlMDItMjlh
-        My00M2VmLTg5YWQtZDdjNGJlYjc5NTVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzcuNTkyMzk0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGI2ZjhmNmMtYmQ2
+        YS00Mzg2LThjMTQtZmYxNDE0OTIyY2I5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MDkuMTg0NTgzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMWE2YzJiY2MyZDk0MzBiOWY3Y2ZjNTFi
-        ZWRkMjlhNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjM3LjYy
-        NDQwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzcuNzQz
-        NTUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxZmRhY2Q0Nzk3NzM0NmEzODM4ODcwMWVh
+        YzU3MDM0ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjA5LjIz
+        MTY0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MDkuNDI0
+        NTQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjU5ZjYxM2EtMTM0MS00MzUy
-        LWEwMjEtYzE2YzcxNTdkN2IwLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjYwZjI3YzktOWYyNy00ZGUx
+        LWFjMjEtMDkxZTI2YWMzNzAyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:37 GMT
+      - Fri, 29 Jul 2022 08:59:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 04ec3a07415e4ae4b3a3877bb4f248bc
+      - 355e235cfb3e4cc1916efd3ff113424d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:37 GMT
+      - Fri, 29 Jul 2022 08:59:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6a9ad22f131c48ef94d154452485e0cc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vYTUyZDliYzMtNjNlOS00MzhiLWIzYzUtODhkMWUzOTdkZDY2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MDUuMzQ4Njc2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/a52d9bc3-63e9-438b-b3c5-88d1e397dd66/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c6007a2345454b33a16fc747fc901026
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyNTEwN2Y0LTA5ZTAtNDU5
+        Ny1iOGM2LWUxYTNlODAxMjJhYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d25107f4-09e0-4597-b8c6-e1a3e80122ac/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 36d4d443f39a4974af9c20aa23136774
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDI1MTA3ZjQtMDll
+        MC00NTk3LWI4YzYtZTFhM2U4MDEyMmFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MDkuNjEzNzUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjNjAwN2EyMzQ1NDU0YjMzYTE2ZmM3NDdm
+        YzkwMTAyNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjA5LjY2
+        NzExNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MDkuNzEw
+        MTMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11840919175a41bf83348107a188b66d
+      - 7073b03a75184b0797f52e3dd6163795
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:37 GMT
+      - Fri, 29 Jul 2022 08:59:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d0e7a575a0144d98f6924971e6425b2
+      - bb37d560a5ab47379bfa43a52f41c9b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c051399e7b2f42a4b9f4fd938cc73709
+      - bf3055c38acf46bdab143ecffc93e134
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 563dc63c866d4857a6bda51d042f89ba
+      - a126f0fd69b34469aecf9bcffcdff0ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:38 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - cfddacad541c45f38e2dd9a18612d22a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/5d62f331-a0bf-4332-b85a-6139942894d7/"
+      - "/pulp/api/v3/remotes/rpm/rpm/72a01c4a-3818-4858-94f5-687f0d760219/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd00115d78904de29e171c3a500aaa8b
+      - 89dd809ddefd4997bad5f0fa68df96a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVk
-        NjJmMzMxLWEwYmYtNDMzMi1iODVhLTYxMzk5NDI4OTRkNy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjM4LjE5NTY3NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcy
+        YTAxYzRhLTM4MTgtNDg1OC05NGY1LTY4N2YwZDc2MDIxOS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjEwLjE1MTA4OVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjM4LjE5NTY5NVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjEwLjE1MTExNFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/"
+      - "/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d6e8377a50754f9981330a58c8ce0dc9
+      - 1eb207b43a004d47b1a61bc4ca9c6cb2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOGY4OTAxOTItZmFkNy00ZTBhLTlkZTUtYjRjODY0ZjAwZTEyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MzguMzA2MzE0WiIsInZl
+        cG0vYTY3ODUwY2MtMTk1Ny00MDk1LWEwZDUtNWNhYWE5ZWQ1Yjc4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MTAuMjk3NjcxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOGY4OTAxOTItZmFkNy00ZTBhLTlkZTUtYjRjODY0ZjAwZTEyL3ZlcnNp
+        cG0vYTY3ODUwY2MtMTk1Ny00MDk1LWEwZDUtNWNhYWE5ZWQ1Yjc4L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84Zjg5MDE5Mi1m
-        YWQ3LTRlMGEtOWRlNS1iNGM4NjRmMDBlMTIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hNjc4NTBjYy0x
+        OTU3LTQwOTUtYTBkNS01Y2FhYTllZDViNzgvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4115be89bc2844a7ae5a982442bbf2ea
+      - 987b30edc04f4f3ba1741f26122e6268
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '307'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83YTY3ZGQ2Yi1mMDJjLTQwYjYtYTE5Yy1mMTQ5Y2RkMDY2M2Uv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzozMi40NTE0MjFa
+        cnBtL3JwbS9jYmQ0NWVhYy04YzI0LTRhYTMtOTEwMS03OGJmMWI1MjZjYTYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODo1OS42OTA4NjVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83YTY3ZGQ2Yi1mMDJjLTQwYjYtYTE5Yy1mMTQ5Y2RkMDY2M2Uv
+        cnBtL3JwbS9jYmQ0NWVhYy04YzI0LTRhYTMtOTEwMS03OGJmMWI1MjZjYTYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdhNjdk
-        ZDZiLWYwMmMtNDBiNi1hMTljLWYxNDljZGQwNjYzZS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2NiZDQ1
+        ZWFjLThjMjQtNGFhMy05MTAxLTc4YmYxYjUyNmNhNi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 822b281a78bb415589f942b2c405e4b2
+      - a6336a8474ba4802890902bec78bf1dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkMGJlOTgzLTc1ZGQtNDUw
-        OC04YTdkLTg5NjQ3OWU4NDlkMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliYWU1MTdkLWJlYTQtNDgy
+        YS1hZWYzLTNlNzg4YWFmZjNkMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1e8f7fc715b4981a05ce64d57eaa1d2
+      - 1a31f79c87814b5ea43a2a18c141bfed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNjFjNTgzNDktMmMwMi00ZDg3LWI3MDEtMGM0MDJiODhiOTU2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MzEuNjQ5OTQxWiIsIm5h
+        cG0vMGM4MzU0MWUtYWFhYy00MTIxLTg1ZDItMzE5MDVmNWY0NzVjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NTguNTE0NjM4WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzozMi43NjI2MjJaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1OTowMC4xNDM1MDJaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/61c58349-2c02-4d87-b701-0c402b88b956/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/0c83541e-aaac-4121-85d2-31905f5f475c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a7063f63f54f4cb6addf02cff97e0339
+      - 436195a435cc40f89a1d48c6ec14de14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzMmUxYzVjLWJjMTctNDQy
-        Yi05ODM4LWI0OTM0NDlhYzkwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmNTQ5ODY5LTBiZWQtNGIz
+        OS04YjIwLTNlOTRmOTcxYTYwZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ed0be983-75dd-4508-8a7d-896479e849d0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9bae517d-bea4-482a-aef3-3e788aaff3d3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b901453f546b4075aa84bf8877b7e2ba
+      - 364b4ba54c614bf39dbb416d7462f8be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWQwYmU5ODMtNzVk
-        ZC00NTA4LThhN2QtODk2NDc5ZTg0OWQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzguNDU5NzQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWJhZTUxN2QtYmVh
+        NC00ODJhLWFlZjMtM2U3ODhhYWZmM2QzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MTAuNTI2MDY3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4MjJiMjgxYTc4YmI0MTU1ODlmOTQyYjJj
-        NDA1ZTRiMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjM4LjQ5
-        MDA3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzguNTQ4
-        NDk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhNjMzNmE4NDc0YmE0ODAyODkwOTAyYmVj
+        NzhiZjFkZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjEwLjU2
+        NDc5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MTAuNjUy
+        MzE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2E2N2RkNmItZjAyYy00MGI2
-        LWExOWMtZjE0OWNkZDA2NjNlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2JkNDVlYWMtOGMyNC00YWEz
+        LTkxMDEtNzhiZjFiNTI2Y2E2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/832e1c5c-bc17-442b-9838-b493449ac901/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7f549869-0bed-4b39-8b20-3e94f971a60e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3af8557113d74c45a9ab50b2bac5fa90
+      - d257d6cd4afc4c6bbeb2f35b6eb8165e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODMyZTFjNWMtYmMx
-        Ny00NDJiLTk4MzgtYjQ5MzQ0OWFjOTAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzguNTQ3NzU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2Y1NDk4NjktMGJl
+        ZC00YjM5LThiMjAtM2U5NGY5NzFhNjBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MTAuNjc2NTM0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhNzA2M2Y2M2Y1NGY0Y2I2YWRkZjAyY2Zm
-        OTdlMDMzOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjM4LjU3
-        OTQ4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzguNjIy
-        NzY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0MzYxOTVhNDM1Y2M0MGY4OWExZDQ4YzZl
+        YzE0ZGUxNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjEwLjcy
+        NjIyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MTAuNzg4
+        NDkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYxYzU4MzQ5LTJjMDItNGQ4Ny1iNzAx
-        LTBjNDAyYjg4Yjk1Ni8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBjODM1NDFlLWFhYWMtNDEyMS04NWQy
+        LTMxOTA1ZjVmNDc1Yy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f159902037a6439392ef86e8ddddcf8a
+      - 247c2e4297964ca29d0145cbc8f854ed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '03969a20f46b482ebb5f341020210916'
+      - 62c79d259ab04104b7dd9f185d8dff44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a435618ff00d43b3949250e33f4f4bb4
+      - 700cff589e5c4ec4b0dbc86163d5bbc2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 709d4b7ff351409c9fc32fdb304c2aee
+      - e1a3d666fdf2450facafa2acff84affc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9dd218e94f104af29e527036fcef5080
+      - 5e011557362c48c7b2ff7ad75dbe858a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:38 GMT
+      - Fri, 29 Jul 2022 08:59:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9881e7a9e0714eb4a7d1eaa4167cd10c
+      - e9b0c415840744d5a803faed91d853f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:38 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:39 GMT
+      - Fri, 29 Jul 2022 08:59:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/"
+      - "/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f70cdab6d9c641ebaf44218c5522364b
+      - 633361508e8f402c8d2fd7fb5402ee83
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vODdhZTFjMDUtZjE0Ni00MTRmLWJmZjYtZDE0NDlhNDhmMGQyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MzkuMDAwNzI3WiIsInZl
+        cG0vNzE0NWFhZTktYTcyMi00ZjBiLTljZDUtNWYxZmEzZGY4MjFjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MTEuMjk4Njg5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vODdhZTFjMDUtZjE0Ni00MTRmLWJmZjYtZDE0NDlhNDhmMGQyL3ZlcnNp
+        cG0vNzE0NWFhZTktYTcyMi00ZjBiLTljZDUtNWYxZmEzZGY4MjFjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84N2FlMWMwNS1m
-        MTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MTQ1YWFlOS1h
+        NzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:39 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:11 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5d62f331-a0bf-4332-b85a-6139942894d7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/72a01c4a-3818-4858-94f5-687f0d760219/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:39 GMT
+      - Fri, 29 Jul 2022 08:59:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1521e4487ca4e819cc4fbca520e76bc
+      - 8f06d9f698ae4c82bb5fe287c208142f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlM2ZiZGQ0LTBiNzEtNDk0
-        Yy1iNWIwLTZiMzc3MzgwMGFiMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjNDExNDU0LWJlYWMtNGNm
+        Ni05OTdiLWJiN2ViNWEzNDFkZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:39 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4e3fbdd4-0b71-494c-b5b0-6b3773800ab1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ac411454-beac-4cf6-997b-bb7eb5a341de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:39 GMT
+      - Fri, 29 Jul 2022 08:59:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a0a79600d124f25912a7d3228c7e7ec
+      - 8f04748fd4fd438190845e7fe8bc0822
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGUzZmJkZDQtMGI3
-        MS00OTRjLWI1YjAtNmIzNzczODAwYWIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzkuMzU1NzExWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWM0MTE0NTQtYmVh
+        Yy00Y2Y2LTk5N2ItYmI3ZWI1YTM0MWRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MTEuNzAxNDYyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJjMTUyMWU0NDg3Y2E0ZTgxOWNjNGZiY2E1
-        MjBlNzZiYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjM5LjM4
-        NjYxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzkuNDEx
-        MTE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4ZjA2ZDlmNjk4YWU0YzgyYmI1ZmUyODdj
+        MjA4MTQyZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjExLjc1
+        MDQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MTEuNzg3
+        NTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVkNjJmMzMxLWEwYmYtNDMzMi1iODVh
-        LTYxMzk5NDI4OTRkNy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcyYTAxYzRhLTM4MTgtNDg1OC05NGY1
+        LTY4N2YwZDc2MDIxOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:39 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVkNjJm
-        MzMxLWEwYmYtNDMzMi1iODVhLTYxMzk5NDI4OTRkNy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcyYTAx
+        YzRhLTM4MTgtNDg1OC05NGY1LTY4N2YwZDc2MDIxOS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:39 GMT
+      - Fri, 29 Jul 2022 08:59:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f37e0ee317df42599413a4173f65a67b
+      - 34ad44e4e49d4a1fb0546da2136d2398
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFkYjg1ZTc2LWRiOWItNGZi
-        Ny05YzQxLTQ1MmUwZWI0MWIwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2MWNmZWU1LTVjMDYtNDdl
+        Yi1hYWQwLTU2Y2RiMGI1NzI4Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:39 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1db85e76-db9b-4fb7-9c41-452e0eb41b01/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/361cfee5-5c06-47eb-aad0-56cdb0b57286/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,82 +1787,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:41 GMT
+      - Fri, 29 Jul 2022 08:59:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3838c5beb54b46b1bc8078cb68551213
+      - 792bd7907d1c4c90aa1a409aa87220a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '596'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWRiODVlNzYtZGI5
-        Yi00ZmI3LTljNDEtNDUyZTBlYjQxYjAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzkuNTM2NDc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzYxY2ZlZTUtNWMw
+        Ni00N2ViLWFhZDAtNTZjZGIwYjU3Mjg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MTEuOTQ4MDIyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmMzdlMGVlMzE3ZGY0MjU5OTQx
-        M2E0MTczZjY1YTY3YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjM5LjU2NzM0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDEuMTE2NDE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzNGFkNDRlNGU0OWQ0YTFmYjA1
+        NDZkYTIxMzZkMjM5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjExLjk4NzAxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MTUuOTI0MTQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
         IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBh
-        Y2thZ2VzIiwiY29kZSI6InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRl
-        IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgi
-        Om51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5hZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
-        OiJVbi1Bc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRp
-        bmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
         ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
         bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vOGY4OTAxOTItZmFkNy00ZTBhLTlkZTUt
-        YjRjODY0ZjAwZTEyL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzhmODkwMTkyLWZhZDctNGUwYS05ZGU1LWI0Yzg2NGYwMGUxMi8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS81ZDYyZjMzMS1hMGJm
-        LTQzMzItYjg1YS02MTM5OTQyODk0ZDcvIl19
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2E2Nzg1MGNjLTE5NTctNDA5NS1hMGQ1LTVj
+        YWFhOWVkNWI3OC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9h
+        Njc4NTBjYy0xOTU3LTQwOTUtYTBkNS01Y2FhYTllZDViNzgvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNzJhMDFjNGEtMzgxOC00
+        ODU4LTk0ZjUtNjg3ZjBkNzYwMjE5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:16 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOGY4OTAxOTItZmFkNy00ZTBhLTlkZTUtYjRjODY0ZjAw
-        ZTEyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYTY3ODUwY2MtMTk1Ny00MDk1LWEwZDUtNWNhYWE5ZWQ1
+        Yjc4L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:41 GMT
+      - Fri, 29 Jul 2022 08:59:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 289e3b98740d4a568d33bdaa33d52444
+      - 6b133f87daf844989447f9a6de5ff52d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzljYTZjNWQ5LTUyNTUtNGU3
-        ZS04NWUyLWQyODllZjE4M2M2ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhMjdhZDg1LTIwMjItNGQ0
+        ZS1iMTg3LWRiZWY2NjBhYjBkYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9ca6c5d9-5255-4e7e-85e2-d289ef183c6d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9a27ad85-2022-4d4e-b187-dbef660ab0db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:41 GMT
+      - Fri, 29 Jul 2022 08:59:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6a83168926c844afad70b5d776766982
+      - 650241a9bd274bc98c09393e3200732b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWNhNmM1ZDktNTI1
-        NS00ZTdlLTg1ZTItZDI4OWVmMTgzYzZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDEuMzMxODUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWEyN2FkODUtMjAy
+        Mi00ZDRlLWIxODctZGJlZjY2MGFiMGRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MTYuNDQ1MTkzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjI4OWUzYjk4NzQwZDRhNTY4ZDMzYmRhYTMz
-        ZDUyNDQ0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDEuMzYx
-        MzE1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzo0MS41NDQy
-        NDhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjZiMTMzZjg3ZGFmODQ0OTg5NDQ3ZjlhNmRl
+        NWZmNTJkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MTYuNTA1
+        MTk1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1OToxNi44Mjkz
+        NThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZGI2ZjZl
-        OGUtMDFkZC00NzQ5LWI3ODUtOTliYTJkNGYwNjllLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMjM5MmM0
+        OWItZDM0OS00N2RkLTllOWItYmJiNGI0YzBmZmYzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOGY4OTAxOTItZmFkNy00ZTBhLTlkZTUtYjRjODY0
-        ZjAwZTEyLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYTY3ODUwY2MtMTk1Ny00MDk1LWEwZDUtNWNhYWE5
+        ZWQ1Yjc4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:41 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e7ea2a472e1440c08c48f1e31292abd4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:41 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:41 GMT
+      - Fri, 29 Jul 2022 08:59:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 26adef712b7648adba2a790df69e28ba
+      - 28d0334ccdd74d46a28752c83c121348
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/2392c49b-d349-47dd-9e9b-bbb4b4c0fff3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:41 GMT
+      - Fri, 29 Jul 2022 08:59:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f06b1a38063645f0b1157f47446fcc38
+      - 81f4b8773ebb41e8bdfbea605a3d0a19
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMjM5MmM0OWItZDM0OS00N2RkLTllOWItYmJiNGI0YzBmZmYzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MTYuNTM2NDA0WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hNjc4NTBjYy0xOTU3LTQwOTUtYTBkNS01Y2FhYTllZDViNzgv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2E2Nzg1MGNjLTE5NTctNDA5NS1hMGQ1LTVjYWFh
+        OWVkNWI3OC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:17 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8yMzkyYzQ5Yi1kMzQ5LTQ3ZGQtOWU5Yi1iYmI0YjRjMGZmZjMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4e2ffd6012ff450391b5f87742339faf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3Y2U3N2Y1LWY1MGQtNDAw
+        OS04ZTM1LWJiZTE5MjA1NjdiMy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d7ce77f5-f50d-4009-8e35-bbe1920567b3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c5da022a22f3497b9a83679b8fc10e02
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDdjZTc3ZjUtZjUw
+        ZC00MDA5LThlMzUtYmJlMTkyMDU2N2IzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MTcuMjA0Nzc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI0ZTJmZmQ2MDEyZmY0NTAzOTFiNWY4Nzc0
+        MjMzOWZhZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjE3LjI2
+        MjMwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MTcuNTQ2
+        NTg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNzc3
+        YzVmMGItMzA1Yy00MjJjLWIyMzgtMWU3ODI0ODZkNTU4LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/777c5f0b-305c-422c-b238-1e782486d558/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - dd8999c9de304dc9994ec00da3d2a2c5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzc3N2M1ZjBiLTMwNWMtNDIyYy1iMjM4LTFlNzgyNDg2ZDU1OC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjE3LjUyNjAyOFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMjM5MmM0OWItZDM0OS00N2RkLTllOWIt
+        YmJiNGI0YzBmZmYzLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2a871209cd46473e8dca48a7e45a49d1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ea35ae57c237498090b1ffee11755848
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8318c9cea7214ab98cb23cf99b6ff6b6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1064e042f2fe4f5ebf86ee7a0da5b6a2
+      - e7d849e7c6ad46b8ad9354b721eaeaed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5efa12383ecf4d02bfb3482d82a01a89
+      - 9e56fddc699f4481956ef5880ba3d060
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c85bfcd53e1f4fdeac3c384e85021520
+      - 61e9991f59d74759958ad5014ae985ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.5.2/ruby
+      - OpenAPI-Generator/1.5.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,296 +2976,167 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5837'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5fdff6b802834557acf311cbe3e7e241
+      - 7ff91adf6bac4773bc2b1d1a0a558765
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3230'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZhYWE3ODY4LTRlM2ItNDdiOS04NDYzLWJmZmFk
-        MDBhMzkzZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjEw
-        LjE5NjY2N1oiLCJuYW1lIjoidGVzdF9mb3JfY3JlYXRpb24iLCJkZXNjcmlw
-        dGlvbiI6bnVsbCwiY2FfY2VydGlmaWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAg
-        ICBEYXRhOlxuICAgICAgICBWZXJzaW9uOiAzICgweDIpXG4gICAgICAgIFNl
-        cmlhbCBOdW1iZXI6XG4gICAgICAgICAgICBmZDpiYTpiYzo3MTo2ZToyNTph
-        Mzo3OFxuICAgIFNpZ25hdHVyZSBBbGdvcml0aG06IHNoYTI1NldpdGhSU0FF
-        bmNyeXB0aW9uXG4gICAgICAgIElzc3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fy
-        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
-        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
-        VmFsaWRpdHlcbiAgICAgICAgICAgIE5vdCBCZWZvcmU6IE1heSAgNyAxNDoy
-        MTo1MCAyMDIwIEdNVFxuICAgICAgICAgICAgTm90IEFmdGVyIDogSmFuIDE4
-        IDE0OjIxOjUwIDIwMzggR01UXG4gICAgICAgIFN1YmplY3Q6IEM9VVMsIFNU
-        PU5vcnRoIENhcm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9U29t
-        ZU9yZ1VuaXQsIENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29t
-        XG4gICAgICAgIFN1YmplY3QgUHVibGljIEtleSBJbmZvOlxuICAgICAgICAg
-        ICAgUHVibGljIEtleSBBbGdvcml0aG06IHJzYUVuY3J5cHRpb25cbiAgICAg
-        ICAgICAgICAgICBQdWJsaWMtS2V5OiAoMjA0OCBiaXQpXG4gICAgICAgICAg
-        ICAgICAgTW9kdWx1czpcbiAgICAgICAgICAgICAgICAgICAgMDA6OWY6ZDI6
-        YzE6MTA6ZmY6MDE6MWE6MzM6MTk6MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAg
-        ICAgICAgICAgICAgIDhhOjczOmJhOjJkOjNjOjY2OmIxOjc4OmNkOjg5Ojhj
-        OjYwOmU1OjgxOmE2OlxuICAgICAgICAgICAgICAgICAgICBlODo0ZDo5Njo1
-        ZDowNzpjMzpiZTphMjo5YzpjMjo3Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAg
-        ICAgICAgICAgICAgNDQ6NDY6ZWY6ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6
-        OTc6Y2Q6OTc6MTc6XG4gICAgICAgICAgICAgICAgICAgIGQ3OjNmOmU3OjY3
-        OmZlOmE5OjJhOmYxOmJjOjQ3Ojg3OjZlOmVkOjZkOmI2OlxuICAgICAgICAg
-        ICAgICAgICAgICA5ZTpmMTowZDo2Mzo1MzpjMTozZjpmZDoxNzphYjo1Zjoz
-        NTo3YTo4NDpjZjpcbiAgICAgICAgICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6
-        MDk6OTk6NTY6Mzk6ZGU6Mjk6NmI6ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAg
-        ICAgICAgICAgIDU2OjJhOjEwOmIzOjBhOmNhOmI4OjZjOmZiOmI4OmM4OmVi
-        OmU1OmUyOmFlOlxuICAgICAgICAgICAgICAgICAgICBkNTo0MTowNTo0Yzph
-        MjpjMDpiZTo3YjpiMDo2ZDoxZDo3Yzo2Njo4MDo4ODpcbiAgICAgICAgICAg
-        ICAgICAgICAgNWE6Yjc6MDc6OWI6ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6
-        NDg6OTU6ODM6XG4gICAgICAgICAgICAgICAgICAgIDM0OjI3OmM2OmFjOmNj
-        OmEwOjBiOjU2OmFiOjIyOjM0OjcxOjRmOjc5OmJmOlxuICAgICAgICAgICAg
-        ICAgICAgICA2ZTo0YjpjOTo4OTo1OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3
-        MDplZTo1ODpcbiAgICAgICAgICAgICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6
-        MWU6ZDk6YjI6NTc6M2E6ZTA6NTk6OGU6YjM6NmE6XG4gICAgICAgICAgICAg
-        ICAgICAgIDk3OjNkOjlhOjgwOmNjOjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5
-        OmI2OmIzOlxuICAgICAgICAgICAgICAgICAgICBhYTo5NTo1NDo1NTo5ZTox
-        Mzo2NTo3Zjo5NTpjMDo3Mzo5NjpjNTpmYjo3NzpcbiAgICAgICAgICAgICAg
-        ICAgICAgYTA6NDg6MjA6YTY6N2Q6ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6
-        MWE6ZTI6XG4gICAgICAgICAgICAgICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3
-        OjU2OmYwOjkzOmE4OmI5OjBhOjczOmNmOmY3OlxuICAgICAgICAgICAgICAg
-        ICAgICAwMTowZlxuICAgICAgICAgICAgICAgIEV4cG9uZW50OiA2NTUzNyAo
-        MHgxMDAwMSlcbiAgICAgICAgWDUwOXYzIGV4dGVuc2lvbnM6XG4gICAgICAg
-        ICAgICBYNTA5djMgQmFzaWMgQ29uc3RyYWludHM6XG4gICAgICAgICAgICAg
-        ICAgQ0E6VFJVRVxuICAgICAgICAgICAgWDUwOXYzIEtleSBVc2FnZTpcbiAg
-        ICAgICAgICAgICAgICBEaWdpdGFsIFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVy
-        bWVudCwgQ2VydGlmaWNhdGUgU2lnbiwgQ1JMIFNpZ25cbiAgICAgICAgICAg
-        IFg1MDl2MyBFeHRlbmRlZCBLZXkgVXNhZ2U6XG4gICAgICAgICAgICAgICAg
-        VExTIFdlYiBTZXJ2ZXIgQXV0aGVudGljYXRpb24sIFRMUyBXZWIgQ2xpZW50
-        IEF1dGhlbnRpY2F0aW9uXG4gICAgICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5
-        cGU6XG4gICAgICAgICAgICAgICAgU1NMIFNlcnZlciwgU1NMIENBXG4gICAg
-        ICAgICAgICBOZXRzY2FwZSBDb21tZW50OlxuICAgICAgICAgICAgICAgIEth
-        dGVsbG8gU1NMIFRvb2wgR2VuZXJhdGVkIENlcnRpZmljYXRlXG4gICAgICAg
-        ICAgICBYNTA5djMgU3ViamVjdCBLZXkgSWRlbnRpZmllcjpcbiAgICAgICAg
-        ICAgICAgICA5QjpEMjpEOTo2OTo4ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3
-        Njo3QTo3RDpEMTo4NTo0RDo1Mzo1RFxuICAgICAgICAgICAgWDUwOXYzIEF1
-        dGhvcml0eSBLZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICBrZXlp
-        ZDo5QjpEMjpEOTo2OTo4ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3
-        RDpEMTo4NTo0RDo1Mzo1RFxuICAgICAgICAgICAgICAgIERpck5hbWU6L0M9
-        VVMvU1Q9Tm9ydGggQ2Fyb2xpbmEvTD1SYWxlaWdoL089S2F0ZWxsby9PVT1T
-        b21lT3JnVW5pdC9DTj1jZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNv
-        bVxuICAgICAgICAgICAgICAgIHNlcmlhbDpGRDpCQTpCQzo3MTo2RToyNTpB
-        Mzo3OFxuXG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJT
-        QUVuY3J5cHRpb25cbiAgICAgICAgIDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJl
-        OjY0OjE2OmIwOjdjOmEzOjRiOjEwOmU4OjVhOmI0OlxuICAgICAgICAgMTc6
-        NzQ6ZmQ6NzU6YzY6MjY6ZDI6ODg6MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6
-        YTU6MjU6XG4gICAgICAgICAxMzo2Yjo2MDozNDpkMDoyYzpkZTpkODo0ODox
-        NTpmNTpjYzoxZjowNzo4MDoyYjoxZDoyODpcbiAgICAgICAgIDkwOmU5Ojhi
-        OjQ3OmMxOjcxOjFhOmRhOjg2OmEwOjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRi
-        OlxuICAgICAgICAgMTc6MmY6MGU6OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6
-        Mjk6NWU6NGI6OTk6NjA6ZmE6OTI6XG4gICAgICAgICAxMjoyNDpmYzpiYzow
-        NDo5NDoyNDo2NTpmMzo2MDpjYzo1ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAg
-        ICAgICAgIGI5OjNjOjk5OjhhOjQ0OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBl
-        OjE1Ojk0OmM0OmM1OjIzOlxuICAgICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6
-        OGM6NTY6NGI6MDQ6MzU6OTU6Nzk6NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAg
-        ICAzYTo2ODpkMDpmMzozZTo4ODo3ZDozODoyOTozMjpmMjo0NzpiMToxNzo5
-        OTpmZDphNjo0ODpcbiAgICAgICAgIDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZl
-        OjY1OjliOjk5OmU0OjYwOjdhOjMyOmNkOjAyOmZlOlxuICAgICAgICAgNzE6
-        ZGE6MTk6ZTM6OTM6YmQ6YzU6YTc6YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6
-        OTE6Yzc6XG4gICAgICAgICBhNzo1MTo0ZTo4MTowOTpkMTpmMTozOTo1Yjow
-        Nzo4Nzo0MTozYjpiNzplMzoxYjphODo3ZTpcbiAgICAgICAgIDUxOjUyOjRl
-        OjY2OjIwOmIxOmNkOmM1OmFlOmRlOjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVl
-        OlxuICAgICAgICAgODg6ZWY6ZTM6OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6
-        M2Q6NTM6NTI6ZmY6NWU6MGI6MWI6XG4gICAgICAgICA1Yjo2Yzo5YjphNlxu
-        LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lC
-        QWdJSkFQMjZ2SEZ1SmFONE1BMEdDU3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dD
-        UVlEXG5WUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhw
-        Ym1FeEVEQU9CZ05WQkFjTUIxSmhiR1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0
-        aGRHVnNiRzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lE
-        XG5WUVFERENCalpXNTBiM00zTFdSbGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4
-        bExtTnZiVEFlRncweU1EQTFNRGN4XG5OREl4TlRCYUZ3MHpPREF4TVRneE5E
-        SXhOVEJhTUlHTE1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPXG5U
-        bTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVE
-        QU9CZ05WQkFvTUIwdGhkR1ZzXG5iRzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBj
-        bWRWYm1sME1Ta3dKd1lEVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6
-        WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVENDQVNJd0RRWUpLb1pJaHZjTkFRRUJC
-        UUFEZ2dFUEFEQ0NBUW9DXG5nZ0VCQUovU3dSRC9BUm96R1E1RG5ZUGxpbk82
-        TFR4bXNYak5pWXhnNVlHbTZFMldYUWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZ
-        Z1J6dldOZjJYelpjWDF6L25aLzZwS3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBY
-        cTE4MWVvVFBhOTJtXG5qZ21aVmpuZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1q
-        cjVlS3UxVUVGVEtMQXZudXdiUjE4Wm9DSVdyY0htOU80XG4vNVB6R1ROalNK
-        V0ROQ2ZHck15Z0MxYXJJalJ4VDNtL2JrdkppVm1IaTNzMWViZ2NjTzVZNW5z
-        aWVhY2UyYkpYXG5PdUJaanJOcWx6MmFnTXc3MVhmVStucFlhYmF6cXBWVVZa
-        NFRaWCtWd0hPV3hmdDNvRWdncG4zMHhOUHBxNVNUXG5UaHJpWFp2RmgxREhW
-        dkNUcUxrS2M4LzNBUThDQXdFQUFhT0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1B
-        TUJBZjh3XG5Dd1lEVlIwUEJBUURBZ0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dB
-        UVVGQndNQkJnZ3JCZ0VGQlFjREFqQVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1D
-        QWtRd05RWUpZSVpJQVliNFFnRU5CQ2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZi
-        MndnXG5SMlZ1WlhKaGRHVmtJRU5sY25ScFptbGpZWFJsTUIwR0ExVWREZ1FX
-        QkJTYjB0bHBpSmtzTG5BcnQybDJlbjNSXG5oVTFUWFRDQndBWURWUjBqQklH
-        NE1JRzFnQlNiMHRscGlKa3NMbkFydDJsMmVuM1JoVTFUWGFHQmthU0JqakNC
-        XG5pekVMTUFrR0ExVUVCaE1DVlZNeEZ6QVZCZ05WQkFnTURrNXZjblJvSUVO
-        aGNtOXNhVzVoTVJBd0RnWURWUVFIXG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZR
-        UUtEQWRMWVhSbGJHeHZNUlF3RWdZRFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5k
-        REVwTUNjR0ExVUVBd3dnWTJWdWRHOXpOeTFrWlhabGJESXVjMkZ0YVhJdVpY
-        aGhiWEJzWlM1amIyMkNDUUQ5XG51cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJB
-        UXNGQUFPQ0FRRUFNaGxzeHErdXdyNWtGckI4bzBzUTZGcTBGM1Q5XG5kY1lt
-        MG9nQi9wVXVQd29laUtVbEUydGdOTkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxS
-        OEZ4R3RxR29DZm94SWcyXG5vLy9iRnk4T20rRTVweC9jSnBjcFhrdVpZUHFT
-        RWlUOHZBU1VKR1h6WU14ZTdrSy9uand4dVR5WmlrUTlLVjJtXG5tYXJWRGhX
-        VXhNVWpqTGx1NVFrVGpGWkxCRFdWZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpI
-        c1JlWi9hWklBZ1JyXG5uN25hd201bG01bmtZSG95elFMK2Nkb1o0NU85eGFl
-        Z1JwNG8wcEdzanBISHAxRk9nUW5SOFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1pp
-        Q3h6Y1d1M2hjNjE4NEhOOWhlaU8vamxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5
-        YnBnPT1cbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNt
-        LzA3ZDY2MTBhLTYxOWEtNGJiMC05YzlkLWM0OWQ0ZTI1YjRhNC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE0OjAzLjM1NDYwMloiLCJuYW1l
-        IjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9jZXJ0
-        aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAgIFZl
-        cnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAgICAg
-        ICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0dXJl
-        IEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAgICAg
-        SXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBP
-        PUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVsMi5z
-        YW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAgICAg
-        ICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4gICAg
-        ICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBHTVRc
-        biAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9
-        UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9z
-        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVjdCBQ
-        dWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFsZ29y
-        aXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1YmxpYy1L
-        ZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxuICAg
-        ICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYTozMzox
-        OTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6NzM6
-        YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4gICAg
-        ICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjljOmMy
-        OjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0Njpl
-        ZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAgICAg
-        ICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6NDc6
-        ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYxOjBk
-        OjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAgICAg
-        ICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToyOTo2
-        YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6MTA6
-        YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAgICAg
-        ICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZkOjFk
-        OjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzowNzo5
-        YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAgICAg
-        ICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6MzQ6
-        NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5Ojg5
-        OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAgICAg
-        ICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTplMDo1
-        OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6ODA6
-        Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAgICAg
-        ICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjczOjk2
-        OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDphNjo3
-        ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAgICAg
-        ICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6MGE6
-        NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAgICAg
-        ICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAgICBY
-        NTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNpYyBD
-        b25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAgICAg
-        ICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERpZ2l0
-        YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0ZSBT
-        aWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVkIEtl
-        eSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBBdXRo
-        ZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25cbiAg
-        ICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAgICAg
-        ICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBlIENv
-        bW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBHZW5l
-        cmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJqZWN0
-        IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5OjY5
-        Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUz
-        OjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVudGlm
-        aWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4Ojk5
-        OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVEXG4g
-        ICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJvbGlu
-        YS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAgICAg
-        c2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWduYXR1
-        cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAg
-        ICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6NGI6
-        MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpkMjo4
-        ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAgIDEz
-        OjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3OjgwOjJi
-        OjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6ODY6
-        YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoyZjow
-        ZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpmYTo5
-        MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYwOmNj
-        OjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6OGE6
-        NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6XG4g
-        ICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5NTo3
-        OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNlOjg4
-        OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAgICAg
-        ICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6N2E6
-        MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpjNTph
-        NzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAgIGE3
-        OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUzOjFi
-        OmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6YWU6
-        ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODplZjpl
-        Mzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTowYjox
-        YjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJRklD
-        QVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40TUEw
-        R0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpFWE1C
-        VUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFK
-        aGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdOVkJB
-        c01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIzTTNM
-        V1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURBMU1E
-        Y3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NRWURW
-        UVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNc
-        bmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURWUVFE
-        RENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Ncbmdn
-        RUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdtNkUy
-        V1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXovblov
-        NnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpnbVpW
-        am5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51d2JS
-        MThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklqUnhU
-        M20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpqck5x
-        bHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29FZ2dw
-        bjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENBd0VB
-        QWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQQkFR
-        REFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZCUWNE
-        QWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0UWdF
-        TkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdWa0lF
-        TmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFydDJs
-        MmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUprc0xu
-        QXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJoTUNW
-        Vk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZRFZR
-        UUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1SUXdF
-        Z1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZMlZ1
-        ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NRRDlc
-        bnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4cSt1
-        d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1VsRTJ0
-        Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJcbm8v
-        L2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhlN2tL
-        L25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZaTEJE
-        V1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43bmF3
-        bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFGT2dR
-        blI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45aGVp
-        Ty9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQgQ0VS
-        VElGSUNBVEUtLS0tLSJ9XX0=
+        L2NlcnRndWFyZC9yaHNtLzY2NmMyZTNhLWE0ZDYtNGRhOC04ZmEwLTlmMzc5
+        NGQ1ODcxMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjUwOjAz
+        LjkxNzc5NVoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
+        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
+        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
+        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
+        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
+        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
+        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
+        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
+        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
+        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
+        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
+        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
+        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
+        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
+        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
+        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
+        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
+        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
+        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
+        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
+        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
+        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
+        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
+        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
+        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
+        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
+        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
+        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
+        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
+        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
+        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
+        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
+        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
+        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
+        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
+        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
+        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
+        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
+        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
+        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
+        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
+        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
+        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
+        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
+        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
+        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
+        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
+        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
+        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
+        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
+        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
+        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
+        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
+        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
+        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
+        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
+        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
+        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
+        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
+        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
+        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
+        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
+        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
+        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
+        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
+        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
+        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
+        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
+        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
+        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
+        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
+        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
+        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
+        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
+        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
+        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
+        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
+        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
+        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
+        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
+        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
+        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
+        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
+        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
+        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
+        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
+        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
+        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
+        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
+        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
+        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
+        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
+        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
+        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
+        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
+        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
+        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
+        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
+        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
+        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
+        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
+        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
+        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
+        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
+        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
+        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
+        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
+        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
+        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
+        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
+        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
+        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
+        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=9
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=9
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2848,7 +3144,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2861,73 +3157,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - db42fcbf77b14404a0c109be06c464d0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jZjIxNWRjYi0wNTk0LTQ4NGYtYjE4ZS03Mzc5MzYwNzJiZDgv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTo0OC40NjA5Mjha
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jZjIxNWRjYi0wNTk0LTQ4NGYtYjE4ZS03Mzc5MzYwNzJiZDgv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2NmMjE1
-        ZGNiLTA1OTQtNDg0Zi1iMThlLTczNzkzNjA3MmJkOC92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiI5IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
-        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
-        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
-        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
-        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/cf215dcb-0594-484f-b18e-737936072bd8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2935,31 +3165,31 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '67'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c38d2f27e2943bbbdc5e2c58a3ea088
+      - e6e54d07f3c94bd092235073cdb469f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQxOWJjYjI0LWRkNGQtNDE5
-        My1hZDgyLTg1NmRjNzdiY2UzNy8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=9
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=9
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2967,7 +3197,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2980,72 +3210,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 196eb7f2350843a19033069949ade2db
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNTVhNDA0M2EtYzMxMy00ZDdjLWI2ZDAtN2I4NGFkZDQzZjRmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6NDguMzQ4ODMzWiIsIm5h
-        bWUiOiI5IiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
-        cnRzL3Rlc3RfcmVwb3Mvem9vMl9kdXAiLCJjYV9jZXJ0IjpudWxsLCJjbGll
-        bnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3Vy
-        bCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6NTEuOTQyOTYyWiIsImRvd25sb2FkX2NvbmN1
-        cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1t
-        ZWRpYXRlIiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVv
-        dXQiOjYwLjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3Jl
-        YWRfdGltZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0
-        IjowLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/55a4043a-c313-4d7c-b6d0-7b84add43f4f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3053,224 +3218,31 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0031755a77e24884a4d8d5a0e075feaa
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzODIyNWUwLTk5ZDItNDkw
-        Ny04MzE0LTQzYzJmMDFmMzg0OC8ifQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/419bcb24-dd4d-4193-ad82-856dc77bce37/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 26162ad695cf4dc0a00f86f9766c4489
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDE5YmNiMjQtZGQ0
-        ZC00MTkzLWFkODItODU2ZGM3N2JjZTM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDIuMzY3ODczWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2YzM4ZDJmMjdlMjk0M2JiYmRjNWUyYzU4
-        YTNlYTA4OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjQyLjQw
-        NDEzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDIuNDYw
-        MzQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2YyMTVkY2ItMDU5NC00ODRm
-        LWIxOGUtNzM3OTM2MDcyYmQ4LyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f38225e0-99d2-4907-8314-43c2f01f3848/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 9b236e3bf6094a45b62b6b4518282e07
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjM4MjI1ZTAtOTlk
-        Mi00OTA3LTgzMTQtNDNjMmYwMWYzODQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDIuNDYzNjMxWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMDMxNzU1YTc3ZTI0ODg0YTRkOGQ1YTBl
-        MDc1ZmVhYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjQyLjQ5
-        NjUxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDIuNTM5
-        NTUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU1YTQwNDNhLWMzMTMtNGQ3Yy1iNmQw
-        LTdiODRhZGQ0M2Y0Zi8iXX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=9
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf1ebfdb46e74e70b4ebbbbad4867c49
+      - 82713826378c4bd3abba90593ef17d42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '340'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vNGRlYjFjM2MtMDYzOS00OGVjLWFkM2UtODNmMjAwMDUxZDhh
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6NTAuNjQ4NjU5
-        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9yaGVs
-        XzdfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOC1rYXRlbGxv
-        LWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNN
-        RV9Db3Jwb3JhdGlvbi9saWJyYXJ5L3JoZWxfN19sYWJlbC8iLCJjb250ZW50
-        X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJk
-        L3Joc20vMDdkNjYxMGEtNjE5YS00YmIwLTljOWQtYzQ5ZDRlMjViNGE0LyIs
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjkiLCJyZXBvc2l0b3J5IjpudWxs
-        LCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/4deb1c3c-0639-48ec-ad3e-83f200051d8a/
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=9
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3278,7 +3250,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3287,11 +3259,11 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3299,31 +3271,31 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '67'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 28c7d55e4e664ee78f88928ead44bab2
+      - 915d8362805a4e7ba6eadc7861511223
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RkZTg1MzI5LWU4N2QtNDFl
-        NC1iYjRlLTgzZTE1M2FlNjk5Mi8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/rhel_7_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/rhel_7_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3331,7 +3303,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3344,70 +3316,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - dfd9768c7357458ea2792a1c5b5253aa
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '340'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vNGRlYjFjM2MtMDYzOS00OGVjLWFkM2UtODNmMjAwMDUxZDhh
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6NTAuNjQ4NjU5
-        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9yaGVs
-        XzdfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOC1rYXRlbGxv
-        LWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNN
-        RV9Db3Jwb3JhdGlvbi9saWJyYXJ5L3JoZWxfN19sYWJlbC8iLCJjb250ZW50
-        X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJk
-        L3Joc20vMDdkNjYxMGEtNjE5YS00YmIwLTljOWQtYzQ5ZDRlMjViNGE0LyIs
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjkiLCJyZXBvc2l0b3J5IjpudWxs
-        LCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/4deb1c3c-0639-48ec-ad3e-83f200051d8a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3415,95 +3324,31 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '23'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8543caf66b624b409154071b0804ae2b
+      - f801c738861643df874ff4be274e8be9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
-
-'
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dde85329-e87d-41e4-bb4e-83e153ae6992/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 040d6321525f4e8dae2007c2cbc6624e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '344'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGRlODUzMjktZTg3
-        ZC00MWU0LWJiNGUtODNlMTUzYWU2OTkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDIuNjUyNzY2WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyOGM3ZDU1ZTRlNjY0ZWU3OGY4ODkyOGVh
-        ZDQ0YmFiMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjQyLjY4
-        NTAwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDIuNzEz
-        Njk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
-        L2Rpc3RyaWJ1dGlvbnMvIl19
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3519,7 +3364,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3532,13 +3377,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:42 GMT
+      - Fri, 29 Jul 2022 08:59:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/6aee4114-c9f1-411c-83c2-dfb24f316d04/"
+      - "/pulp/api/v3/remotes/rpm/rpm/34a4271e-c980-4763-b065-57c2f8a11ca6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -3552,32 +3397,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 770e4d849e5f4040a29728b53a8787fa
+      - 14d324ab6722434fb2f43109cd0bce63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZh
-        ZWU0MTE0LWM5ZjEtNDExYy04M2MyLWRmYjI0ZjMxNmQwNC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQyLjg3Mjk2NFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM0
+        YTQyNzFlLWM5ODAtNDc2My1iMDY1LTU3YzJmOGExMWNhNi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjE4Ljk3MDE0NFoiLCJuYW1lIjoi
         OSIsInVybCI6ImZpbGU6Ly8vdmFyL2xpYi9wdWxwL3N5bmNfaW1wb3J0cy90
         ZXN0X3JlcG9zL3pvb19kdXAiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2Vy
         dCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
         bCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjIt
-        MDUtMjNUMjM6MjM6NDIuODcyOTgzWiIsImRvd25sb2FkX2NvbmN1cnJlbmN5
+        MDctMjlUMDg6NTk6MTguOTcwMTY5WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5
         IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRl
         IiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYw
         LjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGlt
         ZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJz
         bGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiOSIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -3587,7 +3432,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3600,13 +3445,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/"
+      - "/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -3620,22 +3465,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 34b479a3d40248d39d935b4ebd4fac2c
+      - b2d19dc6c6504bdfa4935d9b3ec98e63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNWIzZDM5MzItOWE4ZS00Njk2LTllOGItYjNhZTQwMjg5ZTM1LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDMuMDYyNDU5WiIsInZl
+        cG0vMDNhOTc5OTMtNzAxZS00YTk0LWEzMmUtYTAxYjIzZDg3ZmZmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MTkuMTI3ODQ2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNWIzZDM5MzItOWE4ZS00Njk2LTllOGItYjNhZTQwMjg5ZTM1L3ZlcnNp
+        cG0vMDNhOTc5OTMtNzAxZS00YTk0LWEzMmUtYTAxYjIzZDg3ZmZmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81YjNkMzkzMi05
-        YThlLTQ2OTYtOWU4Yi1iM2FlNDAyODllMzUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wM2E5Nzk5My03
+        MDFlLTRhOTQtYTMyZS1hMDFiMjNkODdmZmYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiOSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -3643,10 +3488,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3654,7 +3499,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.5.2/ruby
+      - OpenAPI-Generator/1.5.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -3667,296 +3512,167 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5837'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1fa2282fbfca48c5a96b624b585963e1
+      - 3a686f779cad4b2181a993dff982e608
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3230'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZhYWE3ODY4LTRlM2ItNDdiOS04NDYzLWJmZmFk
-        MDBhMzkzZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjEw
-        LjE5NjY2N1oiLCJuYW1lIjoidGVzdF9mb3JfY3JlYXRpb24iLCJkZXNjcmlw
-        dGlvbiI6bnVsbCwiY2FfY2VydGlmaWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAg
-        ICBEYXRhOlxuICAgICAgICBWZXJzaW9uOiAzICgweDIpXG4gICAgICAgIFNl
-        cmlhbCBOdW1iZXI6XG4gICAgICAgICAgICBmZDpiYTpiYzo3MTo2ZToyNTph
-        Mzo3OFxuICAgIFNpZ25hdHVyZSBBbGdvcml0aG06IHNoYTI1NldpdGhSU0FF
-        bmNyeXB0aW9uXG4gICAgICAgIElzc3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fy
-        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
-        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
-        VmFsaWRpdHlcbiAgICAgICAgICAgIE5vdCBCZWZvcmU6IE1heSAgNyAxNDoy
-        MTo1MCAyMDIwIEdNVFxuICAgICAgICAgICAgTm90IEFmdGVyIDogSmFuIDE4
-        IDE0OjIxOjUwIDIwMzggR01UXG4gICAgICAgIFN1YmplY3Q6IEM9VVMsIFNU
-        PU5vcnRoIENhcm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9U29t
-        ZU9yZ1VuaXQsIENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29t
-        XG4gICAgICAgIFN1YmplY3QgUHVibGljIEtleSBJbmZvOlxuICAgICAgICAg
-        ICAgUHVibGljIEtleSBBbGdvcml0aG06IHJzYUVuY3J5cHRpb25cbiAgICAg
-        ICAgICAgICAgICBQdWJsaWMtS2V5OiAoMjA0OCBiaXQpXG4gICAgICAgICAg
-        ICAgICAgTW9kdWx1czpcbiAgICAgICAgICAgICAgICAgICAgMDA6OWY6ZDI6
-        YzE6MTA6ZmY6MDE6MWE6MzM6MTk6MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAg
-        ICAgICAgICAgICAgIDhhOjczOmJhOjJkOjNjOjY2OmIxOjc4OmNkOjg5Ojhj
-        OjYwOmU1OjgxOmE2OlxuICAgICAgICAgICAgICAgICAgICBlODo0ZDo5Njo1
-        ZDowNzpjMzpiZTphMjo5YzpjMjo3Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAg
-        ICAgICAgICAgICAgNDQ6NDY6ZWY6ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6
-        OTc6Y2Q6OTc6MTc6XG4gICAgICAgICAgICAgICAgICAgIGQ3OjNmOmU3OjY3
-        OmZlOmE5OjJhOmYxOmJjOjQ3Ojg3OjZlOmVkOjZkOmI2OlxuICAgICAgICAg
-        ICAgICAgICAgICA5ZTpmMTowZDo2Mzo1MzpjMTozZjpmZDoxNzphYjo1Zjoz
-        NTo3YTo4NDpjZjpcbiAgICAgICAgICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6
-        MDk6OTk6NTY6Mzk6ZGU6Mjk6NmI6ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAg
-        ICAgICAgICAgIDU2OjJhOjEwOmIzOjBhOmNhOmI4OjZjOmZiOmI4OmM4OmVi
-        OmU1OmUyOmFlOlxuICAgICAgICAgICAgICAgICAgICBkNTo0MTowNTo0Yzph
-        MjpjMDpiZTo3YjpiMDo2ZDoxZDo3Yzo2Njo4MDo4ODpcbiAgICAgICAgICAg
-        ICAgICAgICAgNWE6Yjc6MDc6OWI6ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6
-        NDg6OTU6ODM6XG4gICAgICAgICAgICAgICAgICAgIDM0OjI3OmM2OmFjOmNj
-        OmEwOjBiOjU2OmFiOjIyOjM0OjcxOjRmOjc5OmJmOlxuICAgICAgICAgICAg
-        ICAgICAgICA2ZTo0YjpjOTo4OTo1OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3
-        MDplZTo1ODpcbiAgICAgICAgICAgICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6
-        MWU6ZDk6YjI6NTc6M2E6ZTA6NTk6OGU6YjM6NmE6XG4gICAgICAgICAgICAg
-        ICAgICAgIDk3OjNkOjlhOjgwOmNjOjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5
-        OmI2OmIzOlxuICAgICAgICAgICAgICAgICAgICBhYTo5NTo1NDo1NTo5ZTox
-        Mzo2NTo3Zjo5NTpjMDo3Mzo5NjpjNTpmYjo3NzpcbiAgICAgICAgICAgICAg
-        ICAgICAgYTA6NDg6MjA6YTY6N2Q6ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6
-        MWE6ZTI6XG4gICAgICAgICAgICAgICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3
-        OjU2OmYwOjkzOmE4OmI5OjBhOjczOmNmOmY3OlxuICAgICAgICAgICAgICAg
-        ICAgICAwMTowZlxuICAgICAgICAgICAgICAgIEV4cG9uZW50OiA2NTUzNyAo
-        MHgxMDAwMSlcbiAgICAgICAgWDUwOXYzIGV4dGVuc2lvbnM6XG4gICAgICAg
-        ICAgICBYNTA5djMgQmFzaWMgQ29uc3RyYWludHM6XG4gICAgICAgICAgICAg
-        ICAgQ0E6VFJVRVxuICAgICAgICAgICAgWDUwOXYzIEtleSBVc2FnZTpcbiAg
-        ICAgICAgICAgICAgICBEaWdpdGFsIFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVy
-        bWVudCwgQ2VydGlmaWNhdGUgU2lnbiwgQ1JMIFNpZ25cbiAgICAgICAgICAg
-        IFg1MDl2MyBFeHRlbmRlZCBLZXkgVXNhZ2U6XG4gICAgICAgICAgICAgICAg
-        VExTIFdlYiBTZXJ2ZXIgQXV0aGVudGljYXRpb24sIFRMUyBXZWIgQ2xpZW50
-        IEF1dGhlbnRpY2F0aW9uXG4gICAgICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5
-        cGU6XG4gICAgICAgICAgICAgICAgU1NMIFNlcnZlciwgU1NMIENBXG4gICAg
-        ICAgICAgICBOZXRzY2FwZSBDb21tZW50OlxuICAgICAgICAgICAgICAgIEth
-        dGVsbG8gU1NMIFRvb2wgR2VuZXJhdGVkIENlcnRpZmljYXRlXG4gICAgICAg
-        ICAgICBYNTA5djMgU3ViamVjdCBLZXkgSWRlbnRpZmllcjpcbiAgICAgICAg
-        ICAgICAgICA5QjpEMjpEOTo2OTo4ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3
-        Njo3QTo3RDpEMTo4NTo0RDo1Mzo1RFxuICAgICAgICAgICAgWDUwOXYzIEF1
-        dGhvcml0eSBLZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICBrZXlp
-        ZDo5QjpEMjpEOTo2OTo4ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3
-        RDpEMTo4NTo0RDo1Mzo1RFxuICAgICAgICAgICAgICAgIERpck5hbWU6L0M9
-        VVMvU1Q9Tm9ydGggQ2Fyb2xpbmEvTD1SYWxlaWdoL089S2F0ZWxsby9PVT1T
-        b21lT3JnVW5pdC9DTj1jZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNv
-        bVxuICAgICAgICAgICAgICAgIHNlcmlhbDpGRDpCQTpCQzo3MTo2RToyNTpB
-        Mzo3OFxuXG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJT
-        QUVuY3J5cHRpb25cbiAgICAgICAgIDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJl
-        OjY0OjE2OmIwOjdjOmEzOjRiOjEwOmU4OjVhOmI0OlxuICAgICAgICAgMTc6
-        NzQ6ZmQ6NzU6YzY6MjY6ZDI6ODg6MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6
-        YTU6MjU6XG4gICAgICAgICAxMzo2Yjo2MDozNDpkMDoyYzpkZTpkODo0ODox
-        NTpmNTpjYzoxZjowNzo4MDoyYjoxZDoyODpcbiAgICAgICAgIDkwOmU5Ojhi
-        OjQ3OmMxOjcxOjFhOmRhOjg2OmEwOjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRi
-        OlxuICAgICAgICAgMTc6MmY6MGU6OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6
-        Mjk6NWU6NGI6OTk6NjA6ZmE6OTI6XG4gICAgICAgICAxMjoyNDpmYzpiYzow
-        NDo5NDoyNDo2NTpmMzo2MDpjYzo1ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAg
-        ICAgICAgIGI5OjNjOjk5OjhhOjQ0OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBl
-        OjE1Ojk0OmM0OmM1OjIzOlxuICAgICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6
-        OGM6NTY6NGI6MDQ6MzU6OTU6Nzk6NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAg
-        ICAzYTo2ODpkMDpmMzozZTo4ODo3ZDozODoyOTozMjpmMjo0NzpiMToxNzo5
-        OTpmZDphNjo0ODpcbiAgICAgICAgIDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZl
-        OjY1OjliOjk5OmU0OjYwOjdhOjMyOmNkOjAyOmZlOlxuICAgICAgICAgNzE6
-        ZGE6MTk6ZTM6OTM6YmQ6YzU6YTc6YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6
-        OTE6Yzc6XG4gICAgICAgICBhNzo1MTo0ZTo4MTowOTpkMTpmMTozOTo1Yjow
-        Nzo4Nzo0MTozYjpiNzplMzoxYjphODo3ZTpcbiAgICAgICAgIDUxOjUyOjRl
-        OjY2OjIwOmIxOmNkOmM1OmFlOmRlOjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVl
-        OlxuICAgICAgICAgODg6ZWY6ZTM6OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6
-        M2Q6NTM6NTI6ZmY6NWU6MGI6MWI6XG4gICAgICAgICA1Yjo2Yzo5YjphNlxu
-        LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lC
-        QWdJSkFQMjZ2SEZ1SmFONE1BMEdDU3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dD
-        UVlEXG5WUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhw
-        Ym1FeEVEQU9CZ05WQkFjTUIxSmhiR1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0
-        aGRHVnNiRzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lE
-        XG5WUVFERENCalpXNTBiM00zTFdSbGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4
-        bExtTnZiVEFlRncweU1EQTFNRGN4XG5OREl4TlRCYUZ3MHpPREF4TVRneE5E
-        SXhOVEJhTUlHTE1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPXG5U
-        bTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVE
-        QU9CZ05WQkFvTUIwdGhkR1ZzXG5iRzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBj
-        bWRWYm1sME1Ta3dKd1lEVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6
-        WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVENDQVNJd0RRWUpLb1pJaHZjTkFRRUJC
-        UUFEZ2dFUEFEQ0NBUW9DXG5nZ0VCQUovU3dSRC9BUm96R1E1RG5ZUGxpbk82
-        TFR4bXNYak5pWXhnNVlHbTZFMldYUWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZ
-        Z1J6dldOZjJYelpjWDF6L25aLzZwS3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBY
-        cTE4MWVvVFBhOTJtXG5qZ21aVmpuZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1q
-        cjVlS3UxVUVGVEtMQXZudXdiUjE4Wm9DSVdyY0htOU80XG4vNVB6R1ROalNK
-        V0ROQ2ZHck15Z0MxYXJJalJ4VDNtL2JrdkppVm1IaTNzMWViZ2NjTzVZNW5z
-        aWVhY2UyYkpYXG5PdUJaanJOcWx6MmFnTXc3MVhmVStucFlhYmF6cXBWVVZa
-        NFRaWCtWd0hPV3hmdDNvRWdncG4zMHhOUHBxNVNUXG5UaHJpWFp2RmgxREhW
-        dkNUcUxrS2M4LzNBUThDQXdFQUFhT0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1B
-        TUJBZjh3XG5Dd1lEVlIwUEJBUURBZ0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dB
-        UVVGQndNQkJnZ3JCZ0VGQlFjREFqQVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1D
-        QWtRd05RWUpZSVpJQVliNFFnRU5CQ2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZi
-        MndnXG5SMlZ1WlhKaGRHVmtJRU5sY25ScFptbGpZWFJsTUIwR0ExVWREZ1FX
-        QkJTYjB0bHBpSmtzTG5BcnQybDJlbjNSXG5oVTFUWFRDQndBWURWUjBqQklH
-        NE1JRzFnQlNiMHRscGlKa3NMbkFydDJsMmVuM1JoVTFUWGFHQmthU0JqakNC
-        XG5pekVMTUFrR0ExVUVCaE1DVlZNeEZ6QVZCZ05WQkFnTURrNXZjblJvSUVO
-        aGNtOXNhVzVoTVJBd0RnWURWUVFIXG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZR
-        UUtEQWRMWVhSbGJHeHZNUlF3RWdZRFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5k
-        REVwTUNjR0ExVUVBd3dnWTJWdWRHOXpOeTFrWlhabGJESXVjMkZ0YVhJdVpY
-        aGhiWEJzWlM1amIyMkNDUUQ5XG51cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJB
-        UXNGQUFPQ0FRRUFNaGxzeHErdXdyNWtGckI4bzBzUTZGcTBGM1Q5XG5kY1lt
-        MG9nQi9wVXVQd29laUtVbEUydGdOTkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxS
-        OEZ4R3RxR29DZm94SWcyXG5vLy9iRnk4T20rRTVweC9jSnBjcFhrdVpZUHFT
-        RWlUOHZBU1VKR1h6WU14ZTdrSy9uand4dVR5WmlrUTlLVjJtXG5tYXJWRGhX
-        VXhNVWpqTGx1NVFrVGpGWkxCRFdWZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpI
-        c1JlWi9hWklBZ1JyXG5uN25hd201bG01bmtZSG95elFMK2Nkb1o0NU85eGFl
-        Z1JwNG8wcEdzanBISHAxRk9nUW5SOFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1pp
-        Q3h6Y1d1M2hjNjE4NEhOOWhlaU8vamxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5
-        YnBnPT1cbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNt
-        LzA3ZDY2MTBhLTYxOWEtNGJiMC05YzlkLWM0OWQ0ZTI1YjRhNC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE0OjAzLjM1NDYwMloiLCJuYW1l
-        IjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9jZXJ0
-        aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAgIFZl
-        cnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAgICAg
-        ICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0dXJl
-        IEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAgICAg
-        SXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBP
-        PUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVsMi5z
-        YW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAgICAg
-        ICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4gICAg
-        ICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBHTVRc
-        biAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9
-        UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9z
-        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVjdCBQ
-        dWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFsZ29y
-        aXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1YmxpYy1L
-        ZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxuICAg
-        ICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYTozMzox
-        OTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6NzM6
-        YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4gICAg
-        ICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjljOmMy
-        OjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0Njpl
-        ZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAgICAg
-        ICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6NDc6
-        ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYxOjBk
-        OjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAgICAg
-        ICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToyOTo2
-        YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6MTA6
-        YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAgICAg
-        ICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZkOjFk
-        OjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzowNzo5
-        YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAgICAg
-        ICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6MzQ6
-        NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5Ojg5
-        OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAgICAg
-        ICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTplMDo1
-        OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6ODA6
-        Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAgICAg
-        ICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjczOjk2
-        OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDphNjo3
-        ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAgICAg
-        ICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6MGE6
-        NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAgICAg
-        ICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAgICBY
-        NTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNpYyBD
-        b25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAgICAg
-        ICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERpZ2l0
-        YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0ZSBT
-        aWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVkIEtl
-        eSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBBdXRo
-        ZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25cbiAg
-        ICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAgICAg
-        ICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBlIENv
-        bW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBHZW5l
-        cmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJqZWN0
-        IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5OjY5
-        Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUz
-        OjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVudGlm
-        aWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4Ojk5
-        OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVEXG4g
-        ICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJvbGlu
-        YS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAgICAg
-        c2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWduYXR1
-        cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAg
-        ICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6NGI6
-        MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpkMjo4
-        ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAgIDEz
-        OjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3OjgwOjJi
-        OjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6ODY6
-        YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoyZjow
-        ZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpmYTo5
-        MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYwOmNj
-        OjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6OGE6
-        NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6XG4g
-        ICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5NTo3
-        OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNlOjg4
-        OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAgICAg
-        ICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6N2E6
-        MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpjNTph
-        NzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAgIGE3
-        OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUzOjFi
-        OmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6YWU6
-        ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODplZjpl
-        Mzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTowYjox
-        YjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJRklD
-        QVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40TUEw
-        R0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpFWE1C
-        VUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFK
-        aGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdOVkJB
-        c01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIzTTNM
-        V1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURBMU1E
-        Y3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NRWURW
-        UVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNc
-        bmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURWUVFE
-        RENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Ncbmdn
-        RUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdtNkUy
-        V1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXovblov
-        NnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpnbVpW
-        am5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51d2JS
-        MThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklqUnhU
-        M20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpqck5x
-        bHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29FZ2dw
-        bjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENBd0VB
-        QWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQQkFR
-        REFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZCUWNE
-        QWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0UWdF
-        TkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdWa0lF
-        TmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFydDJs
-        MmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUprc0xu
-        QXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJoTUNW
-        Vk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZRFZR
-        UUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1SUXdF
-        Z1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZMlZ1
-        ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NRRDlc
-        bnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4cSt1
-        d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1VsRTJ0
-        Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJcbm8v
-        L2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhlN2tL
-        L25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZaTEJE
-        V1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43bmF3
-        bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFGT2dR
-        blI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45aGVp
-        Ty9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQgQ0VS
-        VElGSUNBVEUtLS0tLSJ9XX0=
+        L2NlcnRndWFyZC9yaHNtLzY2NmMyZTNhLWE0ZDYtNGRhOC04ZmEwLTlmMzc5
+        NGQ1ODcxMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjUwOjAz
+        LjkxNzc5NVoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
+        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
+        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
+        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
+        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
+        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
+        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
+        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
+        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
+        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
+        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
+        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
+        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
+        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
+        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
+        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
+        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
+        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
+        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
+        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
+        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
+        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
+        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
+        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
+        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
+        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
+        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
+        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
+        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
+        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
+        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
+        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
+        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
+        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
+        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
+        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
+        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
+        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
+        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
+        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
+        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
+        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
+        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
+        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
+        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
+        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
+        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
+        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
+        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
+        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
+        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
+        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
+        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
+        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
+        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
+        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
+        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
+        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
+        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
+        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
+        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
+        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
+        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
+        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
+        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
+        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
+        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
+        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
+        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
+        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
+        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
+        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
+        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
+        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
+        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
+        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
+        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
+        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
+        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
+        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
+        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
+        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
+        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
+        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
+        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
+        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
+        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
+        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
+        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
+        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
+        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
+        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
+        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
+        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
+        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
+        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
+        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
+        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
+        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
+        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
+        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
+        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
+        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
+        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
+        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
+        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
+        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
+        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
+        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
+        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
+        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
+        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
+        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=pulp-uuid-rhel_6_x86_64
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=pulp-uuid-rhel_6_x86_64
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3964,7 +3680,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3977,7 +3693,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3995,21 +3711,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b37587a2a0254546b5c4f8d34f704a1f
+      - 38865dfceb244b6da619edcada61916d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=pulp-uuid-rhel_6_x86_64
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=pulp-uuid-rhel_6_x86_64
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4017,7 +3733,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4030,7 +3746,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4048,21 +3764,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c99e4022407547da94e8b4b5666ea733
+      - 6dc984c02e414c808637469b5b68b210
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=pulp-uuid-rhel_6_x86_64
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=pulp-uuid-rhel_6_x86_64
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4070,7 +3786,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4083,7 +3799,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4101,21 +3817,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6e61be16b037431fb5e795747ec1b595
+      - 9cb091f02fae4fbb8c26fc7b0913d0bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/rhel_6_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/rhel_6_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4123,7 +3839,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4136,7 +3852,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4154,21 +3870,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 073733d146d54b14b50273a0e84d10b5
+      - 04c9c1b585fe4786a5b44d08d88bb7e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4184,7 +3900,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4197,13 +3913,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/e14bf51e-896b-4bcf-8ecf-c3a9184b9b32/"
+      - "/pulp/api/v3/remotes/rpm/rpm/e31d5a57-5d36-4824-8a20-6b82d4d82ccf/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -4217,33 +3933,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aabf2457fc784686a0f76e4081805bb8
+      - bfa38f95b4034a05af0d2f748f0f67b5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Ux
-        NGJmNTFlLTg5NmItNGJjZi04ZWNmLWMzYTkxODRiOWIzMi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQzLjQwNDg2MFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Uz
+        MWQ1YTU3LTVkMzYtNDgyNC04YTIwLTZiODJkNGQ4MmNjZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjE5LjY0NTY5NVoiLCJuYW1lIjoi
         cHVscC11dWlkLXJoZWxfNl94ODZfNjQiLCJ1cmwiOiJmaWxlOi8vL3Zhci9s
         aWIvcHVscC9zeW5jX2ltcG9ydHMvdGVzdF9yZXBvcy96b29fZHVwX2R1cCIs
         ImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRh
         dGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30s
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0My40MDQ4
-        ODFaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVz
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1OToxOS42NDU3
+        MjFaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVz
         IjpudWxsLCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0Ijoz
         NjAwLjAsImNvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3Rp
         bWVvdXQiOjYwLjAsInNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRl
         cnMiOm51bGwsInJhdGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVs
         bH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4253,7 +3969,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4266,13 +3982,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -4286,22 +4002,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5533d7f031084f4681da6c1faa2d8ab9
+      - ca7347a350564a33a1bd242538f20450
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWQ3NzkxOTctYjkxMy00M2JjLWEwYzAtMzc2MjIxZjgzNWViLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDMuNTE2MTg5WiIsInZl
+        cG0vZDA1YWMxMDYtMWZlZS00ZDQzLTk5OTUtNGFhMjFhOTExM2QwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MTkuODAwNTQyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWQ3NzkxOTctYjkxMy00M2JjLWEwYzAtMzc2MjIxZjgzNWViL3ZlcnNp
+        cG0vZDA1YWMxMDYtMWZlZS00ZDQzLTk5OTUtNGFhMjFhOTExM2QwL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xZDc3OTE5Ny1i
-        OTEzLTQzYmMtYTBjMC0zNzYyMjFmODM1ZWIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kMDVhYzEwNi0x
+        ZmVlLTRkNDMtOTk5NS00YWEyMWE5MTEzZDAvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoicHVscC11dWlkLXJoZWxfNl94ODZfNjQiLCJkZXNjcmlwdGlvbiI6bnVs
         bCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwi
         YXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2Ui
@@ -4310,10 +4026,10 @@ http_interactions:
         bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0
         YWRhdGEiOmZhbHNlfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:19 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5d62f331-a0bf-4332-b85a-6139942894d7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/72a01c4a-3818-4858-94f5-687f0d760219/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4329,7 +4045,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4342,7 +4058,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4360,21 +4076,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 006a23cbd3ca4daf9f9844d56a6c0f70
+      - f2ddff0e54934513bcc175014c408b2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdlMDVkNDMwLTE1YjctNDU4
-        MS04YzM0LTYwYjQzODk2MmYwZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0OWQwMjdjLTZmZTgtNDUy
+        ZC04YzRhLTI0NTBiNjIwZTRkZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7e05d430-15b7-4581-8c34-60b438962f0e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/949d027c-6fe8-452d-8c4a-2450b620e4dd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4395,63 +4111,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:43 GMT
+      - Fri, 29 Jul 2022 08:59:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ecc0c515afb94085ad8f1a987f41e776
+      - 6153d66bd69a4ccfb1ddb64a1a33935d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2UwNWQ0MzAtMTVi
-        Ny00NTgxLThjMzQtNjBiNDM4OTYyZjBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDMuODY2MDQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQ5ZDAyN2MtNmZl
+        OC00NTJkLThjNGEtMjQ1MGI2MjBlNGRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjAuMjE4MzQ3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwMDZhMjNjYmQzY2E0ZGFmOWY5ODQ0ZDU2
-        YTZjMGY3MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjQzLjg5
-        ODM3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDMuOTIx
-        MzU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmMmRkZmYwZTU0OTM0NTEzYmNjMTc1MDE0
+        YzQwOGIyYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjIwLjI2
+        NjUxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MjAuMjk3
+        NzkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVkNjJmMzMxLWEwYmYtNDMzMi1iODVh
-        LTYxMzk5NDI4OTRkNy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcyYTAxYzRhLTM4MTgtNDg1OC05NGY1
+        LTY4N2YwZDc2MDIxOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:20 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVkNjJm
-        MzMxLWEwYmYtNDMzMi1iODVhLTYxMzk5NDI4OTRkNy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcyYTAx
+        YzRhLTM4MTgtNDg1OC05NGY1LTY4N2YwZDc2MDIxOS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4464,7 +4180,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:44 GMT
+      - Fri, 29 Jul 2022 08:59:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4482,21 +4198,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e2528c888e048929c8b9fe089e7b13d
+      - 87e1deea34b84b8d9a1c504fbfee7515
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2NjliZDc0LTVhZTAtNGZm
-        MS1iOGNkLTY5ZmQzNzllNzMwMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1ZWQxYTkxLTU5YjEtNDQ2
+        Mi1hZDNmLTU3YzNhOGEyNmNmZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:44 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b669bd74-5ae0-4ff1-b8cd-69fd379e7302/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e5ed1a91-59b1-4462-ad3f-57c3a8a26cfe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4517,90 +4233,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:45 GMT
+      - Fri, 29 Jul 2022 08:59:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1866'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7f0c6f8f556547d8970108166699b71f
+      - 74644d7c06e8415fbe6833d3ad927ad2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '656'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjY2OWJkNzQtNWFl
-        MC00ZmYxLWI4Y2QtNjlmZDM3OWU3MzAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDQuMDUzMjM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVlZDFhOTEtNTli
+        MS00NDYyLWFkM2YtNTdjM2E4YTI2Y2ZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjAuNDAyMTE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwZTI1MjhjODg4ZTA0ODkyOWM4
-        YjlmZTA4OWU3YjEzZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ0LjA4MzI5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDUuMDgwODU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI4N2UxZGVlYTM0Yjg0YjhkOWEx
+        YzUwNGZiZmVlNzUxNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjIwLjQzOTQxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MjEuODUzNDAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
         IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjIyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0
-        aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQxLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBNb2R1bGVtZCIsImNvZGUi
-        OiJzeW5jLnBhcnNpbmcubW9kdWxlbWRzIiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
-        OiJQYXJzZWQgTW9kdWxlbWQtZGVmYXVsdHMiLCJjb2RlIjoic3luYy5wYXJz
-        aW5nLm1vZHVsZW1kX2RlZmF1bHRzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6MywiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgUGFja2FnZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLnBhY2thZ2Vz
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MjAs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29k
-        ZSI6InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
-        UGFyc2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlz
-        b3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3
-        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzUsInN1ZmZpeCI6
-        bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vOGY4OTAxOTItZmFkNy00ZTBhLTlkZTUtYjRj
-        ODY0ZjAwZTEyL3ZlcnNpb25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzhm
-        ODkwMTkyLWZhZDctNGUwYS05ZGU1LWI0Yzg2NGYwMGUxMi8iLCJzaGFyZWQ6
-        L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS81ZDYyZjMzMS1hMGJmLTQz
-        MzItYjg1YS02MTM5OTQyODk0ZDcvIl19
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1v
+        ZHVsZW1kIiwiY29kZSI6InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNv
+        ZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9
+        LHsibWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBh
+        cnNpbmcucGFja2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoy
+        MCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2Vk
+        IENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoi
+        Y29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0s
+        eyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5w
+        YXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        Ijo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFz
+        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MzUsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29u
+        dGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDEsInN1ZmZpeCI6bnVs
+        bH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vYTY3ODUwY2MtMTk1Ny00MDk1LWEwZDUtNWNhYWE5
+        ZWQ1Yjc4L3ZlcnNpb25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNv
+        cmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2E2Nzg1
+        MGNjLTE5NTctNDA5NS1hMGQ1LTVjYWFhOWVkNWI3OC8iLCJzaGFyZWQ6L3B1
+        bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS83MmEwMWM0YS0zODE4LTQ4NTgt
+        OTRmNS02ODdmMGQ3NjAyMTkvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:45 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:22 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOGY4OTAxOTItZmFkNy00ZTBhLTlkZTUtYjRjODY0ZjAw
-        ZTEyL3ZlcnNpb25zLzIvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYTY3ODUwY2MtMTk1Ny00MDk1LWEwZDUtNWNhYWE5ZWQ1
+        Yjc4L3ZlcnNpb25zLzIvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4613,7 +4329,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:45 GMT
+      - Fri, 29 Jul 2022 08:59:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4631,21 +4347,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1c4f72291a064a9e8d888dcc1dddafb2
+      - '04808fb3c44f4de5b6b8fc63d738078f'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiNzJjYzljLWUyZTItNDVh
-        Ni1hY2U4LWI4MTJkMDg3N2VhYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1ZjY2NGRjLTdmYjItNGQ4
+        Ny05MzNiLTRkMzlkMGUyMjNmOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:45 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2b72cc9c-e2e2-45a6-ace8-b812d0877eac/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e5f664dc-7fb2-4d87-933b-4d39d0e223f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4666,72 +4382,192 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:45 GMT
+      - Fri, 29 Jul 2022 08:59:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9236a9b996384912a5535473d89ec1cd
+      - 2ec425071f59456caa6a3c66b7c2430b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI3MmNjOWMtZTJl
-        Mi00NWE2LWFjZTgtYjgxMmQwODc3ZWFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDUuMzU0MzcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVmNjY0ZGMtN2Zi
+        Mi00ZDg3LTkzM2ItNGQzOWQwZTIyM2Y4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjIuMzk3ODc5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjFjNGY3MjI5MWEwNjRhOWU4ZDg4OGRjYzFk
-        ZGRhZmIyIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDUuMzg0
-        NDU0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzo0NS42MjA4
-        MzdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjA0ODA4ZmIzYzQ0ZjRkZTViNmI4ZmM2M2Q3
+        MzgwNzhmIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MjIuNDQ0
+        NjU0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1OToyMy4wMDg0
+        NTRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNmZhMzM0
-        YjUtY2Q1ZC00ZmNkLWE4ZTQtYWFjMmY4NDQ0YjhhLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTAzNWFm
+        N2YtOWY0Ny00ODA2LTliOWQtY2Y2NmI3ZTI5ZjUxLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOGY4OTAxOTItZmFkNy00ZTBhLTlkZTUtYjRjODY0
-        ZjAwZTEyLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYTY3ODUwY2MtMTk1Ny00MDk1LWEwZDUtNWNhYWE5
+        ZWQ1Yjc4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:45 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:23 GMT
 - request:
-    method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/6aee4114-c9f1-411c-83c2-dfb24f316d04/
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IjkiLCJ1cmwiOiJmaWxl
-        Oi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVzdF9yZXBvcy96b29f
-        ZHVwIiwicHJveHlfdXJsIjpudWxsLCJwcm94eV91c2VybmFtZSI6bnVsbCwi
-        cHJveHlfcGFzc3dvcmQiOm51bGwsInRvdGFsX3RpbWVvdXQiOjM2MDAsImNv
-        bm5lY3RfdGltZW91dCI6NjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MCwi
-        c29ja19yZWFkX3RpbWVvdXQiOjM2MDAsInJhdGVfbGltaXQiOjAsInVzZXJu
-        YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRl
-        In0=
+      encoding: US-ASCII
+      base64_string: ''
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '517'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f782c57e2a594042bb884c7a6a85a533
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNzc3YzVmMGItMzA1Yy00MjJjLWIyMzgtMWU3ODI0ODZkNTU4
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MTcuNTI2MDI4
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2Fw
+        aS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8yMzkyYzQ5Yi1kMzQ5LTQ3ZGQt
+        OWU5Yi1iYmI0YjRjMGZmZjMvIn1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/9035af7f-9f47-4806-9b9d-cf66b7e29f51/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 02fa19194aa74115ad7536f309a7f138
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vOTAzNWFmN2YtOWY0Ny00ODA2LTliOWQtY2Y2NmI3ZTI5ZjUxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MjIuNDc1MTEyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hNjc4NTBjYy0xOTU3LTQwOTUtYTBkNS01Y2FhYTllZDViNzgv
+        dmVyc2lvbnMvMi8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2E2Nzg1MGNjLTE5NTctNDA5NS1hMGQ1LTVjYWFh
+        OWVkNWI3OC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:23 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/777c5f0b-305c-422c-b238-1e782486d558/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
+        cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTAz
+        NWFmN2YtOWY0Ny00ODA2LTliOWQtY2Y2NmI3ZTI5ZjUxLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4744,7 +4580,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:45 GMT
+      - Fri, 29 Jul 2022 08:59:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4762,21 +4598,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10e6b27760bb48749c11e93759e71b90
+      - 9f7d9eaf412944af9eb9e872f890e149
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlOTJlMTAyLTg1OWMtNGRm
-        NC04YzE2LTk1MTRhNGEyODRkMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0NzY1YTA3LTQ2NjctNDg3
+        ZC1iZWM3LTJkMjlmZGFlMGE3NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:45 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4e92e102-859c-4df4-8c16-9514a4a284d0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/74765a07-4667-487d-bec7-2d29fdae0a75/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4797,63 +4633,123 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:46 GMT
+      - Fri, 29 Jul 2022 08:59:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53be9d589c6342898954d6b754fb8973
+      - f4f0923b93354a70b31e77ee4d6029fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGU5MmUxMDItODU5
-        Yy00ZGY0LThjMTYtOTUxNGE0YTI4NGQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDUuOTY4Njk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzQ3NjVhMDctNDY2
+        Ny00ODdkLWJlYzctMmQyOWZkYWUwYTc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjMuMzEwNTI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIxMGU2YjI3NzYwYmI0ODc0OWMxMWU5Mzc1
-        OWU3MWI5MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ2LjAw
-        MDEzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDYuMDI0
-        NzE4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5ZjdkOWVhZjQxMjk0NGFmOWViOWU4NzJm
+        ODkwZTE0OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjIzLjM0
+        OTYwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MjMuNTYw
+        ODE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZhZWU0MTE0LWM5ZjEtNDExYy04M2My
-        LWRmYjI0ZjMxNmQwNC8iXX0=
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:46 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:23 GMT
 - request:
-    method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/sync/
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/9035af7f-9f47-4806-9b9d-cf66b7e29f51/
     body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZhZWU0
-        MTE0LWM5ZjEtNDExYy04M2MyLWRmYjI0ZjMxNmQwNC8iLCJzeW5jX3BvbGlj
-        eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
-        aW1pemUiOnRydWV9
+      encoding: US-ASCII
+      base64_string: ''
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ff7acb049d18470888df6deaaae63014
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vOTAzNWFmN2YtOWY0Ny00ODA2LTliOWQtY2Y2NmI3ZTI5ZjUxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MjIuNDc1MTEyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hNjc4NTBjYy0xOTU3LTQwOTUtYTBkNS01Y2FhYTllZDViNzgv
+        dmVyc2lvbnMvMi8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2E2Nzg1MGNjLTE5NTctNDA5NS1hMGQ1LTVjYWFh
+        OWVkNWI3OC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:23 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/777c5f0b-305c-422c-b238-1e782486d558/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
+        cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTAz
+        NWFmN2YtOWY0Ny00ODA2LTliOWQtY2Y2NmI3ZTI5ZjUxLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4866,7 +4762,190 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:46 GMT
+      - Fri, 29 Jul 2022 08:59:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b98c9ed7ff6444a898b944768deecf67
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzNTZiMmZmLTViMTItNDgw
+        OS1hYTFhLTk3MTg3ZTcyNjJiZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:23 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/34a4271e-c980-4763-b065-57c2f8a11ca6/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IjkiLCJ1cmwiOiJmaWxl
+        Oi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVzdF9yZXBvcy96b29f
+        ZHVwIiwicHJveHlfdXJsIjpudWxsLCJwcm94eV91c2VybmFtZSI6bnVsbCwi
+        cHJveHlfcGFzc3dvcmQiOm51bGwsInRvdGFsX3RpbWVvdXQiOjM2MDAsImNv
+        bm5lY3RfdGltZW91dCI6NjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MCwi
+        c29ja19yZWFkX3RpbWVvdXQiOjM2MDAsInJhdGVfbGltaXQiOjAsInVzZXJu
+        YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRl
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f85806c491f44849825cc63279bcee89
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4ZjUyNWUwLTM0NmEtNDUz
+        Ny04OWQ4LTUzN2NkZGMwODFiNy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:24 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/48f525e0-346a-4537-89d8-537cddc081b7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e57b41fd1762404aa94e5f49fbc18ece
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDhmNTI1ZTAtMzQ2
+        YS00NTM3LTg5ZDgtNTM3Y2RkYzA4MWI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjQuMjI2OTUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmODU4MDZjNDkxZjQ0ODQ5ODI1Y2M2MzI3
+        OWJjZWU4OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjI0LjI3
+        MzMwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MjQuMjk4
+        NzA2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM0YTQyNzFlLWM5ODAtNDc2My1iMDY1
+        LTU3YzJmOGExMWNhNi8iXX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:24 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM0YTQy
+        NzFlLWM5ODAtNDc2My1iMDY1LTU3YzJmOGExMWNhNi8iLCJzeW5jX3BvbGlj
+        eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
+        aW1pemUiOnRydWV9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4884,21 +4963,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1ee28d9820f4fecbda8c4a3180f0e0d
+      - '0586d53c877d4b79b78721e8212ed4a2'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2ZGJmMTEyLTdhNzMtNGM3
-        YS1hMzg1LWM1ZjYwN2YyNWQwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyMDFiMzllLWYzZDctNDRj
+        Yy04ZmNjLWMwOGJiMzc1MmFlZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:46 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/56dbf112-7a73-4c7a-a385-c5f607f25d01/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d201b39e-f3d7-44cc-8fcc-c08bb3752aef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4919,42 +4998,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:47 GMT
+      - Fri, 29 Jul 2022 08:59:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9535b68ba24e4406898f5640e70f7ffc
+      - df9917dd3fdd4882b47361c31723e612
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '653'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTZkYmYxMTItN2E3
-        My00YzdhLWEzODUtYzVmNjA3ZjI1ZDAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDYuMTgwMzIxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDIwMWIzOWUtZjNk
+        Ny00NGNjLThmY2MtYzA4YmIzNzUyYWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjQuNDA4MTUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkMWVlMjhkOTgyMGY0ZmVjYmRh
-        OGM0YTMxODBmMGUwZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ2LjIzMDE2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDcuMDA4NzE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwNTg2ZDUzYzg3N2Q0Yjc5Yjc4
+        NzIxZTgyMTJlZDRhMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjI0LjQ1MzY1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MjUuNTUzOTgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -4971,38 +5050,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzViM2QzOTMyLTlhOGUtNDY5Ni05ZThiLWIzYWU0
-        MDI4OWUzNS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81YjNk
-        MzkzMi05YThlLTQ2OTYtOWU4Yi1iM2FlNDAyODllMzUvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNmFlZTQxMTQtYzlmMS00MTFj
-        LTgzYzItZGZiMjRmMzE2ZDA0LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS8wM2E5Nzk5My03MDFlLTRhOTQtYTMyZS1hMDFiMjNk
+        ODdmZmYvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDNhOTc5
+        OTMtNzAxZS00YTk0LWEzMmUtYTAxYjIzZDg3ZmZmLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM0YTQyNzFlLWM5ODAtNDc2My1i
+        MDY1LTU3YzJmOGExMWNhNi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:47 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:25 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNWIzZDM5MzItOWE4ZS00Njk2LTllOGItYjNhZTQwMjg5
-        ZTM1L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMDNhOTc5OTMtNzAxZS00YTk0LWEzMmUtYTAxYjIzZDg3
+        ZmZmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5015,7 +5094,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:47 GMT
+      - Fri, 29 Jul 2022 08:59:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5033,21 +5112,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce25c776683a4d05a14c1ecf32cbe6a3
+      - 1c4166c40db94427a217e02270edae2e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0ODk3ZDFmLWNiZDUtNDZh
-        Yi1iMTVkLTFiYWY1NTdkODY0ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiM2U4MDI1LTgxYWUtNDRj
+        MS1hNGI1LTRhOTIwOWYyMjM2Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:47 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/04897d1f-cbd5-46ab-b15d-1baf557d864d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ab3e8025-81ae-44c1-a4b5-4a9209f2236b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5068,56 +5147,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:47 GMT
+      - Fri, 29 Jul 2022 08:59:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 788d9b9951bb421c98508e43d49d500c
+      - 5cd7e248fd714a27b2a1f2a3bcb34c46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQ4OTdkMWYtY2Jk
-        NS00NmFiLWIxNWQtMWJhZjU1N2Q4NjRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDcuMzE4MDYwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWIzZTgwMjUtODFh
+        ZS00NGMxLWE0YjUtNGE5MjA5ZjIyMzZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjUuOTgxMzg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImNlMjVjNzc2NjgzYTRkMDVhMTRjMWVjZjMy
-        Y2JlNmEzIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDcuMzUw
-        NzkxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzo0Ny41OTM4
-        MDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjFjNDE2NmM0MGRiOTQ0MjdhMjE3ZTAyMjcw
+        ZWRhZTJlIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MjYuMDQ4
+        MjQzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1OToyNi40ODgz
+        OTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vY2Y4MDI0
-        NWItMzc5MS00NWIxLTlmMDEtZWUyOTE0N2UzMGYyLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZTAyNDQy
+        ZjctNTBhNS00YWVkLTk2YzgtOGVlZmRjYTJlMTk0LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNWIzZDM5MzItOWE4ZS00Njk2LTllOGItYjNhZTQw
-        Mjg5ZTM1LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMDNhOTc5OTMtNzAxZS00YTk0LWEzMmUtYTAxYjIz
+        ZDg3ZmZmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:47 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5125,7 +5204,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.5.2/ruby
+      - OpenAPI-Generator/1.5.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -5138,37 +5217,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:47 GMT
+      - Fri, 29 Jul 2022 08:59:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5837'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 17eaaf12c02f46b88cad555a89c56a71
+      - bca948a0bbd942c2844ebe2d934f5e90
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3082'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzA3ZDY2MTBhLTYxOWEtNGJiMC05YzlkLWM0OWQ0
-        ZTI1YjRhNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE0OjAz
-        LjM1NDYwMloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        L2NlcnRndWFyZC9yaHNtLzY2NmMyZTNhLWE0ZDYtNGRhOC04ZmEwLTlmMzc5
+        NGQ1ODcxMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjUwOjAz
+        LjkxNzc5NVoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
         IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
         dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
         IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
@@ -5295,10 +5374,10 @@ http_interactions:
         V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
         PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:47 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:26 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/07d6610a-619a-4bb0-9c9d-c49d4e25b4a4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/666c2e3a-a4d6-4da8-8fa0-9f3794d58710/
     body:
       encoding: UTF-8
       base64_string: |
@@ -5431,7 +5510,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.5.2/ruby
+      - OpenAPI-Generator/1.5.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -5444,36 +5523,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:47 GMT
+      - Fri, 29 Jul 2022 08:59:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5785'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c1aa98374304a24a479fa4cf668c760
+      - a1306f4192694b29b6ac50d38800af1e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3046'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wN2Q2NjEwYS02MTlhLTRiYjAtOWM5ZC1jNDlkNGUyNWI0
-        YTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNDowMy4zNTQ2
-        MDJaIiwibmFtZSI6IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVs
+        Z3VhcmQvcmhzbS82NjZjMmUzYS1hNGQ2LTRkYTgtOGZhMC05ZjM3OTRkNTg3
+        MTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1MDowMy45MTc3
+        OTVaIiwibmFtZSI6IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVs
         bCwiY2FfY2VydGlmaWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxu
         ICAgICAgICBWZXJzaW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1i
         ZXI6XG4gICAgICAgICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAg
@@ -5600,26 +5679,624 @@ http_interactions:
         NjE4NEhOOWhlaU8vamxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0t
         LS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:47 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:26 GMT
 - request:
-    method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/e14bf51e-896b-4bcf-8ecf-c3a9184b9b32/
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
     body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6InB1bHAtdXVpZC1yaGVs
-        XzZfeDg2XzY0IiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19p
-        bXBvcnRzL3Rlc3RfcmVwb3Mvem9vX2R1cF9kdXAiLCJwcm94eV91cmwiOm51
-        bGwsInByb3h5X3VzZXJuYW1lIjpudWxsLCJwcm94eV9wYXNzd29yZCI6bnVs
-        bCwidG90YWxfdGltZW91dCI6MzYwMCwiY29ubmVjdF90aW1lb3V0Ijo2MCwi
-        c29ja19jb25uZWN0X3RpbWVvdXQiOjYwLCJzb2NrX3JlYWRfdGltZW91dCI6
-        MzYwMCwicmF0ZV9saW1pdCI6MCwidXNlcm5hbWUiOm51bGwsInBhc3N3b3Jk
-        IjpudWxsLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
+      encoding: US-ASCII
+      base64_string: ''
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/1.5.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5837'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5bc7d26f082445309100ef3960a764f2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzY2NmMyZTNhLWE0ZDYtNGRhOC04ZmEwLTlmMzc5
+        NGQ1ODcxMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjUwOjAz
+        LjkxNzc5NVoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
+        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
+        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
+        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
+        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
+        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
+        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
+        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
+        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
+        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
+        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
+        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
+        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
+        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
+        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
+        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
+        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
+        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
+        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
+        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
+        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
+        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
+        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
+        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
+        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
+        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
+        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
+        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
+        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
+        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
+        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
+        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
+        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
+        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
+        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
+        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
+        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
+        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
+        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
+        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
+        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
+        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
+        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
+        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
+        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
+        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
+        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
+        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
+        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
+        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
+        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
+        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
+        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
+        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
+        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
+        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
+        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
+        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
+        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
+        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
+        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
+        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
+        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
+        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
+        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
+        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
+        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
+        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
+        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
+        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
+        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
+        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
+        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
+        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
+        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
+        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
+        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
+        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
+        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
+        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
+        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
+        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
+        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
+        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
+        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
+        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
+        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
+        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
+        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
+        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
+        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
+        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
+        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
+        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
+        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
+        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
+        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
+        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
+        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
+        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
+        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
+        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
+        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
+        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
+        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
+        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
+        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
+        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
+        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
+        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
+        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
+        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
+        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:26 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/666c2e3a-a4d6-4da8-8fa0-9f3794d58710/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
+        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
+        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
+        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
+        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
+        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
+        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
+        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
+        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
+        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
+        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
+        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
+        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
+        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
+        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
+        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
+        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
+        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
+        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
+        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
+        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
+        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
+        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
+        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
+        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
+        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
+        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
+        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
+        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
+        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
+        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
+        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
+        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
+        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
+        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
+        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
+        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
+        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
+        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
+        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
+        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
+        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
+        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
+        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
+        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
+        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
+        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
+        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
+        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
+        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
+        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
+        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
+        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
+        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
+        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
+        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
+        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
+        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
+        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
+        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
+        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
+        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
+        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
+        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
+        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
+        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
+        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
+        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
+        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
+        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
+        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
+        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
+        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
+        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
+        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
+        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
+        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
+        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
+        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
+        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
+        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
+        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
+        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
+        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
+        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
+        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
+        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
+        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
+        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
+        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
+        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
+        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
+        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
+        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
+        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
+        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
+        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
+        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
+        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
+        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
+        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
+        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
+        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
+        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
+        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
+        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
+        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
+        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
+        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
+        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
+        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
+        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
+        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
+        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.5.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5785'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 349986a972d843ebbe7b4bf33f1cbef2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
+        Z3VhcmQvcmhzbS82NjZjMmUzYS1hNGQ2LTRkYTgtOGZhMC05ZjM3OTRkNTg3
+        MTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1MDowMy45MTc3
+        OTVaIiwibmFtZSI6IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVs
+        bCwiY2FfY2VydGlmaWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxu
+        ICAgICAgICBWZXJzaW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1i
+        ZXI6XG4gICAgICAgICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAg
+        IFNpZ25hdHVyZSBBbGdvcml0aG06IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9u
+        XG4gICAgICAgIElzc3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9
+        UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9z
+        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgVmFsaWRpdHlc
+        biAgICAgICAgICAgIE5vdCBCZWZvcmU6IE1heSAgNyAxNDoyMTo1MCAyMDIw
+        IEdNVFxuICAgICAgICAgICAgTm90IEFmdGVyIDogSmFuIDE4IDE0OjIxOjUw
+        IDIwMzggR01UXG4gICAgICAgIFN1YmplY3Q6IEM9VVMsIFNUPU5vcnRoIENh
+        cm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQs
+        IENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        IFN1YmplY3QgUHVibGljIEtleSBJbmZvOlxuICAgICAgICAgICAgUHVibGlj
+        IEtleSBBbGdvcml0aG06IHJzYUVuY3J5cHRpb25cbiAgICAgICAgICAgICAg
+        ICBQdWJsaWMtS2V5OiAoMjA0OCBiaXQpXG4gICAgICAgICAgICAgICAgTW9k
+        dWx1czpcbiAgICAgICAgICAgICAgICAgICAgMDA6OWY6ZDI6YzE6MTA6ZmY6
+        MDE6MWE6MzM6MTk6MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAgICAgICAgICAg
+        ICAgIDhhOjczOmJhOjJkOjNjOjY2OmIxOjc4OmNkOjg5OjhjOjYwOmU1Ojgx
+        OmE2OlxuICAgICAgICAgICAgICAgICAgICBlODo0ZDo5Njo1ZDowNzpjMzpi
+        ZTphMjo5YzpjMjo3Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAgICAgICAgICAg
+        ICAgNDQ6NDY6ZWY6ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6OTc6Y2Q6OTc6
+        MTc6XG4gICAgICAgICAgICAgICAgICAgIGQ3OjNmOmU3OjY3OmZlOmE5OjJh
+        OmYxOmJjOjQ3Ojg3OjZlOmVkOjZkOmI2OlxuICAgICAgICAgICAgICAgICAg
+        ICA5ZTpmMTowZDo2Mzo1MzpjMTozZjpmZDoxNzphYjo1ZjozNTo3YTo4NDpj
+        ZjpcbiAgICAgICAgICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6MDk6OTk6NTY6
+        Mzk6ZGU6Mjk6NmI6ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAgICAgICAgICAg
+        IDU2OjJhOjEwOmIzOjBhOmNhOmI4OjZjOmZiOmI4OmM4OmViOmU1OmUyOmFl
+        OlxuICAgICAgICAgICAgICAgICAgICBkNTo0MTowNTo0YzphMjpjMDpiZTo3
+        YjpiMDo2ZDoxZDo3Yzo2Njo4MDo4ODpcbiAgICAgICAgICAgICAgICAgICAg
+        NWE6Yjc6MDc6OWI6ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6NDg6OTU6ODM6
+        XG4gICAgICAgICAgICAgICAgICAgIDM0OjI3OmM2OmFjOmNjOmEwOjBiOjU2
+        OmFiOjIyOjM0OjcxOjRmOjc5OmJmOlxuICAgICAgICAgICAgICAgICAgICA2
+        ZTo0YjpjOTo4OTo1OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3MDplZTo1ODpc
+        biAgICAgICAgICAgICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6MWU6ZDk6YjI6
+        NTc6M2E6ZTA6NTk6OGU6YjM6NmE6XG4gICAgICAgICAgICAgICAgICAgIDk3
+        OjNkOjlhOjgwOmNjOjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5OmI2OmIzOlxu
+        ICAgICAgICAgICAgICAgICAgICBhYTo5NTo1NDo1NTo5ZToxMzo2NTo3Zjo5
+        NTpjMDo3Mzo5NjpjNTpmYjo3NzpcbiAgICAgICAgICAgICAgICAgICAgYTA6
+        NDg6MjA6YTY6N2Q6ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6MWE6ZTI6XG4g
+        ICAgICAgICAgICAgICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3OjU2OmYwOjkz
+        OmE4OmI5OjBhOjczOmNmOmY3OlxuICAgICAgICAgICAgICAgICAgICAwMTow
+        ZlxuICAgICAgICAgICAgICAgIEV4cG9uZW50OiA2NTUzNyAoMHgxMDAwMSlc
+        biAgICAgICAgWDUwOXYzIGV4dGVuc2lvbnM6XG4gICAgICAgICAgICBYNTA5
+        djMgQmFzaWMgQ29uc3RyYWludHM6XG4gICAgICAgICAgICAgICAgQ0E6VFJV
+        RVxuICAgICAgICAgICAgWDUwOXYzIEtleSBVc2FnZTpcbiAgICAgICAgICAg
+        ICAgICBEaWdpdGFsIFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVybWVudCwgQ2Vy
+        dGlmaWNhdGUgU2lnbiwgQ1JMIFNpZ25cbiAgICAgICAgICAgIFg1MDl2MyBF
+        eHRlbmRlZCBLZXkgVXNhZ2U6XG4gICAgICAgICAgICAgICAgVExTIFdlYiBT
+        ZXJ2ZXIgQXV0aGVudGljYXRpb24sIFRMUyBXZWIgQ2xpZW50IEF1dGhlbnRp
+        Y2F0aW9uXG4gICAgICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5cGU6XG4gICAg
+        ICAgICAgICAgICAgU1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAgICBO
+        ZXRzY2FwZSBDb21tZW50OlxuICAgICAgICAgICAgICAgIEthdGVsbG8gU1NM
+        IFRvb2wgR2VuZXJhdGVkIENlcnRpZmljYXRlXG4gICAgICAgICAgICBYNTA5
+        djMgU3ViamVjdCBLZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICA5
+        QjpEMjpEOTo2OTo4ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpE
+        MTo4NTo0RDo1Mzo1RFxuICAgICAgICAgICAgWDUwOXYzIEF1dGhvcml0eSBL
+        ZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICBrZXlpZDo5QjpEMjpE
+        OTo2OTo4ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0
+        RDo1Mzo1RFxuICAgICAgICAgICAgICAgIERpck5hbWU6L0M9VVMvU1Q9Tm9y
+        dGggQ2Fyb2xpbmEvTD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21lT3JnVW5p
+        dC9DTj1jZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAg
+        ICAgICAgICAgIHNlcmlhbDpGRDpCQTpCQzo3MTo2RToyNTpBMzo3OFxuXG4g
+        ICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRp
+        b25cbiAgICAgICAgIDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJlOjY0OjE2OmIw
+        OjdjOmEzOjRiOjEwOmU4OjVhOmI0OlxuICAgICAgICAgMTc6NzQ6ZmQ6NzU6
+        YzY6MjY6ZDI6ODg6MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6YTU6MjU6XG4g
+        ICAgICAgICAxMzo2Yjo2MDozNDpkMDoyYzpkZTpkODo0ODoxNTpmNTpjYzox
+        ZjowNzo4MDoyYjoxZDoyODpcbiAgICAgICAgIDkwOmU5OjhiOjQ3OmMxOjcx
+        OjFhOmRhOjg2OmEwOjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRiOlxuICAgICAg
+        ICAgMTc6MmY6MGU6OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6Mjk6NWU6NGI6
+        OTk6NjA6ZmE6OTI6XG4gICAgICAgICAxMjoyNDpmYzpiYzowNDo5NDoyNDo2
+        NTpmMzo2MDpjYzo1ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAgICAgICAgIGI5
+        OjNjOjk5OjhhOjQ0OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBlOjE1Ojk0OmM0
+        OmM1OjIzOlxuICAgICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6OGM6NTY6NGI6
+        MDQ6MzU6OTU6Nzk6NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAgICAzYTo2ODpk
+        MDpmMzozZTo4ODo3ZDozODoyOTozMjpmMjo0NzpiMToxNzo5OTpmZDphNjo0
+        ODpcbiAgICAgICAgIDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZlOjY1OjliOjk5
+        OmU0OjYwOjdhOjMyOmNkOjAyOmZlOlxuICAgICAgICAgNzE6ZGE6MTk6ZTM6
+        OTM6YmQ6YzU6YTc6YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6OTE6Yzc6XG4g
+        ICAgICAgICBhNzo1MTo0ZTo4MTowOTpkMTpmMTozOTo1YjowNzo4Nzo0MToz
+        YjpiNzplMzoxYjphODo3ZTpcbiAgICAgICAgIDUxOjUyOjRlOjY2OjIwOmIx
+        OmNkOmM1OmFlOmRlOjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVlOlxuICAgICAg
+        ICAgODg6ZWY6ZTM6OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6M2Q6NTM6NTI6
+        ZmY6NWU6MGI6MWI6XG4gICAgICAgICA1Yjo2Yzo5YjphNlxuLS0tLS1CRUdJ
+        TiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lCQWdJSkFQMjZ2
+        SEZ1SmFONE1BMEdDU3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dDUVlEXG5WUVFH
+        RXdKVlV6RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9C
+        Z05WQkFjTUIxSmhiR1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4
+        RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEXG5WUVFERENC
+        alpXNTBiM00zTFdSbGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVEFl
+        RncweU1EQTFNRGN4XG5OREl4TlRCYUZ3MHpPREF4TVRneE5ESXhOVEJhTUlH
+        TE1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPXG5UbTl5ZEdnZ1Ey
+        RnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVEQU9CZ05WQkFv
+        TUIwdGhkR1ZzXG5iRzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1T
+        a3dKd1lEVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6WVcxcGNpNWxl
+        R0Z0Y0d4bExtTnZiVENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFE
+        Q0NBUW9DXG5nZ0VCQUovU3dSRC9BUm96R1E1RG5ZUGxpbk82TFR4bXNYak5p
+        WXhnNVlHbTZFMldYUWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZZ1J6dldOZjJY
+        elpjWDF6L25aLzZwS3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBYcTE4MWVvVFBh
+        OTJtXG5qZ21aVmpuZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1qcjVlS3UxVUVG
+        VEtMQXZudXdiUjE4Wm9DSVdyY0htOU80XG4vNVB6R1ROalNKV0ROQ2ZHck15
+        Z0MxYXJJalJ4VDNtL2JrdkppVm1IaTNzMWViZ2NjTzVZNW5zaWVhY2UyYkpY
+        XG5PdUJaanJOcWx6MmFnTXc3MVhmVStucFlhYmF6cXBWVVZaNFRaWCtWd0hP
+        V3hmdDNvRWdncG4zMHhOUHBxNVNUXG5UaHJpWFp2RmgxREhWdkNUcUxrS2M4
+        LzNBUThDQXdFQUFhT0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1BTUJBZjh3XG5D
+        d1lEVlIwUEJBUURBZ0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJn
+        Z3JCZ0VGQlFjREFqQVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1DQWtRd05RWUpZ
+        SVpJQVliNFFnRU5CQ2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZiMndnXG5SMlZ1
+        WlhKaGRHVmtJRU5sY25ScFptbGpZWFJsTUIwR0ExVWREZ1FXQkJTYjB0bHBp
+        SmtzTG5BcnQybDJlbjNSXG5oVTFUWFRDQndBWURWUjBqQklHNE1JRzFnQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JoVTFUWGFHQmthU0JqakNCXG5pekVMTUFr
+        R0ExVUVCaE1DVlZNeEZ6QVZCZ05WQkFnTURrNXZjblJvSUVOaGNtOXNhVzVo
+        TVJBd0RnWURWUVFIXG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZRUUtEQWRMWVhS
+        bGJHeHZNUlF3RWdZRFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5kREVwTUNjR0Ex
+        VUVBd3dnWTJWdWRHOXpOeTFrWlhabGJESXVjMkZ0YVhJdVpYaGhiWEJzWlM1
+        amIyMkNDUUQ5XG51cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FR
+        RUFNaGxzeHErdXdyNWtGckI4bzBzUTZGcTBGM1Q5XG5kY1ltMG9nQi9wVXVQ
+        d29laUtVbEUydGdOTkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxSOEZ4R3RxR29D
+        Zm94SWcyXG5vLy9iRnk4T20rRTVweC9jSnBjcFhrdVpZUHFTRWlUOHZBU1VK
+        R1h6WU14ZTdrSy9uand4dVR5WmlrUTlLVjJtXG5tYXJWRGhXVXhNVWpqTGx1
+        NVFrVGpGWkxCRFdWZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpIc1JlWi9hWklB
+        Z1JyXG5uN25hd201bG01bmtZSG95elFMK2Nkb1o0NU85eGFlZ1JwNG8wcEdz
+        anBISHAxRk9nUW5SOFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hj
+        NjE4NEhOOWhlaU8vamxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0t
+        LS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/rhel_7_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 89616f621ae34e4d90b56fa7a8f0871f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/e02442f7-50a5-4aed-96c8-8eefdca2e194/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6a1a5ebdde6844f4b2277cdc1fb57e90
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vZTAyNDQyZjctNTBhNS00YWVkLTk2YzgtOGVlZmRjYTJlMTk0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MjYuMDc4NzQzWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8wM2E5Nzk5My03MDFlLTRhOTQtYTMyZS1hMDFiMjNkODdmZmYv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzAzYTk3OTkzLTcwMWUtNGE5NC1hMzJlLWEwMWIy
+        M2Q4N2ZmZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:26 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvcmhlbF83
+        X2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzY2NmMyZTNhLWE0ZDYtNGRhOC04ZmEw
+        LTlmMzc5NGQ1ODcxMC8iLCJuYW1lIjoiOSIsInB1YmxpY2F0aW9uIjoiL3B1
+        bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtL2UwMjQ0MmY3LTUwYTUt
+        NGFlZC05NmM4LThlZWZkY2EyZTE5NC8ifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5632,7 +6309,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:48 GMT
+      - Fri, 29 Jul 2022 08:59:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5640,7 +6317,7 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
@@ -5650,21 +6327,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33275e81f8d04894b9fedef53fd63ce5
+      - c5df792a70eb46dfb6534486a171d219
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1M2IwYzZiLWEyNDgtNGU0
-        YS05MTdjLWI0Mzk5MTY3NzlhNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q0NTRiZjM3LWU2NzctNGVm
+        ZC1iODNjLWM1YmNlMDMxOWE4ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:48 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/353b0c6b-a248-4e4a-917c-b439916779a4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d454bf37-e677-4efd-b83c-c5bce0319a8d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5685,63 +6362,131 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:48 GMT
+      - Fri, 29 Jul 2022 08:59:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '632'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e65eb0f1dcd141b19d8b1de04d13f1ee
+      - 773353cbc48042f0854805c25701bd88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzUzYjBjNmItYTI0
-        OC00ZTRhLTkxN2MtYjQzOTkxNjc3OWE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDguMTA2MjkyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIzMzI3NWU4MWY4ZDA0ODk0YjlmZWRlZjUz
-        ZmQ2M2NlNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ4LjEz
-        ODQ1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDguMTYz
-        NDExWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDQ1NGJmMzctZTY3
+        Ny00ZWZkLWI4M2MtYzViY2UwMzE5YThkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjcuMDQwNTgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJjNWRmNzkyYTcwZWI0NmRmYjY1MzQ0ODZh
+        MTcxZDIxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjI3LjA4
+        MzY5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MjcuMzQ4
+        MTYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2UxNGJmNTFlLTg5NmItNGJjZi04ZWNm
-        LWMzYTkxODRiOWIzMi8iXX0=
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vOTY5
+        YTY3NGMtMjAwNi00ODc0LWEyMGYtNTJhZWNkOTdkNDIwLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:48 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:27 GMT
 - request:
-    method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/sync/
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/969a674c-2006-4874-a20f-52aecd97d420/
     body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2UxNGJm
-        NTFlLTg5NmItNGJjZi04ZWNmLWMzYTkxODRiOWIzMi8iLCJzeW5jX3BvbGlj
-        eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
-        aW1pemUiOnRydWV9
+      encoding: US-ASCII
+      base64_string: ''
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '524'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fc09abc11b37460e8632652bbb94e571
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzk2OWE2NzRjLTIwMDYtNDg3NC1hMjBmLTUyYWVjZDk3ZDQyMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjI3LjMzMDMwOVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvcmhlbF83X2xh
+        YmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0ZWxsby1kZXZl
+        bC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9s
+        aWJyYXJ5L3JoZWxfN19sYWJlbC8iLCJjb250ZW50X2d1YXJkIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vNjY2YzJlM2Et
+        YTRkNi00ZGE4LThmYTAtOWYzNzk0ZDU4NzEwLyIsInB1bHBfbGFiZWxzIjp7
+        fSwibmFtZSI6IjkiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9lMDI0NDJmNy01
+        MGE1LTRhZWQtOTZjOC04ZWVmZGNhMmUxOTQvIn0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:27 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/e31d5a57-5d36-4824-8a20-6b82d4d82ccf/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6InB1bHAtdXVpZC1yaGVs
+        XzZfeDg2XzY0IiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19p
+        bXBvcnRzL3Rlc3RfcmVwb3Mvem9vX2R1cF9kdXAiLCJwcm94eV91cmwiOm51
+        bGwsInByb3h5X3VzZXJuYW1lIjpudWxsLCJwcm94eV9wYXNzd29yZCI6bnVs
+        bCwidG90YWxfdGltZW91dCI6MzYwMCwiY29ubmVjdF90aW1lb3V0Ijo2MCwi
+        c29ja19jb25uZWN0X3RpbWVvdXQiOjYwLCJzb2NrX3JlYWRfdGltZW91dCI6
+        MzYwMCwicmF0ZV9saW1pdCI6MCwidXNlcm5hbWUiOm51bGwsInBhc3N3b3Jk
+        IjpudWxsLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5754,7 +6499,129 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:48 GMT
+      - Fri, 29 Jul 2022 08:59:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f797fa637238444db29b761cca7eccbe
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y1ZTExYTJlLWUwODctNGU3
+        MC05YjVmLWJjZGRjMjY2N2RmZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:27 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f5e11a2e-e087-4e70-9b5f-bcddc2667dff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 65c56d9d2749412aa5642ee6094cae00
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjVlMTFhMmUtZTA4
+        Ny00ZTcwLTliNWYtYmNkZGMyNjY3ZGZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjcuODkzMjEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmNzk3ZmE2MzcyMzg0NDRkYjI5Yjc2MWNj
+        YTdlY2NiZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjI3Ljk0
+        MjE0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MjcuOTY2
+        ODgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2UzMWQ1YTU3LTVkMzYtNDgyNC04YTIw
+        LTZiODJkNGQ4MmNjZi8iXX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:28 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2UzMWQ1
+        YTU3LTVkMzYtNDgyNC04YTIwLTZiODJkNGQ4MmNjZi8iLCJzeW5jX3BvbGlj
+        eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
+        aW1pemUiOnRydWV9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5772,21 +6639,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6a8f44da286847dc807e238b8a10d0d9
+      - e301ca5b116e4a2b9728327de896ef1c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkYjk0YzI4LTZkNzEtNDg1
-        OC05MTJlLWExODU2ODlhMDcyZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiODM4ZDMwLWE2OTItNGRj
+        NS05NTg3LWE0ZDE0ODdmMDlhNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:48 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4db94c28-6d71-4858-912e-a185689a072e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fb838d30-a692-4dc5-9587-a4d1487f09a4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5807,90 +6674,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:49 GMT
+      - Fri, 29 Jul 2022 08:59:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 37a769420d2040098c7e12fd83e399e1
+      - e56d84bcc81f4a759f6dedf1d726f20d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '663'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGRiOTRjMjgtNmQ3
-        MS00ODU4LTkxMmUtYTE4NTY4OWEwNzJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDguMzA1MzUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmI4MzhkMzAtYTY5
+        Mi00ZGM1LTk1ODctYTRkMTQ4N2YwOWE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjguMTMyMjA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI2YThmNDRkYTI4Njg0N2RjODA3
-        ZTIzOGI4YTEwZDBkOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ4LjMzODI0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDkuMTMwMzcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJlMzAxY2E1YjExNmU0YTJiOTcy
+        ODMyN2RlODk2ZWYxYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjI4LjE4NDY1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MjkuNDgyNDg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
-        IlBhcnNlZCBDb21wcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuY29tcHMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgi
-        Om51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5hZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6NywiZG9uZSI6Nywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
-        OiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9h
-        ZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
-        dWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFz
-        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250
-        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
-        ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo0Miwic3VmZml4IjpudWxs
-        fSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNv
-        ZGUiOiJzeW5jLmRvd25sb2FkaW5nLm1ldGFkYXRhIiwic3RhdGUiOiJjb21w
-        bGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Nywic3VmZml4IjpudWxsfSx7
-        Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQiLCJjb2RlIjoic3luYy5wYXJz
-        aW5nLm1vZHVsZW1kcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjYs
-        ImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1v
-        ZHVsZW1kLWRlZmF1bHRzIiwiY29kZSI6InN5bmMucGFyc2luZy5tb2R1bGVt
-        ZF9kZWZhdWx0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
-        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2th
-        Z2VzIiwiY29kZSI6InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjIwLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzFkNzc5MTk3LWI5MTMtNDNiYy1hMGMwLTM3NjIy
-        MWY4MzVlYi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xZDc3
-        OTE5Ny1iOTEzLTQzYmMtYTBjMC0zNzYyMjFmODM1ZWIvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZTE0YmY1MWUtODk2Yi00YmNm
-        LThlY2YtYzNhOTE4NGI5YjMyLyJdfQ==
+        IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
+        bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9kMDVhYzEwNi0xZmVlLTRkNDMtOTk5NS00YWEyMWE5
+        MTEzZDAvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDA1YWMx
+        MDYtMWZlZS00ZDQzLTk5OTUtNGFhMjFhOTExM2QwLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2UzMWQ1YTU3LTVkMzYtNDgyNC04
+        YTIwLTZiODJkNGQ4MmNjZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:49 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:29 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMWQ3NzkxOTctYjkxMy00M2JjLWEwYzAtMzc2MjIxZjgz
-        NWViL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZDA1YWMxMDYtMWZlZS00ZDQzLTk5OTUtNGFhMjFhOTEx
+        M2QwL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5903,7 +6770,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:49 GMT
+      - Fri, 29 Jul 2022 08:59:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5921,21 +6788,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2cf737c8c12b4eebabda3fa67b1c788d
+      - 1bb579480244456ca917f73a5de115d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5NTA1ZWM5LTM3NzQtNGZh
-        MS04MzQ1LWI2YzIxMjZjY2NhZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdlODI0ODQ5LThmNjgtNDMy
+        NC04NTA1LTk4ZmFmM2M1NjZlYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:49 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/29505ec9-3774-4fa1-8345-b6c2126cccaf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7e824849-8f68-4324-8505-98faf3c566ec/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5956,56 +6823,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:49 GMT
+      - Fri, 29 Jul 2022 08:59:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c6ee9fa8621647a781b3b7ad48a606db
+      - a91b05c8d78e4d9dafdb503fbd57dfe4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjk1MDVlYzktMzc3
-        NC00ZmExLTgzNDUtYjZjMjEyNmNjY2FmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDkuNDI5Mzc4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2U4MjQ4NDktOGY2
+        OC00MzI0LTg1MDUtOThmYWYzYzU2NmVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MjkuOTExMDg0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjJjZjczN2M4YzEyYjRlZWJhYmRhM2ZhNjdi
-        MWM3ODhkIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NDkuNDY1
-        OTk5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzo0OS43MDk3
-        NjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjFiYjU3OTQ4MDI0NDQ1NmNhOTE3ZjczYTVk
+        ZTExNWQyIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MjkuOTQz
+        ODEyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1OTozMC4zODY4
+        NTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMmFiOTY5
-        NzktZjg1ZC00YjQ1LTkwMTAtYzRiYTk3ODcwYzcwLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjc4YmEz
+        NWItNzE3My00MzE3LTk4OTAtMTRlYjU2NTQ4YzMyLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMWQ3NzkxOTctYjkxMy00M2JjLWEwYzAtMzc2MjIx
-        ZjgzNWViLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZDA1YWMxMDYtMWZlZS00ZDQzLTk5OTUtNGFhMjFh
+        OTExM2QwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:49 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -6013,7 +6880,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.5.2/ruby
+      - OpenAPI-Generator/1.5.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -6026,37 +6893,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:49 GMT
+      - Fri, 29 Jul 2022 08:59:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5837'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 28b83c51973c4f4cab0bb0b7782adbe5
+      - 68e6d65b9ba14c089a29c2e56061bf61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3082'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzA3ZDY2MTBhLTYxOWEtNGJiMC05YzlkLWM0OWQ0
-        ZTI1YjRhNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE0OjAz
-        LjM1NDYwMloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        L2NlcnRndWFyZC9yaHNtLzY2NmMyZTNhLWE0ZDYtNGRhOC04ZmEwLTlmMzc5
+        NGQ1ODcxMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjUwOjAz
+        LjkxNzc5NVoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
         IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
         dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
         IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
@@ -6183,10 +7050,10 @@ http_interactions:
         V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
         PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:49 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:30 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/07d6610a-619a-4bb0-9c9d-c49d4e25b4a4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/666c2e3a-a4d6-4da8-8fa0-9f3794d58710/
     body:
       encoding: UTF-8
       base64_string: |
@@ -6319,7 +7186,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.5.2/ruby
+      - OpenAPI-Generator/1.5.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -6332,36 +7199,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:49 GMT
+      - Fri, 29 Jul 2022 08:59:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5785'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f8ddad475a746fe8cb6da0157264d04
+      - 42e9898c70494c9f929bfbe7c3687974
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3046'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wN2Q2NjEwYS02MTlhLTRiYjAtOWM5ZC1jNDlkNGUyNWI0
-        YTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNDowMy4zNTQ2
-        MDJaIiwibmFtZSI6IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVs
+        Z3VhcmQvcmhzbS82NjZjMmUzYS1hNGQ2LTRkYTgtOGZhMC05ZjM3OTRkNTg3
+        MTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1MDowMy45MTc3
+        OTVaIiwibmFtZSI6IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVs
         bCwiY2FfY2VydGlmaWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxu
         ICAgICAgICBWZXJzaW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1i
         ZXI6XG4gICAgICAgICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAg
@@ -6488,10 +7355,10 @@ http_interactions:
         NjE4NEhOOWhlaU8vamxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0t
         LS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:49 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -6499,7 +7366,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/1.5.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -6512,35 +7379,825 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:50 GMT
+      - Fri, 29 Jul 2022 08:59:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5837'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f121302986ff4ec39ab02564cc0092b5
+      - aaf28d630ac548cfa7dd322f72be9239
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1945'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzY2NmMyZTNhLWE0ZDYtNGRhOC04ZmEwLTlmMzc5
+        NGQ1ODcxMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjUwOjAz
+        LjkxNzc5NVoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
+        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
+        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
+        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
+        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
+        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
+        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
+        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
+        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
+        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
+        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
+        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
+        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
+        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
+        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
+        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
+        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
+        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
+        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
+        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
+        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
+        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
+        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
+        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
+        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
+        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
+        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
+        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
+        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
+        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
+        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
+        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
+        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
+        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
+        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
+        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
+        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
+        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
+        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
+        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
+        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
+        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
+        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
+        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
+        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
+        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
+        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
+        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
+        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
+        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
+        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
+        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
+        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
+        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
+        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
+        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
+        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
+        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
+        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
+        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
+        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
+        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
+        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
+        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
+        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
+        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
+        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
+        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
+        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
+        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
+        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
+        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
+        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
+        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
+        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
+        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
+        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
+        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
+        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
+        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
+        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
+        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
+        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
+        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
+        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
+        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
+        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
+        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
+        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
+        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
+        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
+        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
+        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
+        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
+        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
+        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
+        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
+        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
+        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
+        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
+        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
+        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
+        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
+        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
+        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
+        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
+        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
+        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
+        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
+        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
+        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
+        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
+        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:30 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/666c2e3a-a4d6-4da8-8fa0-9f3794d58710/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
+        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
+        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
+        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
+        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
+        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
+        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
+        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
+        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
+        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
+        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
+        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
+        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
+        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
+        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
+        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
+        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
+        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
+        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
+        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
+        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
+        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
+        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
+        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
+        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
+        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
+        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
+        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
+        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
+        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
+        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
+        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
+        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
+        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
+        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
+        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
+        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
+        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
+        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
+        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
+        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
+        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
+        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
+        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
+        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
+        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
+        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
+        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
+        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
+        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
+        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
+        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
+        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
+        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
+        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
+        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
+        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
+        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
+        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
+        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
+        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
+        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
+        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
+        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
+        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
+        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
+        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
+        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
+        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
+        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
+        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
+        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
+        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
+        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
+        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
+        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
+        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
+        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
+        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
+        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
+        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
+        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
+        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
+        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
+        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
+        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
+        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
+        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
+        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
+        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
+        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
+        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
+        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
+        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
+        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
+        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
+        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
+        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
+        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
+        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
+        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
+        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
+        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
+        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
+        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
+        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
+        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
+        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
+        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
+        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
+        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
+        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
+        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
+        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.5.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5785'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 366bb92d4d5d439fb2f376629eb145fd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
+        Z3VhcmQvcmhzbS82NjZjMmUzYS1hNGQ2LTRkYTgtOGZhMC05ZjM3OTRkNTg3
+        MTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1MDowMy45MTc3
+        OTVaIiwibmFtZSI6IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVs
+        bCwiY2FfY2VydGlmaWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxu
+        ICAgICAgICBWZXJzaW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1i
+        ZXI6XG4gICAgICAgICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAg
+        IFNpZ25hdHVyZSBBbGdvcml0aG06IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9u
+        XG4gICAgICAgIElzc3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9
+        UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9z
+        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgVmFsaWRpdHlc
+        biAgICAgICAgICAgIE5vdCBCZWZvcmU6IE1heSAgNyAxNDoyMTo1MCAyMDIw
+        IEdNVFxuICAgICAgICAgICAgTm90IEFmdGVyIDogSmFuIDE4IDE0OjIxOjUw
+        IDIwMzggR01UXG4gICAgICAgIFN1YmplY3Q6IEM9VVMsIFNUPU5vcnRoIENh
+        cm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQs
+        IENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        IFN1YmplY3QgUHVibGljIEtleSBJbmZvOlxuICAgICAgICAgICAgUHVibGlj
+        IEtleSBBbGdvcml0aG06IHJzYUVuY3J5cHRpb25cbiAgICAgICAgICAgICAg
+        ICBQdWJsaWMtS2V5OiAoMjA0OCBiaXQpXG4gICAgICAgICAgICAgICAgTW9k
+        dWx1czpcbiAgICAgICAgICAgICAgICAgICAgMDA6OWY6ZDI6YzE6MTA6ZmY6
+        MDE6MWE6MzM6MTk6MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAgICAgICAgICAg
+        ICAgIDhhOjczOmJhOjJkOjNjOjY2OmIxOjc4OmNkOjg5OjhjOjYwOmU1Ojgx
+        OmE2OlxuICAgICAgICAgICAgICAgICAgICBlODo0ZDo5Njo1ZDowNzpjMzpi
+        ZTphMjo5YzpjMjo3Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAgICAgICAgICAg
+        ICAgNDQ6NDY6ZWY6ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6OTc6Y2Q6OTc6
+        MTc6XG4gICAgICAgICAgICAgICAgICAgIGQ3OjNmOmU3OjY3OmZlOmE5OjJh
+        OmYxOmJjOjQ3Ojg3OjZlOmVkOjZkOmI2OlxuICAgICAgICAgICAgICAgICAg
+        ICA5ZTpmMTowZDo2Mzo1MzpjMTozZjpmZDoxNzphYjo1ZjozNTo3YTo4NDpj
+        ZjpcbiAgICAgICAgICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6MDk6OTk6NTY6
+        Mzk6ZGU6Mjk6NmI6ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAgICAgICAgICAg
+        IDU2OjJhOjEwOmIzOjBhOmNhOmI4OjZjOmZiOmI4OmM4OmViOmU1OmUyOmFl
+        OlxuICAgICAgICAgICAgICAgICAgICBkNTo0MTowNTo0YzphMjpjMDpiZTo3
+        YjpiMDo2ZDoxZDo3Yzo2Njo4MDo4ODpcbiAgICAgICAgICAgICAgICAgICAg
+        NWE6Yjc6MDc6OWI6ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6NDg6OTU6ODM6
+        XG4gICAgICAgICAgICAgICAgICAgIDM0OjI3OmM2OmFjOmNjOmEwOjBiOjU2
+        OmFiOjIyOjM0OjcxOjRmOjc5OmJmOlxuICAgICAgICAgICAgICAgICAgICA2
+        ZTo0YjpjOTo4OTo1OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3MDplZTo1ODpc
+        biAgICAgICAgICAgICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6MWU6ZDk6YjI6
+        NTc6M2E6ZTA6NTk6OGU6YjM6NmE6XG4gICAgICAgICAgICAgICAgICAgIDk3
+        OjNkOjlhOjgwOmNjOjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5OmI2OmIzOlxu
+        ICAgICAgICAgICAgICAgICAgICBhYTo5NTo1NDo1NTo5ZToxMzo2NTo3Zjo5
+        NTpjMDo3Mzo5NjpjNTpmYjo3NzpcbiAgICAgICAgICAgICAgICAgICAgYTA6
+        NDg6MjA6YTY6N2Q6ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6MWE6ZTI6XG4g
+        ICAgICAgICAgICAgICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3OjU2OmYwOjkz
+        OmE4OmI5OjBhOjczOmNmOmY3OlxuICAgICAgICAgICAgICAgICAgICAwMTow
+        ZlxuICAgICAgICAgICAgICAgIEV4cG9uZW50OiA2NTUzNyAoMHgxMDAwMSlc
+        biAgICAgICAgWDUwOXYzIGV4dGVuc2lvbnM6XG4gICAgICAgICAgICBYNTA5
+        djMgQmFzaWMgQ29uc3RyYWludHM6XG4gICAgICAgICAgICAgICAgQ0E6VFJV
+        RVxuICAgICAgICAgICAgWDUwOXYzIEtleSBVc2FnZTpcbiAgICAgICAgICAg
+        ICAgICBEaWdpdGFsIFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVybWVudCwgQ2Vy
+        dGlmaWNhdGUgU2lnbiwgQ1JMIFNpZ25cbiAgICAgICAgICAgIFg1MDl2MyBF
+        eHRlbmRlZCBLZXkgVXNhZ2U6XG4gICAgICAgICAgICAgICAgVExTIFdlYiBT
+        ZXJ2ZXIgQXV0aGVudGljYXRpb24sIFRMUyBXZWIgQ2xpZW50IEF1dGhlbnRp
+        Y2F0aW9uXG4gICAgICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5cGU6XG4gICAg
+        ICAgICAgICAgICAgU1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAgICBO
+        ZXRzY2FwZSBDb21tZW50OlxuICAgICAgICAgICAgICAgIEthdGVsbG8gU1NM
+        IFRvb2wgR2VuZXJhdGVkIENlcnRpZmljYXRlXG4gICAgICAgICAgICBYNTA5
+        djMgU3ViamVjdCBLZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICA5
+        QjpEMjpEOTo2OTo4ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpE
+        MTo4NTo0RDo1Mzo1RFxuICAgICAgICAgICAgWDUwOXYzIEF1dGhvcml0eSBL
+        ZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICBrZXlpZDo5QjpEMjpE
+        OTo2OTo4ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0
+        RDo1Mzo1RFxuICAgICAgICAgICAgICAgIERpck5hbWU6L0M9VVMvU1Q9Tm9y
+        dGggQ2Fyb2xpbmEvTD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21lT3JnVW5p
+        dC9DTj1jZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAg
+        ICAgICAgICAgIHNlcmlhbDpGRDpCQTpCQzo3MTo2RToyNTpBMzo3OFxuXG4g
+        ICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRp
+        b25cbiAgICAgICAgIDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJlOjY0OjE2OmIw
+        OjdjOmEzOjRiOjEwOmU4OjVhOmI0OlxuICAgICAgICAgMTc6NzQ6ZmQ6NzU6
+        YzY6MjY6ZDI6ODg6MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6YTU6MjU6XG4g
+        ICAgICAgICAxMzo2Yjo2MDozNDpkMDoyYzpkZTpkODo0ODoxNTpmNTpjYzox
+        ZjowNzo4MDoyYjoxZDoyODpcbiAgICAgICAgIDkwOmU5OjhiOjQ3OmMxOjcx
+        OjFhOmRhOjg2OmEwOjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRiOlxuICAgICAg
+        ICAgMTc6MmY6MGU6OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6Mjk6NWU6NGI6
+        OTk6NjA6ZmE6OTI6XG4gICAgICAgICAxMjoyNDpmYzpiYzowNDo5NDoyNDo2
+        NTpmMzo2MDpjYzo1ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAgICAgICAgIGI5
+        OjNjOjk5OjhhOjQ0OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBlOjE1Ojk0OmM0
+        OmM1OjIzOlxuICAgICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6OGM6NTY6NGI6
+        MDQ6MzU6OTU6Nzk6NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAgICAzYTo2ODpk
+        MDpmMzozZTo4ODo3ZDozODoyOTozMjpmMjo0NzpiMToxNzo5OTpmZDphNjo0
+        ODpcbiAgICAgICAgIDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZlOjY1OjliOjk5
+        OmU0OjYwOjdhOjMyOmNkOjAyOmZlOlxuICAgICAgICAgNzE6ZGE6MTk6ZTM6
+        OTM6YmQ6YzU6YTc6YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6OTE6Yzc6XG4g
+        ICAgICAgICBhNzo1MTo0ZTo4MTowOTpkMTpmMTozOTo1YjowNzo4Nzo0MToz
+        YjpiNzplMzoxYjphODo3ZTpcbiAgICAgICAgIDUxOjUyOjRlOjY2OjIwOmIx
+        OmNkOmM1OmFlOmRlOjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVlOlxuICAgICAg
+        ICAgODg6ZWY6ZTM6OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6M2Q6NTM6NTI6
+        ZmY6NWU6MGI6MWI6XG4gICAgICAgICA1Yjo2Yzo5YjphNlxuLS0tLS1CRUdJ
+        TiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lCQWdJSkFQMjZ2
+        SEZ1SmFONE1BMEdDU3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dDUVlEXG5WUVFH
+        RXdKVlV6RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9C
+        Z05WQkFjTUIxSmhiR1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4
+        RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEXG5WUVFERENC
+        alpXNTBiM00zTFdSbGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVEFl
+        RncweU1EQTFNRGN4XG5OREl4TlRCYUZ3MHpPREF4TVRneE5ESXhOVEJhTUlH
+        TE1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPXG5UbTl5ZEdnZ1Ey
+        RnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVEQU9CZ05WQkFv
+        TUIwdGhkR1ZzXG5iRzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1T
+        a3dKd1lEVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6WVcxcGNpNWxl
+        R0Z0Y0d4bExtTnZiVENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFE
+        Q0NBUW9DXG5nZ0VCQUovU3dSRC9BUm96R1E1RG5ZUGxpbk82TFR4bXNYak5p
+        WXhnNVlHbTZFMldYUWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZZ1J6dldOZjJY
+        elpjWDF6L25aLzZwS3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBYcTE4MWVvVFBh
+        OTJtXG5qZ21aVmpuZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1qcjVlS3UxVUVG
+        VEtMQXZudXdiUjE4Wm9DSVdyY0htOU80XG4vNVB6R1ROalNKV0ROQ2ZHck15
+        Z0MxYXJJalJ4VDNtL2JrdkppVm1IaTNzMWViZ2NjTzVZNW5zaWVhY2UyYkpY
+        XG5PdUJaanJOcWx6MmFnTXc3MVhmVStucFlhYmF6cXBWVVZaNFRaWCtWd0hP
+        V3hmdDNvRWdncG4zMHhOUHBxNVNUXG5UaHJpWFp2RmgxREhWdkNUcUxrS2M4
+        LzNBUThDQXdFQUFhT0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1BTUJBZjh3XG5D
+        d1lEVlIwUEJBUURBZ0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJn
+        Z3JCZ0VGQlFjREFqQVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1DQWtRd05RWUpZ
+        SVpJQVliNFFnRU5CQ2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZiMndnXG5SMlZ1
+        WlhKaGRHVmtJRU5sY25ScFptbGpZWFJsTUIwR0ExVWREZ1FXQkJTYjB0bHBp
+        SmtzTG5BcnQybDJlbjNSXG5oVTFUWFRDQndBWURWUjBqQklHNE1JRzFnQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JoVTFUWGFHQmthU0JqakNCXG5pekVMTUFr
+        R0ExVUVCaE1DVlZNeEZ6QVZCZ05WQkFnTURrNXZjblJvSUVOaGNtOXNhVzVo
+        TVJBd0RnWURWUVFIXG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZRUUtEQWRMWVhS
+        bGJHeHZNUlF3RWdZRFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5kREVwTUNjR0Ex
+        VUVBd3dnWTJWdWRHOXpOeTFrWlhabGJESXVjMkZ0YVhJdVpYaGhiWEJzWlM1
+        amIyMkNDUUQ5XG51cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FR
+        RUFNaGxzeHErdXdyNWtGckI4bzBzUTZGcTBGM1Q5XG5kY1ltMG9nQi9wVXVQ
+        d29laUtVbEUydGdOTkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxSOEZ4R3RxR29D
+        Zm94SWcyXG5vLy9iRnk4T20rRTVweC9jSnBjcFhrdVpZUHFTRWlUOHZBU1VK
+        R1h6WU14ZTdrSy9uand4dVR5WmlrUTlLVjJtXG5tYXJWRGhXVXhNVWpqTGx1
+        NVFrVGpGWkxCRFdWZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpIc1JlWi9hWklB
+        Z1JyXG5uN25hd201bG01bmtZSG95elFMK2Nkb1o0NU85eGFlZ1JwNG8wcEdz
+        anBISHAxRk9nUW5SOFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hj
+        NjE4NEhOOWhlaU8vamxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0t
+        LS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/rhel_6_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4a2fa5d393a046879f4dd0bb58019e83
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/678ba35b-7173-4317-9890-14eb56548c32/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8d6d49b6d131440ebb8fef9a74c679ba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNjc4YmEzNWItNzE3My00MzE3LTk4OTAtMTRlYjU2NTQ4YzMyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MjkuOTY3MTEzWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kMDVhYzEwNi0xZmVlLTRkNDMtOTk5NS00YWEyMWE5MTEzZDAv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2QwNWFjMTA2LTFmZWUtNGQ0My05OTk1LTRhYTIx
+        YTkxMTNkMC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:30 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvcmhlbF82
+        X2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzY2NmMyZTNhLWE0ZDYtNGRhOC04ZmEw
+        LTlmMzc5NGQ1ODcxMC8iLCJuYW1lIjoicHVscC11dWlkLXJoZWxfNl94ODZf
+        NjQiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS82NzhiYTM1Yi03MTczLTQzMTctOTg5MC0xNGViNTY1NDhjMzIv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c268216983264a6cafc36e3e47a7d509
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4M2RiNzhlLTFjMGQtNDc0
+        Ni1hMDk1LWY4MzIwYjUzNWFlZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f83db78e-1c0d-4746-a095-f8320b535aef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 96d812c957134a7eb75a010f47293dce
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjgzZGI3OGUtMWMw
+        ZC00NzQ2LWEwOTUtZjgzMjBiNTM1YWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzAuODc3NTY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJjMjY4MjE2OTgzMjY0YTZjYWZjMzZlM2U0
+        N2E3ZDUwOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjMwLjkx
+        MjU4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MzEuMjc1
+        ODA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMGE4
+        ZTRlMzQtZjM3OC00YzY4LWIyNTUtMjAxMmFjMTIxMWY4LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:31 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/0a8e4e34-f378-4c68-b255-2012ac1211f8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '546'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a8d18fb53b9f4b2ea2a3f394863c840a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzBhOGU0ZTM0LWYzNzgtNGM2OC1iMjU1LTIwMTJhYzEyMTFmOC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjMxLjI0ODIwOVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvcmhlbF82X2xh
+        YmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0ZWxsby1kZXZl
+        bC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9s
+        aWJyYXJ5L3JoZWxfNl9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vNjY2YzJlM2Et
+        YTRkNi00ZGE4LThmYTAtOWYzNzk0ZDU4NzEwLyIsInB1bHBfbGFiZWxzIjp7
+        fSwibmFtZSI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwicmVwb3NpdG9y
+        eSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRp
+        b25zL3JwbS9ycG0vNjc4YmEzNWItNzE3My00MzE3LTk4OTAtMTRlYjU2NTQ4
+        YzMyLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:31 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e6a44ed983774715a798c555ed469865
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNDFjODA3ZDgtMzE5Yi00OGY5LWE1MTAtYTRlMTVkMjBmYjM3
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -6548,16 +8205,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNTZhZDg0NC04NzU2LTQ5OTYt
-        YTY4MC1lOGEyNDc0YzJlMjMvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNi
-        OGYwNjg4LTI2ODMtNGJlOS05NjRlLTlkYmU3YjFlZjNmZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -6565,147 +8222,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2E0Y2EyNDhiLTA5OGYtNDE2Yi04MzVlLTJk
-        ZWVhYjU5OTVkZS8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvODRhZGIyYmMtZjZmNi00NzM3LTllNDgtNjJjNzYyZGU0OTAwLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFiMDJmY2NmLTc1MjUtNDc0
-        Zi1iYzQ2LWE5YWNjYmUwNDZkNy8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2JiMjAwNDk1LTg0ZjItNGUxOS1iYzE0LWIyMWJhZWVhMTY2OC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hOTY2MDc2MC1mMzE0LTQ3ZDItODkwYS0yNjA0
-        MDVlYjM4N2QvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        YzkxNjRlOS05ZTYxLTQ0NDctYmJkOC1iZDgxMGZlNTU1NzMvIiwibmFtZSI6
-        ImdpcmFmZmUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlk
-        YTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIy
-        MDA5ZjlmMTQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFm
-        ZmUiLCJsb2NhdGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzBjYjE1YWEtZTg1Yi00MzFkLThi
-        ZDgtYTM2NzFiNTIwNjQxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2
-        MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVm
-        IjoiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
-        bHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8xMzE2YjFhZS0yZGU0LTQzZDgtODJkNS05YmI1YjU1OGRiODQv
-        IiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMz
-        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
-        YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTFlMmU0ZTgtODcyYy00
-        MmY2LWEwMDItNjlmZWU4NTYxZjIzLyIsIm5hbWUiOiJkdWNrIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4
-        MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hyZWYiOiJk
-        dWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZHVjay0w
-        LjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMDE1OTE1MTkt
-        YjY4NS00NDg4LWJiYTMtYjMwMzhmZTgzOGQ2LyIsIm5hbWUiOiJjaGVldGFo
-        IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0MjJkMGJhYTBjZDlkNzcxM2Fl
-        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwibG9j
-        YXRpb25faHJlZiI6ImNoZWV0YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6ImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2ZhNTczZmNmLWM5MWYtNGRjMS04YzBlLWZmYjM1
-        NDU4ZGIzOS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjIuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiYWJmNjkxZWU1YjQ4ZTQ0NjMyNjg1OWI4ZDhhOGRmMmEyNDExYjdl
-        ZGEyYzA4ZDA1ODllNmYzZDhkMWZmMzk5ZiIsInN1bW1hcnkiOiJGYWtlIHBy
-        b3ZpZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRp
-        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRp
-        bGxvLTIuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjUz
-        ZTY4MzgtNDgwNC00OWU0LWIwNTYtNzVjZDA1MTNhODQ4LyIsIm5hbWUiOiJh
-        cm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4ZDMxOTkwNWVlZGI1
-        YTUyNDdlM2EzNTI1ODg5YTI4ZDVkNjRlODIyMDA3NDEzZDAyNTg3YjZmNTFh
-        YjNiNjVhIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxv
-        LiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMC4yLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMzU5MjEzNy1mOTYwLTRiYzAtODA4
-        MS1lMjRlN2Q0MzcyNDMvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6ImFmNDc4MTMyZjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3
-        YzQ4ZjJkMjliN2M2ZTliYmE4OThhNjFkZGMyN2I1ODkiLCJzdW1tYXJ5Ijoi
-        RmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6
-        ImFybWFkaWxsby0wLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
-        ImFybWFkaWxsby0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZmODUwYjkyNmU1Yy8iLCJu
-        YW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWVhOTFkNzNk
-        OGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5MzlkNTdm
-        Yzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgdHJv
-        dXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4xMi0xLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0xLnNyYy5ycG0iLCJpc19t
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
         b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvOTNmMjgyYzMtMmQ5Mi00ZDRiLWFhNWUtMjcy
-        Yjk3MzNkNzhkLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjgzM2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQx
-        YTg5YjBjNWE5YmY2MTBkZDYxMDNjZTRjYzgiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdh
-        cm9vLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fy
-        b28tMC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kNjYx
-        ZWU5Zi1lZWQ4LTQzNTAtOTFjMy1mY2ZiYjliNGI3MGMvIiwibmFtZSI6ImR1
-        Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC43IiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1YmQzNjNiODYwYWQ2NzgzMjE3
-        Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEy
-        Iiwic3VtbWFyeSI6IlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIs
-        ImxvY2F0aW9uX2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
-        ZmFsc2V9XX0=
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:50 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -6713,7 +8370,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -6726,36 +8383,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:50 GMT
+      - Fri, 29 Jul 2022 08:59:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f714b1b9a10492cafd8ae70bd22f9ab
+      - b9a70d6b1c0944e1ae68978542060298
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2328'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNTQ5MTIwZjItNjZhZS00ZjczLWIzYjEtMjdhNjNlMjZjZTI5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNzAzMzU1
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -6766,17 +8423,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mYjA0
-        M2VlNi04NDI4LTQyNDItYjEyOC01YTVhZTA0NjQwNmYvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDFjODA3ZDgtMzE5
-        Yi00OGY5LWE1MTAtYTRlMTVkMjBmYjM3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMjMxNmU1NGItMTUz
-        OC00MTBmLTk2NTMtMjUxMGI1ODU4ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDQuNjk2NjEzWiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -6787,17 +8444,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy80Y2U0ODgyZC04YzI0LTQzZTAtOTBjZC04
-        YjZjMDEwNTNiNDMvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMDU2YWQ4NDQtODc1Ni00OTk2LWE2ODAtZThhMjQ3NGMy
-        ZTIzLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvMzJhNDQyNWEtNGM5Ni00NzZiLWI3YmQtZWVjYTlmZGIx
-        ZGE4LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNjg2
-        MDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -6807,17 +8464,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        MGE3NjVhNy0wYTc4LTQ0NDctODBlNS0zZjJhMzAwMDUwMzQvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTk2NjA3NjAt
-        ZjMxNC00N2QyLTg5MGEtMjYwNDA1ZWIzODdkLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMjUxZTI0MmEt
-        ODEzMi00YTdkLTljYmUtNTcxOTM4NWM1NWQwLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjM6NDQuNjg0ODQxWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -6828,17 +8485,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mMmI3N2NlMC0xMTFmLTQxNzQtYTU2
-        ZC01MjQyYTg4MDA3MGYvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOTNmMjgyYzMtMmQ5Mi00ZDRiLWFhNWUtMjcyYjk3
-        MzNkNzhkLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvM2E1MjYxYzMtZTA2Yi00NjQyLTg3NmEtZWZmOWVi
-        MjMzM2MwLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQu
-        NjcyMTcxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -6849,16 +8506,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy9iYzFmYjEwZi0wY2ZlLTRjM2MtOTFjYy1hZTczNDYxZDVlYmEvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q2NjFlZTlmLWVlZDgt
-        NDM1MC05MWMzLWZjZmJiOWI0YjcwYy8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U0ZGIxZWJkLWM0MmUt
-        NGQ0Ni1iYzY4LTM3NzM3MWYyZTcyYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjIzOjQ0LjY2OTkyMVoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -6869,18 +8526,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvNTk2ZTE0NzUtYjZmZi00M2E5LThkZDQtZTlk
-        ZGE3ZjZkZGFlLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy9lMWUyZTRlOC04NzJjLTQyZjYtYTAwMi02OWZlZTg1NjFmMjMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:50 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -6888,7 +8545,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -6901,37 +8558,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:50 GMT
+      - Fri, 29 Jul 2022 08:59:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5088040da5649a79316caf8bf3b7d3d
+      - 9d763fe0a13d42c79cfa1ddc5da12313
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzI2OTA1MGRmLWQ5ZDEtNGUxOS04ZDcyLWVjZDI5N2I3OWEw
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3OTMx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -7004,9 +8661,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvNGVmZTVlOGYtYTBhYy00MjZjLThkZjUt
-        ODQzZThlMjY3NGM2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjM6NDQuNjczNDEwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -7022,8 +8679,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzI1Njc1ZDQzLTAzYzUtNGNjMi04MTYxLTc1NTBjZGNkNGI5OS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY2NTAxMloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -7041,9 +8698,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8xMDA0ODg2ZS0xYWNhLTQ0ZDMtOTRlNC1iZTJhNTQ4
-        YzM2ZmQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42
-        NTQ5MTRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -7065,9 +8722,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzJlNzkyMzNiLWVhMDAtNDgxMC05ZDliLTNhNWE5
-        NTdlODEwMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0
-        LjY1Mzc2OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -7083,9 +8740,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvNTBjZmM1MDgtMWUwZC00Y2RhLTlmNGQt
-        NDEyMjJhMTgxOTc3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjM6NDQuNjQ3MDIwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -7094,9 +8751,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy81MDlmY2E4YS00Mzk3LTRjYWYtODU0OC0yODZh
-        YzcxMmU0Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0
-        NC42NDQzMTRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -7125,10 +8782,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:50 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7136,7 +8793,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -7149,37 +8806,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:50 GMT
+      - Fri, 29 Jul 2022 08:59:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 67fdf82980a840a9a63bf2a8021cf512
+      - 4d5da16f811e4a03b097ebc0b38cfe09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzhmNDNmNTNjLWE5NTQtNGU0MS1iMDNhLWIwNWY1MTU4
-        YzAxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3
-        Nzg5NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -7216,9 +8873,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9iNjI3NmJlMC0zYmRjLTQyNWUtYTA4YS05
-        ZDA3ZjljN2ViYWYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Mzo0NC42NTEzODNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -7228,10 +8885,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:50 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7239,7 +8896,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -7252,35 +8909,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:50 GMT
+      - Fri, 29 Jul 2022 08:59:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a16a3b70026e4db588d1dabb19a51b84
+      - 78f600fec4644f49a255db37add5c910
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '282'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy81NzEyODVlNi1hZTM0LTRhYmEtYmMzNC03OTUzYjc1Y2EyODkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -7288,10 +8945,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:50 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7299,7 +8956,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -7312,36 +8969,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:50 GMT
+      - Fri, 29 Jul 2022 08:59:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - edda8891d33247a6ac73a0129d3ef10b
+      - 822b6be00db74d4ab832479604865240
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNGI0M2E4ODMtOGMzNi00MDVlLWJkNTktZmVm
-        ZTNiYWE2NjIyLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -7363,10 +9020,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:50 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7374,7 +9031,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -7387,35 +9044,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:50 GMT
+      - Fri, 29 Jul 2022 08:59:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '7296'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73a48781f40c4e6ba094186eebcd53a2
+      - e37885bfd772406fae4ed688c47a54cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1945'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNDFjODA3ZDgtMzE5Yi00OGY5LWE1MTAtYTRlMTVkMjBmYjM3
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -7423,16 +9080,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNTZhZDg0NC04NzU2LTQ5OTYt
-        YTY4MC1lOGEyNDc0YzJlMjMvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNi
-        OGYwNjg4LTI2ODMtNGJlOS05NjRlLTlkYmU3YjFlZjNmZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -7440,147 +9097,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2E0Y2EyNDhiLTA5OGYtNDE2Yi04MzVlLTJk
-        ZWVhYjU5OTVkZS8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvODRhZGIyYmMtZjZmNi00NzM3LTllNDgtNjJjNzYyZGU0OTAwLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFiMDJmY2NmLTc1MjUtNDc0
-        Zi1iYzQ2LWE5YWNjYmUwNDZkNy8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2JiMjAwNDk1LTg0ZjItNGUxOS1iYzE0LWIyMWJhZWVhMTY2OC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hOTY2MDc2MC1mMzE0LTQ3ZDItODkwYS0yNjA0
-        MDVlYjM4N2QvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        YzkxNjRlOS05ZTYxLTQ0NDctYmJkOC1iZDgxMGZlNTU1NzMvIiwibmFtZSI6
-        ImdpcmFmZmUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlk
-        YTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIy
-        MDA5ZjlmMTQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFm
-        ZmUiLCJsb2NhdGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzBjYjE1YWEtZTg1Yi00MzFkLThi
-        ZDgtYTM2NzFiNTIwNjQxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2
-        MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVm
-        IjoiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
-        bHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8xMzE2YjFhZS0yZGU0LTQzZDgtODJkNS05YmI1YjU1OGRiODQv
-        IiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMz
-        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
-        YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTFlMmU0ZTgtODcyYy00
-        MmY2LWEwMDItNjlmZWU4NTYxZjIzLyIsIm5hbWUiOiJkdWNrIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4
-        MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hyZWYiOiJk
-        dWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZHVjay0w
-        LjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMDE1OTE1MTkt
-        YjY4NS00NDg4LWJiYTMtYjMwMzhmZTgzOGQ2LyIsIm5hbWUiOiJjaGVldGFo
-        IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0MjJkMGJhYTBjZDlkNzcxM2Fl
-        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwibG9j
-        YXRpb25faHJlZiI6ImNoZWV0YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6ImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2ZhNTczZmNmLWM5MWYtNGRjMS04YzBlLWZmYjM1
-        NDU4ZGIzOS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjIuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiYWJmNjkxZWU1YjQ4ZTQ0NjMyNjg1OWI4ZDhhOGRmMmEyNDExYjdl
-        ZGEyYzA4ZDA1ODllNmYzZDhkMWZmMzk5ZiIsInN1bW1hcnkiOiJGYWtlIHBy
-        b3ZpZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRp
-        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRp
-        bGxvLTIuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjUz
-        ZTY4MzgtNDgwNC00OWU0LWIwNTYtNzVjZDA1MTNhODQ4LyIsIm5hbWUiOiJh
-        cm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4ZDMxOTkwNWVlZGI1
-        YTUyNDdlM2EzNTI1ODg5YTI4ZDVkNjRlODIyMDA3NDEzZDAyNTg3YjZmNTFh
-        YjNiNjVhIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxv
-        LiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMC4yLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMzU5MjEzNy1mOTYwLTRiYzAtODA4
-        MS1lMjRlN2Q0MzcyNDMvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6ImFmNDc4MTMyZjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3
-        YzQ4ZjJkMjliN2M2ZTliYmE4OThhNjFkZGMyN2I1ODkiLCJzdW1tYXJ5Ijoi
-        RmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6
-        ImFybWFkaWxsby0wLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
-        ImFybWFkaWxsby0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZmODUwYjkyNmU1Yy8iLCJu
-        YW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWVhOTFkNzNk
-        OGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5MzlkNTdm
-        Yzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgdHJv
-        dXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4xMi0xLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0xLnNyYy5ycG0iLCJpc19t
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
         b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvOTNmMjgyYzMtMmQ5Mi00ZDRiLWFhNWUtMjcy
-        Yjk3MzNkNzhkLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjgzM2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQx
-        YTg5YjBjNWE5YmY2MTBkZDYxMDNjZTRjYzgiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdh
-        cm9vLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fy
-        b28tMC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kNjYx
-        ZWU5Zi1lZWQ4LTQzNTAtOTFjMy1mY2ZiYjliNGI3MGMvIiwibmFtZSI6ImR1
-        Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC43IiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1YmQzNjNiODYwYWQ2NzgzMjE3
-        Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEy
-        Iiwic3VtbWFyeSI6IlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIs
-        ImxvY2F0aW9uX2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
-        ZmFsc2V9XX0=
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:50 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7588,7 +9245,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -7601,36 +9258,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e6656a4500d04c2b81df24e4f6eb3f9c
+      - 3ff4b140e6cc45139981f2f2364fd34f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2328'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNTQ5MTIwZjItNjZhZS00ZjczLWIzYjEtMjdhNjNlMjZjZTI5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNzAzMzU1
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -7641,17 +9298,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mYjA0
-        M2VlNi04NDI4LTQyNDItYjEyOC01YTVhZTA0NjQwNmYvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDFjODA3ZDgtMzE5
-        Yi00OGY5LWE1MTAtYTRlMTVkMjBmYjM3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMjMxNmU1NGItMTUz
-        OC00MTBmLTk2NTMtMjUxMGI1ODU4ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDQuNjk2NjEzWiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -7662,17 +9319,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy80Y2U0ODgyZC04YzI0LTQzZTAtOTBjZC04
-        YjZjMDEwNTNiNDMvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMDU2YWQ4NDQtODc1Ni00OTk2LWE2ODAtZThhMjQ3NGMy
-        ZTIzLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvMzJhNDQyNWEtNGM5Ni00NzZiLWI3YmQtZWVjYTlmZGIx
-        ZGE4LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNjg2
-        MDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -7682,17 +9339,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        MGE3NjVhNy0wYTc4LTQ0NDctODBlNS0zZjJhMzAwMDUwMzQvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTk2NjA3NjAt
-        ZjMxNC00N2QyLTg5MGEtMjYwNDA1ZWIzODdkLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMjUxZTI0MmEt
-        ODEzMi00YTdkLTljYmUtNTcxOTM4NWM1NWQwLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjM6NDQuNjg0ODQxWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -7703,17 +9360,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mMmI3N2NlMC0xMTFmLTQxNzQtYTU2
-        ZC01MjQyYTg4MDA3MGYvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOTNmMjgyYzMtMmQ5Mi00ZDRiLWFhNWUtMjcyYjk3
-        MzNkNzhkLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvM2E1MjYxYzMtZTA2Yi00NjQyLTg3NmEtZWZmOWVi
-        MjMzM2MwLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQu
-        NjcyMTcxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -7724,16 +9381,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy9iYzFmYjEwZi0wY2ZlLTRjM2MtOTFjYy1hZTczNDYxZDVlYmEvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q2NjFlZTlmLWVlZDgt
-        NDM1MC05MWMzLWZjZmJiOWI0YjcwYy8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U0ZGIxZWJkLWM0MmUt
-        NGQ0Ni1iYzY4LTM3NzM3MWYyZTcyYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjIzOjQ0LjY2OTkyMVoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -7744,18 +9401,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvNTk2ZTE0NzUtYjZmZi00M2E5LThkZDQtZTlk
-        ZGE3ZjZkZGFlLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy9lMWUyZTRlOC04NzJjLTQyZjYtYTAwMi02OWZlZTg1NjFmMjMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7763,7 +9420,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -7776,37 +9433,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8826'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2627ba2c93374d5bbbb65a0c4f04c62c
+      - 56a3bc2755e54e16ab1e31bd19a2f38a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2071'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzhhN2FmMjY5LWEwZTMtNDc0MC04YzcyLTcxYmY2OWQxNGIx
-        Ni8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ2LjY1ODE3
-        NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjk5MTQzIiwidXBkYXRlZF9k
+        ZHZpc29yaWVzLzZkOWMzNzE2LTc3NzEtNDlkYS1iZTYxLWZiMWU4YjBmZDY1
+        NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjUwOjAyLjI1MTEx
+        MFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjk5MTQzIiwidXBkYXRlZF9k
         YXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkFybWFkaWxsbyEiLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9tc3RyIjoibHphcCtw
         dWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIsInRpdGxlIjoiQXJt
@@ -7821,9 +9478,9 @@ http_interactions:
         IjoiMSIsInNyYyI6Imh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCJz
         dW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEifV19XSwicmVm
         ZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzI2
-        OTA1MGRmLWQ5ZDEtNGUxOS04ZDcyLWVjZDI5N2I3OWEwOS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3OTMxMFoiLCJpZCI6IktB
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFk
+        MDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2OVoiLCJpZCI6IktB
         VEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEwLTEx
         LTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlwMiBpcyBhIGZyZWVs
         eSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0
@@ -7897,8 +9554,8 @@ http_interactions:
         L2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6bnVsbCwidGl0bGUi
         Om51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1Z2dlc3RlZCI6ZmFs
         c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fk
-        dmlzb3JpZXMvMjU2NzVkNDMtMDNjNS00Y2MyLTgxNjEtNzU1MGNkY2Q0Yjk5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNjY1MDEy
+        dmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzMwOTA4
         WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVkX2RhdGUiOiIyMDE2
         LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJTb3VyY2UgUlBNIEVy
         cmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDYiLCJm
@@ -7916,9 +9573,9 @@ http_interactions:
         LTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzEwMDQ4ODZlLTFhY2EtNDRkMy05NGU0LWJlMmE1
-        NDhjMzZmZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0
-        LjY1NDkxNFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMtNDVhYy1hZTYzLWY3OTMw
+        MDVmZGY5Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MzEwMFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRHVwbGljYXRlIE9uZSBw
         YWNrYWdlIGVycmF0YSIsImlzc3VlZF9kYXRlIjoiMjAxMi0wMS0wMSAwMTow
         MTowMSIsImZyb21zdHIiOiJsemFwK3B1YkByZWRoYXQuY29tIiwic3RhdHVz
@@ -7940,9 +9597,9 @@ http_interactions:
         ZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVy
         c2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dl
         c3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL2Fkdmlzb3JpZXMvMmU3OTIzM2ItZWEwMC00ODEwLTlkOWItM2E1
-        YTk1N2U4MTAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDQuNjUzNzY5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiIsInVw
+        bnQvcnBtL2Fkdmlzb3JpZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0
+        ZTNjZDBhZjRlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjkxMTg5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiIsInVw
         ZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJPbmUgcGFja2FnZSBl
         cnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJm
         cm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJs
@@ -7958,9 +9615,9 @@ http_interactions:
         d3d3LmZlZG9yYXByb2plY3Qub3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIi
         LCJ2ZXJzaW9uIjoiMC4zIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rf
         c3VnZ2VzdGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vYWR2aXNvcmllcy81MGNmYzUwOC0xZTBkLTRjZGEtOWY0
-        ZC00MTIyMmExODE5NzcvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyMzo0NC42NDcwMjBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMDAx
+        Y29udGVudC9ycG0vYWR2aXNvcmllcy9hZmEzNWE2MC05MTRjLTRkNzQtOTI2
+        Ni1iMGUwNzg5NjM4ZDQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yNzcyMDdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMDAx
         IiwidXBkYXRlZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkVtcHR5IGVy
         cmF0YSIsImlzc3VlZF9kYXRlIjoiMjAxMC0wMS0wMSAwMTowMTowMSIsImZy
         b21zdHIiOiJsemFwK3B1YkByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxl
@@ -7969,9 +9626,9 @@ http_interactions:
         aW9uIjoiIiwicmVsZWFzZSI6IjEiLCJyaWdodHMiOiIiLCJwdXNoY291bnQi
         OiIiLCJwa2dsaXN0IjpbXSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdn
         ZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9hZHZpc29yaWVzLzUwOWZjYThhLTQzOTctNGNhZi04NTQ4LTI4
-        NmFjNzEyZTRjYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ0LjY0NDMxNFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEyOjAwNTkiLCJ1
+        ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYyYWItNGMxZi1hNjRkLWI5
+        MWQwNmM0NWI2Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjI3MjE4NFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEyOjAwNTkiLCJ1
         cGRhdGVkX2RhdGUiOiIyMDE4LTA3LTIwIDA2OjAwOjAxIiwiZGVzY3JpcHRp
         b24iOiJEdWNrX0thbmdhcm9fRXJyYXR1bSBkZXNjcmlwdGlvbiIsImlzc3Vl
         ZF9kYXRlIjoiMjAxOC0wMS0yNyAxNjowODowOSIsImZyb21zdHIiOiJlcnJh
@@ -8000,10 +9657,10 @@ http_interactions:
         LjcifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8011,7 +9668,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -8024,37 +9681,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e29ee60503b4415a8156b43d63dbc500
+      - ef3dabf5f2b8487294e80e155b68a860
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzhmNDNmNTNjLWE5NTQtNGU0MS1iMDNhLWIwNWY1MTU4
-        YzAxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3
-        Nzg5NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -8091,9 +9748,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9iNjI3NmJlMC0zYmRjLTQyNWUtYTA4YS05
-        ZDA3ZjljN2ViYWYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Mzo0NC42NTEzODNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -8103,10 +9760,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8114,7 +9771,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -8127,35 +9784,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ffb608c2592648f0ba1e5ad2c8461e88
+      - 48f594ff76884802b24dbb307eebbafe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '282'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy81NzEyODVlNi1hZTM0LTRhYmEtYmMzNC03OTUzYjc1Y2EyODkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -8163,10 +9820,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8174,7 +9831,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -8187,36 +9844,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 062f00bb086146db8e77e25ed58b3dc6
+      - 958226f4d489427ab386a2917d868b6e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNGI0M2E4ODMtOGMzNi00MDVlLWJkNTktZmVm
-        ZTNiYWE2NjIyLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -8238,10 +9895,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8249,7 +9906,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -8262,35 +9919,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '7296'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b9328b2280a4606bda7f0282dfa581d
+      - c5bc782ae2bd49789328b947037fec03
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1945'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNDFjODA3ZDgtMzE5Yi00OGY5LWE1MTAtYTRlMTVkMjBmYjM3
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -8298,16 +9955,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNTZhZDg0NC04NzU2LTQ5OTYt
-        YTY4MC1lOGEyNDc0YzJlMjMvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNi
-        OGYwNjg4LTI2ODMtNGJlOS05NjRlLTlkYmU3YjFlZjNmZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -8315,147 +9972,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2E0Y2EyNDhiLTA5OGYtNDE2Yi04MzVlLTJk
-        ZWVhYjU5OTVkZS8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvODRhZGIyYmMtZjZmNi00NzM3LTllNDgtNjJjNzYyZGU0OTAwLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFiMDJmY2NmLTc1MjUtNDc0
-        Zi1iYzQ2LWE5YWNjYmUwNDZkNy8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2JiMjAwNDk1LTg0ZjItNGUxOS1iYzE0LWIyMWJhZWVhMTY2OC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hOTY2MDc2MC1mMzE0LTQ3ZDItODkwYS0yNjA0
-        MDVlYjM4N2QvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        YzkxNjRlOS05ZTYxLTQ0NDctYmJkOC1iZDgxMGZlNTU1NzMvIiwibmFtZSI6
-        ImdpcmFmZmUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlk
-        YTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIy
-        MDA5ZjlmMTQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFm
-        ZmUiLCJsb2NhdGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzBjYjE1YWEtZTg1Yi00MzFkLThi
-        ZDgtYTM2NzFiNTIwNjQxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2
-        MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVm
-        IjoiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
-        bHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8xMzE2YjFhZS0yZGU0LTQzZDgtODJkNS05YmI1YjU1OGRiODQv
-        IiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMz
-        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
-        YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTFlMmU0ZTgtODcyYy00
-        MmY2LWEwMDItNjlmZWU4NTYxZjIzLyIsIm5hbWUiOiJkdWNrIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4
-        MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hyZWYiOiJk
-        dWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZHVjay0w
-        LjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMDE1OTE1MTkt
-        YjY4NS00NDg4LWJiYTMtYjMwMzhmZTgzOGQ2LyIsIm5hbWUiOiJjaGVldGFo
-        IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0MjJkMGJhYTBjZDlkNzcxM2Fl
-        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwibG9j
-        YXRpb25faHJlZiI6ImNoZWV0YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6ImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2ZhNTczZmNmLWM5MWYtNGRjMS04YzBlLWZmYjM1
-        NDU4ZGIzOS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjIuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiYWJmNjkxZWU1YjQ4ZTQ0NjMyNjg1OWI4ZDhhOGRmMmEyNDExYjdl
-        ZGEyYzA4ZDA1ODllNmYzZDhkMWZmMzk5ZiIsInN1bW1hcnkiOiJGYWtlIHBy
-        b3ZpZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRp
-        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRp
-        bGxvLTIuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjUz
-        ZTY4MzgtNDgwNC00OWU0LWIwNTYtNzVjZDA1MTNhODQ4LyIsIm5hbWUiOiJh
-        cm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4ZDMxOTkwNWVlZGI1
-        YTUyNDdlM2EzNTI1ODg5YTI4ZDVkNjRlODIyMDA3NDEzZDAyNTg3YjZmNTFh
-        YjNiNjVhIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxv
-        LiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMC4yLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMzU5MjEzNy1mOTYwLTRiYzAtODA4
-        MS1lMjRlN2Q0MzcyNDMvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6ImFmNDc4MTMyZjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3
-        YzQ4ZjJkMjliN2M2ZTliYmE4OThhNjFkZGMyN2I1ODkiLCJzdW1tYXJ5Ijoi
-        RmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6
-        ImFybWFkaWxsby0wLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
-        ImFybWFkaWxsby0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZmODUwYjkyNmU1Yy8iLCJu
-        YW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWVhOTFkNzNk
-        OGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5MzlkNTdm
-        Yzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgdHJv
-        dXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4xMi0xLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0xLnNyYy5ycG0iLCJpc19t
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
         b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvOTNmMjgyYzMtMmQ5Mi00ZDRiLWFhNWUtMjcy
-        Yjk3MzNkNzhkLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjgzM2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQx
-        YTg5YjBjNWE5YmY2MTBkZDYxMDNjZTRjYzgiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdh
-        cm9vLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fy
-        b28tMC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kNjYx
-        ZWU5Zi1lZWQ4LTQzNTAtOTFjMy1mY2ZiYjliNGI3MGMvIiwibmFtZSI6ImR1
-        Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC43IiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1YmQzNjNiODYwYWQ2NzgzMjE3
-        Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEy
-        Iiwic3VtbWFyeSI6IlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIs
-        ImxvY2F0aW9uX2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
-        ZmFsc2V9XX0=
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8463,7 +10120,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -8476,36 +10133,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d817bb8038a46ab9b4b09d1467e8656
+      - a26dad820e7045e39eecf7eb914736b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2328'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNTQ5MTIwZjItNjZhZS00ZjczLWIzYjEtMjdhNjNlMjZjZTI5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNzAzMzU1
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -8516,17 +10173,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mYjA0
-        M2VlNi04NDI4LTQyNDItYjEyOC01YTVhZTA0NjQwNmYvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDFjODA3ZDgtMzE5
-        Yi00OGY5LWE1MTAtYTRlMTVkMjBmYjM3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMjMxNmU1NGItMTUz
-        OC00MTBmLTk2NTMtMjUxMGI1ODU4ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NDQuNjk2NjEzWiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -8537,17 +10194,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy80Y2U0ODgyZC04YzI0LTQzZTAtOTBjZC04
-        YjZjMDEwNTNiNDMvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMDU2YWQ4NDQtODc1Ni00OTk2LWE2ODAtZThhMjQ3NGMy
-        ZTIzLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvMzJhNDQyNWEtNGM5Ni00NzZiLWI3YmQtZWVjYTlmZGIx
-        ZGE4LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNjg2
-        MDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -8557,17 +10214,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        MGE3NjVhNy0wYTc4LTQ0NDctODBlNS0zZjJhMzAwMDUwMzQvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTk2NjA3NjAt
-        ZjMxNC00N2QyLTg5MGEtMjYwNDA1ZWIzODdkLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMjUxZTI0MmEt
-        ODEzMi00YTdkLTljYmUtNTcxOTM4NWM1NWQwLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjM6NDQuNjg0ODQxWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -8578,17 +10235,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mMmI3N2NlMC0xMTFmLTQxNzQtYTU2
-        ZC01MjQyYTg4MDA3MGYvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOTNmMjgyYzMtMmQ5Mi00ZDRiLWFhNWUtMjcyYjk3
-        MzNkNzhkLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvM2E1MjYxYzMtZTA2Yi00NjQyLTg3NmEtZWZmOWVi
-        MjMzM2MwLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQu
-        NjcyMTcxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -8599,16 +10256,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy9iYzFmYjEwZi0wY2ZlLTRjM2MtOTFjYy1hZTczNDYxZDVlYmEvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q2NjFlZTlmLWVlZDgt
-        NDM1MC05MWMzLWZjZmJiOWI0YjcwYy8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U0ZGIxZWJkLWM0MmUt
-        NGQ0Ni1iYzY4LTM3NzM3MWYyZTcyYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjIzOjQ0LjY2OTkyMVoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -8619,18 +10276,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvNTk2ZTE0NzUtYjZmZi00M2E5LThkZDQtZTlk
-        ZGE3ZjZkZGFlLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy9lMWUyZTRlOC04NzJjLTQyZjYtYTAwMi02OWZlZTg1NjFmMjMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8638,7 +10295,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -8651,37 +10308,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8826'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9b16fc4f5b3240569718db283d6920af
+      - 9bf68d1f9e244509b64ab1a59e08abe3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2071'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzgyYzU5ODQ5LTJkYzMtNDk0Ny04ZjRiLTFhOTFkZTEwNjM2
-        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ4Ljc5MzUx
-        MVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjk5MTQzIiwidXBkYXRlZF9k
+        ZHZpc29yaWVzL2U3NTI1MWQyLTEwZTEtNDhlMy1hNDRiLTRlMTliMGZjNDRj
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjUwOjA2LjA0Mjkw
+        NFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjk5MTQzIiwidXBkYXRlZF9k
         YXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkFybWFkaWxsbyMiLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9tc3RyIjoibHphcCtw
         dWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIsInRpdGxlIjoiQXJt
@@ -8696,9 +10353,9 @@ http_interactions:
         IjoiMSIsInNyYyI6Imh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCJz
         dW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEifV19XSwicmVm
         ZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzI2
-        OTA1MGRmLWQ5ZDEtNGUxOS04ZDcyLWVjZDI5N2I3OWEwOS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3OTMxMFoiLCJpZCI6IktB
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFk
+        MDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2OVoiLCJpZCI6IktB
         VEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEwLTEx
         LTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlwMiBpcyBhIGZyZWVs
         eSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0
@@ -8772,8 +10429,8 @@ http_interactions:
         L2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6bnVsbCwidGl0bGUi
         Om51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1Z2dlc3RlZCI6ZmFs
         c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fk
-        dmlzb3JpZXMvMjU2NzVkNDMtMDNjNS00Y2MyLTgxNjEtNzU1MGNkY2Q0Yjk5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NDQuNjY1MDEy
+        dmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzMwOTA4
         WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVkX2RhdGUiOiIyMDE2
         LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJTb3VyY2UgUlBNIEVy
         cmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDYiLCJm
@@ -8791,9 +10448,9 @@ http_interactions:
         LTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzEwMDQ4ODZlLTFhY2EtNDRkMy05NGU0LWJlMmE1
-        NDhjMzZmZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0
-        LjY1NDkxNFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMtNDVhYy1hZTYzLWY3OTMw
+        MDVmZGY5Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MzEwMFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRHVwbGljYXRlIE9uZSBw
         YWNrYWdlIGVycmF0YSIsImlzc3VlZF9kYXRlIjoiMjAxMi0wMS0wMSAwMTow
         MTowMSIsImZyb21zdHIiOiJsemFwK3B1YkByZWRoYXQuY29tIiwic3RhdHVz
@@ -8815,9 +10472,9 @@ http_interactions:
         ZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVy
         c2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dl
         c3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL2Fkdmlzb3JpZXMvMmU3OTIzM2ItZWEwMC00ODEwLTlkOWItM2E1
-        YTk1N2U4MTAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDQuNjUzNzY5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiIsInVw
+        bnQvcnBtL2Fkdmlzb3JpZXMvOWExY2RiNjgtZTdkZC00OTBhLTg2ODktNTE0
+        ZTNjZDBhZjRlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjkxMTg5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiIsInVw
         ZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJPbmUgcGFja2FnZSBl
         cnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJm
         cm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJs
@@ -8833,9 +10490,9 @@ http_interactions:
         d3d3LmZlZG9yYXByb2plY3Qub3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIi
         LCJ2ZXJzaW9uIjoiMC4zIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rf
         c3VnZ2VzdGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vYWR2aXNvcmllcy81MGNmYzUwOC0xZTBkLTRjZGEtOWY0
-        ZC00MTIyMmExODE5NzcvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyMzo0NC42NDcwMjBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMDAx
+        Y29udGVudC9ycG0vYWR2aXNvcmllcy9hZmEzNWE2MC05MTRjLTRkNzQtOTI2
+        Ni1iMGUwNzg5NjM4ZDQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yNzcyMDdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMDAx
         IiwidXBkYXRlZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkVtcHR5IGVy
         cmF0YSIsImlzc3VlZF9kYXRlIjoiMjAxMC0wMS0wMSAwMTowMTowMSIsImZy
         b21zdHIiOiJsemFwK3B1YkByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxl
@@ -8844,9 +10501,9 @@ http_interactions:
         aW9uIjoiIiwicmVsZWFzZSI6IjEiLCJyaWdodHMiOiIiLCJwdXNoY291bnQi
         OiIiLCJwa2dsaXN0IjpbXSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdn
         ZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9hZHZpc29yaWVzLzUwOWZjYThhLTQzOTctNGNhZi04NTQ4LTI4
-        NmFjNzEyZTRjYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ0LjY0NDMxNFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEyOjAwNTkiLCJ1
+        ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYyYWItNGMxZi1hNjRkLWI5
+        MWQwNmM0NWI2Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjI3MjE4NFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEyOjAwNTkiLCJ1
         cGRhdGVkX2RhdGUiOiIyMDE4LTA3LTIwIDA2OjAwOjAxIiwiZGVzY3JpcHRp
         b24iOiJEdWNrX0thbmdhcm9fRXJyYXR1bSBkZXNjcmlwdGlvbiIsImlzc3Vl
         ZF9kYXRlIjoiMjAxOC0wMS0yNyAxNjowODowOSIsImZyb21zdHIiOiJlcnJh
@@ -8875,10 +10532,10 @@ http_interactions:
         LjcifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8886,7 +10543,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -8899,37 +10556,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d6a146e877114159a57e6d1e7e26559a
+      - 2ae66967a2084d999670257e57f71e1c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzhmNDNmNTNjLWE5NTQtNGU0MS1iMDNhLWIwNWY1MTU4
-        YzAxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3
-        Nzg5NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -8966,9 +10623,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9iNjI3NmJlMC0zYmRjLTQyNWUtYTA4YS05
-        ZDA3ZjljN2ViYWYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Mzo0NC42NTEzODNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -8978,10 +10635,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8989,7 +10646,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9002,35 +10659,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b7a3451f2054b249297dbb46595b6d8
+      - 8e313f9bfbff4f63827f818e9efa5d43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '282'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy81NzEyODVlNi1hZTM0LTRhYmEtYmMzNC03OTUzYjc1Y2EyODkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -9038,10 +10695,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9049,7 +10706,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9062,36 +10719,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:51 GMT
+      - Fri, 29 Jul 2022 08:59:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9f591f54e20471e84654702ad9c0f25
+      - 4cd34f901609403283012ac513e7af46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNGI0M2E4ODMtOGMzNi00MDVlLWJkNTktZmVm
-        ZTNiYWE2NjIyLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -9113,10 +10770,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:51 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/8f43f53c-a954-4e41-b03a-b05f5158c017/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9124,7 +10781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9137,35 +10794,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e5af065eedbe4ede832eac49769b5bda
+      - 36596cfd7acb49c8b58f0f1275b28ef8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy84ZjQzZjUzYy1hOTU0LTRlNDEtYjAzYS1iMDVmNTE1OGMwMTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42Nzc4OTRa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -9204,10 +10861,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/8f43f53c-a954-4e41-b03a-b05f5158c017/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9215,7 +10872,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9228,35 +10885,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b07aa15616a40e397c24eeac8c74af9
+      - 73ce121b73674cf5b5049e5bee7da0a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy84ZjQzZjUzYy1hOTU0LTRlNDEtYjAzYS1iMDVmNTE1OGMwMTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42Nzc4OTRa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -9295,10 +10952,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/b6276be0-3bdc-425e-a08a-9d07f9c7ebaf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9306,7 +10963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9319,35 +10976,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 710c5e536a54471d900f4e9a1c6b4b4f
+      - e5e57af3017648b78d3f79611ed0b322
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9iNjI3NmJlMC0zYmRjLTQyNWUtYTA4YS05ZDA3ZjljN2ViYWYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42NTEzODNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -9358,10 +11015,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/b6276be0-3bdc-425e-a08a-9d07f9c7ebaf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9369,7 +11026,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9382,35 +11039,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 14501770b1874d58ba0841f6abcb84f0
+      - a073be9509d24c22aee822d8a1794e5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9iNjI3NmJlMC0zYmRjLTQyNWUtYTA4YS05ZDA3ZjljN2ViYWYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42NTEzODNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -9421,10 +11078,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9432,7 +11089,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9445,37 +11102,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 963b189f3ef8498b9d468eaf5d144362
+      - 07f062bf1b4241de9def426bedc117a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYWNmY2U5LTJjM2EtNDQ5NS04MGNhLWFm
-        MTlkYzA5MjI5ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ0LjY5MTY4N1oiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -9486,7 +11143,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvNDY2MTE4YmEtMmY5NC00ZGIxLWEwNTctZTAxM2VmNGYwMDAwLyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -9494,10 +11151,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9505,7 +11162,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9518,36 +11175,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 410111e028c440f2a6b31512d6657049
+      - 61510511c9ff4f9ea3dc1b091ccc017a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNGI0M2E4ODMtOGMzNi00MDVlLWJkNTktZmVm
-        ZTNiYWE2NjIyLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -9569,10 +11226,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9580,7 +11237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9593,47 +11250,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66f233b25211447a80d66ad93fb0212c
+      - c6732ee70b084cd58ab0ded7b6d43b32
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzA1YjBhMDMxLTVhNGMtNDgyYS05ZDgzLWVh
-        ZTc4MTI3NzIxZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjQ0LjY2Mzc3NloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/versions/2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9641,7 +11298,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9654,37 +11311,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43e2ae9cef964bd2961890722822a917
+      - eafaf9b40c4945629a480d8eb6f6fc0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy9mZTNhYzZkNS1lMGQyLTRmYTQtOGEwMy1lNWZi
-        NjA1YTE0OGUvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0
-        NC42NjI1MjhaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -9695,12 +11352,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzLzFmNDc2YTNjLWViNDgtNGRlZi05NDE5LWU4MzVkNzIyYjA0Yy8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvY2Y0NWNmMDktZDhiZC00YzdmLWE0MmEtNGQz
-        YzgxYzA2NjZkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NDQuNjUyNjA0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -9711,12 +11368,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9kMjk4YmY1Ni0yNDcxLTQ1ZWUtOTNhOC0zZDU0YzJjYTVkZTYvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy84M2NkNDA0Ni1lYWM3LTQwZWEtOTc4
-        NC00OGEwNTdiY2FkNzQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyMzo0NC42NTAxMzVaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -9727,14 +11384,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzlhYzcyMTk4LTc1NWMtNDQxZi05ZTc3LTM4YmUwYmQ0NWMy
-        Ni8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -9744,7 +11401,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9757,7 +11414,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -9775,33 +11432,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6381fa3180254811a50e0dc4b027fa80
+      - 2be8871e1d3744b58ef3963347ca3e6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE0MDAyMjJmLTkyZmEtNDli
-        MC1iZGJmLTU0NjYzMzUyMDY2ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAzYTU1YWNkLTQ3ZjUtNGRj
+        OC1hZDZlLWMyZWIwNWViYWExMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yNTY3NWQ0My0wM2M1LTRjYzItODE2MS03NTUwY2Rj
-        ZDRiOTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        MjY5MDUwZGYtZDlkMS00ZTE5LThkNzItZWNkMjk3Yjc5YTA5LyJdfQ==
+        cG0vYWR2aXNvcmllcy8xZDA5ZjBjZS0zZjM5LTQ4ZGUtYWJkNS1hZTE4Yzdk
+        OThiMzgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmItYzE1ZTNjYmQ3NjRjLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9814,7 +11471,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -9832,33 +11489,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08999ed87603465dbbb1da539273c21d'
+      - d7d6f076250340caba1adad323dd03c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzZmViMmYzLThhODMtNDJi
-        ZC1iMzBjLWQ2NTgxZjg3NDY3ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkNTViMmRjLTIwMjMtNDNj
+        ZC04ZWRiLTY0ZTNhOGVlNjIzZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80ZWZlNWU4Zi1hMGFjLTQyNmMtOGRmNS04NDNlOGUy
-        Njc0YzYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NTBjZmM1MDgtMWUwZC00Y2RhLTlmNGQtNDEyMjJhMTgxOTc3LyJdfQ==
+        cG0vYWR2aXNvcmllcy8zOWI0ZTRmNy1kNzdjLTQwNjYtOTJkMC05NTBmZjBl
+        MmJlNjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        YWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9871,7 +11528,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -9889,34 +11546,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0bda7e6903804bbb92aaf6ee1771f501
+      - 545e53984835432ca7c2d82283bd9169
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjODJmMGM2LWI3NDEtNDg4
-        OC1iMDZkLTZjMDUzYTI2MWFkOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjOWFkOWIyLTViYjUtNDRj
+        Ny1hNmQ0LWNjZDkwNjgyN2NjYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRiNDNhODgzLThjMzYtNDA1ZS1iZDU5
-        LWZlZmUzYmFhNjYyMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNTcxMjg1ZTYtYWUzNC00YWJhLWJjMzQtNzk1M2I3NWNhMjg5LyJd
+        cG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdhYi1hNTY3
+        LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyJd
         fQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9929,7 +11586,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -9947,34 +11604,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff1487689a214a2fb1bc05aea8e163cc
+      - 466ce26578a84495befdf60c5af3bbc5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiYmJkMDkzLTlmYzItNDRl
-        Ny1iYTIxLTg4ODlmMGI3NjNlMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiZmYyZGFhLTc5NGEtNDFj
+        My05MmFiLTFhZDA5ZGJjYjljYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvZmE1NzNmY2YtYzkxZi00ZGMxLThjMGUtZmZiMzU0NThk
-        YjM5LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRh
-        X2ZpbGVzLzRhYWNmY2U5LTJjM2EtNDQ5NS04MGNhLWFmMTlkYzA5MjI5ZC8i
+        cG0vcGFja2FnZXMvYjkxMmM5MDUtNjFmNS00NzJiLThlOTEtMzZlYzhmYzM1
+        MDQ4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRh
+        X2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUxMzAzYmZkZmE1Zi8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -9987,7 +11644,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -10005,34 +11662,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb10b3237aef4428b2646c5698e578e9
+      - 2224a76a8dd946d183231961381409f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmMTNiYWU0LTE0YzktNGUx
-        MC04ZTllLWJmMjlkNGRmODU3NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwYjU5YzNkLTlkOTQtNDBm
+        Ny05Y2ExLTI5OTY3NmNmNmJjZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy8wNWIwYTAzMS01YTRjLTQ4MmEtOWQ4
-        My1lYWU3ODEyNzcyMWUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kX2RlZmF1bHRzLzgzY2Q0MDQ2LWVhYzctNDBlYS05Nzg0LTQ4YTA1
-        N2JjYWQ3NC8iXX0=
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
+        ZHVsZW1kX2RlZmF1bHRzLzQyYmFkZjhmLTEwMGUtNGE4ZC1hMDJkLWYyMDNj
+        YTMwY2Y5NC8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -10045,7 +11702,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -10063,34 +11720,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7dbbb806b0c14f1a93b15081dd6bdbb6
+      - b36e9e186ae243459feffb3db59b631c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjYTgzNWNjLTY3MmQtNDM5
-        Zi04YzQ1LWQ3M2ExOTY5MmFmZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NhYWUzNzc0LTA0NjctNGI2
+        ZC04YmM2LTUxMGNkMzM4ZTc0Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvY2Y0NWNmMDktZDhiZC00YzdmLWE0MmEt
-        NGQzYzgxYzA2NjZkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy9mZTNhYzZkNS1lMGQyLTRmYTQtOGEwMy1lNWZiNjA1
-        YTE0OGUvIl19
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYt
+        MDY5ZjQ5YjgyMzIzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2MC02NDE5Yjg2
+        M2U1NzEvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -10103,7 +11760,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:52 GMT
+      - Fri, 29 Jul 2022 08:59:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -10121,21 +11778,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 218644005973478c874379830c09c2db
+      - 7ed5fc806db643f6b90ef2fdb52c8ff5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY3ODRmY2Y3LWI1NDMtNDYz
-        NS05NzYwLTc0ODAxY2MzZmI4YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4NDk5ZWE3LWZkMjktNDJm
+        Yi04OTZlLWI5YTRkZTRiNjIzYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:52 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b3feb2f3-8a83-42bd-b30c-d6581f87467d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2d55b2dc-2023-43cd-8edb-64e3a8ee623e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10156,53 +11813,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:53 GMT
+      - Fri, 29 Jul 2022 08:59:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95cbcd62de15454ca8a0b8c2f9d66f99
+      - d36dcecade9d4eb3b72dc7a17c2d3803
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjNmZWIyZjMtOGE4
-        My00MmJkLWIzMGMtZDY1ODFmODc0NjdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuNjg0NzI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ1NWIyZGMtMjAy
+        My00M2NkLThlZGItNjRlM2E4ZWU2MjNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzUuNjM3MTg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwODk5OWVkODc2MDM0NjVkYmJi
-        MWRhNTM5MjczYzIxZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUyLjgzNjU1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTIuOTY4NzYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkN2Q2ZjA3NjI1MDM0MGNhYmEx
+        YWRhZDMyM2RkMDNjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjM1Ljg4MDIzNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MzYuMTE5NjM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
+        bS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b3feb2f3-8a83-42bd-b30c-d6581f87467d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3c9ad9b2-5bb5-44c7-a6d4-ccd906827ccc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10223,120 +11880,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:53 GMT
+      - Fri, 29 Jul 2022 08:59:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d877db150fa242a6aeee7cda1e0aa8bb
+      - 4dd9f15063604db4bef4cb0165b2285c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjNmZWIyZjMtOGE4
-        My00MmJkLWIzMGMtZDY1ODFmODc0NjdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuNjg0NzI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2M5YWQ5YjItNWJi
+        NS00NGM3LWE2ZDQtY2NkOTA2ODI3Y2NjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzUuNzAxNTM0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwODk5OWVkODc2MDM0NjVkYmJi
-        MWRhNTM5MjczYzIxZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUyLjgzNjU1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTIuOTY4NzYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NDVlNTM5ODQ4MzU0MzJjYTdj
+        MmQ4MjI4M2JkOTE2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjM2LjE5NzI1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MzYuNDc4MzM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
-        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0c82f0c6-b741-4888-b06d-6c053a261ad9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:53 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 651a44bba4054416ae82250b2f66da24
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGM4MmYwYzYtYjc0
-        MS00ODg4LWIwNmQtNmMwNTNhMjYxYWQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuNzM1NjY0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYmRhN2U2OTAzODA0YmJiOTJh
-        YWY2ZWUxNzcxZjUwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUzLjAwMDAxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTMuMTI5MTIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
+        bS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fbbbd093-9fc2-44e7-ba21-8889f0b763e1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2d55b2dc-2023-43cd-8edb-64e3a8ee623e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10357,187 +11947,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:53 GMT
+      - Fri, 29 Jul 2022 08:59:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ffb918c089b74602b8e9a882944172d3
+      - f9cd2bdd255b49be9a977ddfd41fb161
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmJiYmQwOTMtOWZj
-        Mi00NGU3LWJhMjEtODg4OWYwYjc2M2UxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuNzgyMjc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ1NWIyZGMtMjAy
+        My00M2NkLThlZGItNjRlM2E4ZWU2MjNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzUuNjM3MTg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmZjE0ODc2ODlhMjE0YTJmYjFi
-        YzA1YWVhOGUxNjNjYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUzLjE1OTMyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTMuMjkzMjE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkN2Q2ZjA3NjI1MDM0MGNhYmEx
+        YWRhZDMyM2RkMDNjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjM1Ljg4MDIzNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MzYuMTE5NjM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
-        bnMvMy8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/bf13bae4-14c9-4e10-8e9e-bf29d4df8574/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:53 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 350d71de090b4e5b85d9ed8d7de53e3b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmYxM2JhZTQtMTRj
-        OS00ZTEwLThlOWUtYmYyOWQ0ZGY4NTc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuODQwMDgxWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjYjEwYjMyMzdhZWY0NDI4YjI2
-        NDZjNTY5OGU1NzhlOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUzLjMyNTY3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTMuNDY3ODc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
-        bnMvNC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b3feb2f3-8a83-42bd-b30c-d6581f87467d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:53 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 676375c95e0c4b578c9415717d3c2c43
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjNmZWIyZjMtOGE4
-        My00MmJkLWIzMGMtZDY1ODFmODc0NjdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuNjg0NzI3WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwODk5OWVkODc2MDM0NjVkYmJi
-        MWRhNTM5MjczYzIxZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUyLjgzNjU1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTIuOTY4NzYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
+        bS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0c82f0c6-b741-4888-b06d-6c053a261ad9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3c9ad9b2-5bb5-44c7-a6d4-ccd906827ccc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10558,53 +12014,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:53 GMT
+      - Fri, 29 Jul 2022 08:59:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43e7ec491d2b4a43a011a748adad79ab
+      - 2c2f1fb21b684fc3bff18682ef8fdefb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGM4MmYwYzYtYjc0
-        MS00ODg4LWIwNmQtNmMwNTNhMjYxYWQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuNzM1NjY0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2M5YWQ5YjItNWJi
+        NS00NGM3LWE2ZDQtY2NkOTA2ODI3Y2NjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzUuNzAxNTM0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYmRhN2U2OTAzODA0YmJiOTJh
-        YWY2ZWUxNzcxZjUwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUzLjAwMDAxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTMuMTI5MTIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NDVlNTM5ODQ4MzU0MzJjYTdj
+        MmQ4MjI4M2JkOTE2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjM2LjE5NzI1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MzYuNDc4MzM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
+        bS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fbbbd093-9fc2-44e7-ba21-8889f0b763e1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4bff2daa-794a-41c3-92ab-1ad09dbcb9cb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10625,53 +12081,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:53 GMT
+      - Fri, 29 Jul 2022 08:59:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 01afcf0b4fb441c9a540e5db110e9675
+      - 3ec770b9411a4a0884acf8052bb00d02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmJiYmQwOTMtOWZj
-        Mi00NGU3LWJhMjEtODg4OWYwYjc2M2UxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuNzgyMjc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGJmZjJkYWEtNzk0
+        YS00MWMzLTkyYWItMWFkMDlkYmNiOWNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzUuNzY5MTM5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmZjE0ODc2ODlhMjE0YTJmYjFi
-        YzA1YWVhOGUxNjNjYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUzLjE1OTMyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTMuMjkzMjE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0NjZjZTI2NTc4YTg0NDk1YmVm
+        ZGY2MGM1YWYzYmJjNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjM2LjUyNDgxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MzYuNzU4MDcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
+        bS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lv
         bnMvMy8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/bf13bae4-14c9-4e10-8e9e-bf29d4df8574/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/60b59c3d-9d94-40f7-9ca1-299676cf6bcd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10692,53 +12148,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:53 GMT
+      - Fri, 29 Jul 2022 08:59:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad1f254576b246aa848ea4bbdb641fcf
+      - 39440f5873dd4480b3cd79d4e079d37f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmYxM2JhZTQtMTRj
-        OS00ZTEwLThlOWUtYmYyOWQ0ZGY4NTc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuODQwMDgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjBiNTljM2QtOWQ5
+        NC00MGY3LTljYTEtMjk5Njc2Y2Y2YmNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzUuODMzODk2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjYjEwYjMyMzdhZWY0NDI4YjI2
-        NDZjNTY5OGU1NzhlOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUzLjMyNTY3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTMuNDY3ODc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMjI0YTc2YThkZDk0NmQxODMy
+        MzE5NjEzODE0MDlmMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjM2Ljc5NDg0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MzcuMDI3NDU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
+        bS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lv
         bnMvNC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:53 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/bca835cc-672d-439f-8c45-d73a19692aff/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/caae3774-0467-4b6d-8bc6-510cd338e746/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10759,53 +12215,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:54 GMT
+      - Fri, 29 Jul 2022 08:59:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4414949c0b2f466c8211a3a0574f0d53
+      - db5dbe49e8fa4b4d80c16e5d9e086778
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmNhODM1Y2MtNjcy
-        ZC00MzlmLThjNDUtZDczYTE5NjkyYWZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuODkzOTY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2FhZTM3NzQtMDQ2
+        Ny00YjZkLThiYzYtNTEwY2QzMzhlNzQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzUuOTAzNzU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZGJiYjgwNmIwYzE0ZjFhOTNi
-        MTUwODFkZDZiZGJiNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUzLjQ5OTA0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTMuNjMzMzc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiMzZlOWUxODZhZTI0MzQ1OWZl
+        ZmZiM2RiNTliNjMxYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjM3LjA3NTk1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MzcuMzYyNTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
+        bS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lv
         bnMvNS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:54 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6784fcf7-b543-4635-9760-74801cc3fb8a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/98499ea7-fd29-42fb-896e-b9a4de4b623a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10826,53 +12282,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:54 GMT
+      - Fri, 29 Jul 2022 08:59:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - df2210cec3994843b2d3f0fa21734f2b
+      - a62ea041f3804246b7ef19ff7d90e9f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjc4NGZjZjctYjU0
-        My00NjM1LTk3NjAtNzQ4MDFjYzNmYjhhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTIuOTQ2NzExWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTg0OTllYTctZmQy
+        OS00MmZiLTg5NmUtYjlhNGRlNGI2MjNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzUuOTY3ODA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMTg2NDQwMDU5NzM0NzhjODc0
-        Mzc5ODMwYzA5YzJkYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjUzLjY2NDE2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        NTMuODI5NjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZWQ1ZmM4MDZkYjY0M2Y2Yjkw
+        ZWYyZmRiNTJjOGZmNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjM3LjQwMzgyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MzcuNjIwNzI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84N2FlMWMwNS1mMTQ2LTQxNGYtYmZmNi1kMTQ0OWE0OGYwZDIvdmVyc2lv
+        bS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMvdmVyc2lv
         bnMvNi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhZTFjMDUtZjE0Ni00MTRm
-        LWJmZjYtZDE0NDlhNDhmMGQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:54 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/versions/6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/versions/6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10880,7 +12336,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -10893,41 +12349,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:54 GMT
+      - Fri, 29 Jul 2022 08:59:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e28d0ef4a6b24abe884d5d83c28bb14c
+      - e34daf49922146cab1ad23b43e79da12
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9mYTU3M2ZjZi1jOTFmLTRkYzEtOGMwZS1mZmIzNTQ1OGRiMzkv
+        YWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:54 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/versions/6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/versions/6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10935,7 +12391,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -10948,7 +12404,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:54 GMT
+      - Fri, 29 Jul 2022 08:59:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -10966,21 +12422,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a2ea2a1f8f44fb1aa7ba018e9bd51ad
+      - 715577f0f7684bb4a1a334b5c25afd5e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:54 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/versions/6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/versions/6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10988,7 +12444,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11001,37 +12457,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:54 GMT
+      - Fri, 29 Jul 2022 08:59:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5586'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc281e457e6d4e2784e21f27c348e151
+      - 2cb2871cfb99479383cf4aca17bde1be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1692'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzI2OTA1MGRmLWQ5ZDEtNGUxOS04ZDcyLWVjZDI5N2I3OWEw
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY3OTMx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -11104,9 +12560,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvNGVmZTVlOGYtYTBhYy00MjZjLThkZjUt
-        ODQzZThlMjY3NGM2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjM6NDQuNjczNDEwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -11122,8 +12578,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzI1Njc1ZDQzLTAzYzUtNGNjMi04MTYxLTc1NTBjZGNkNGI5OS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjQ0LjY2NTAxMloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -11141,9 +12597,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy81MGNmYzUwOC0xZTBkLTRjZGEtOWY0ZC00MTIyMmEx
-        ODE5NzcvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo0NC42
-        NDcwMjBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMDAxIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy9hZmEzNWE2MC05MTRjLTRkNzQtOTI2Ni1iMGUwNzg5
+        NjM4ZDQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        NzcyMDdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMDAxIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkVtcHR5IGVycmF0YSIsImlz
         c3VlZF9kYXRlIjoiMjAxMC0wMS0wMSAwMTowMTowMSIsImZyb21zdHIiOiJs
         emFwK3B1YkByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0bGUi
@@ -11153,10 +12609,10 @@ http_interactions:
         aXN0IjpbXSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:54 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/versions/6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/versions/6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11164,7 +12620,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11177,7 +12633,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:54 GMT
+      - Fri, 29 Jul 2022 08:59:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -11195,21 +12651,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f9a00c21d1e40d1bcac0dc16559d617
+      - fd35adf102b446f8a6b5c5b943b6de3c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:54 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/versions/6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/versions/6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11217,7 +12673,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11230,41 +12686,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:54 GMT
+      - Fri, 29 Jul 2022 08:59:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7eece8ec69214839838be643613c2cd8
+      - 4da373f7b67842de82c69e644c2c2812
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy81NzEyODVlNi1hZTM0LTRhYmEtYmMzNC03OTUzYjc1Y2EyODkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:54 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/87ae1c05-f146-414f-bff6-d1449a48f0d2/versions/6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/versions/6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11272,7 +12728,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11285,36 +12741,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:54 GMT
+      - Fri, 29 Jul 2022 08:59:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1af69d3d82144009887cfb4301c86d0
+      - f604eaceae5e461b9a8257ebfc05e070
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNGI0M2E4ODMtOGMzNi00MDVlLWJkNTktZmVm
-        ZTNiYWE2NjIyLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -11336,10 +12792,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:54 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:38 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5d62f331-a0bf-4332-b85a-6139942894d7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/72a01c4a-3818-4858-94f5-687f0d760219/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11347,7 +12803,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11360,7 +12816,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:55 GMT
+      - Fri, 29 Jul 2022 08:59:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -11378,21 +12834,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a44dadf981a4d89b05145758b7e8822
+      - 93bb41b0ab994798bf7277afd0db74ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlkNGYzZjRhLWZkMzQtNGVh
-        Yi1iZTViLWQ1OGRmM2Q4NDY1MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzYTFlODRlLWQwNmYtNGZk
+        OC04MDBhLWRmZmNlNDI2OWYzNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:55 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9d4f3f4a-fd34-4eab-be5b-d58df3d84650/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/63a1e84e-d06f-4fd8-800a-dffce4269f37/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11413,51 +12869,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:55 GMT
+      - Fri, 29 Jul 2022 08:59:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2e94bcde2534927a0e7a08c79778811
+      - 1c0db442141847d390f055af5334e0fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWQ0ZjNmNGEtZmQz
-        NC00ZWFiLWJlNWItZDU4ZGYzZDg0NjUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTUuMDQyMzc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjNhMWU4NGUtZDA2
+        Zi00ZmQ4LTgwMGEtZGZmY2U0MjY5ZjM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzguOTU0MjgwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3YTQ0ZGFkZjk4MWE0ZDg5YjA1MTQ1NzU4
-        YjdlODgyMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjU1LjA3
-        NTk1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NTUuMTIx
-        NzIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5M2JiNDFiMGFiOTk0Nzk4YmY3Mjc3YWZk
+        MGRiNzRhZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjM5LjAw
+        NDEwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MzkuMDgx
+        NDE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVkNjJmMzMxLWEwYmYtNDMzMi1iODVh
-        LTYxMzk5NDI4OTRkNy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcyYTAxYzRhLTM4MTgtNDg1OC05NGY1
+        LTY4N2YwZDc2MDIxOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:55 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:39 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/8f890192-fad7-4e0a-9de5-b4c864f00e12/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/777c5f0b-305c-422c-b238-1e782486d558/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11465,7 +12921,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11478,7 +12934,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:55 GMT
+      - Fri, 29 Jul 2022 08:59:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -11496,21 +12952,74 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 523ed584ab6247cd89331e166b199686
+      - aa53395580024c53b6282f64db00aea9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1NzQwOGQ4LWUzNGItNDA5
-        My04ZmRkLTk0ZTc1N2U5Yjg1OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5MzMyMDk4LThiMGEtNGYy
+        Ny1hZTNlLTcwMGRhOWQzOWQ1ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:55 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:39 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a67850cc-1957-4095-a0d5-5caaa9ed5b78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bf75d356536548c9b3b3c56714385d7f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiOTc4NDk4LWRjMjktNGIz
+        MC04MGU0LTJkOTY4ODMxMDRkYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/257408d8-e34b-4093-8fdd-94e757e9b859/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8b978498-dc29-4b30-80e4-2d96883104dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11531,51 +13040,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:55 GMT
+      - Fri, 29 Jul 2022 08:59:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22bec317154141789040009b84aab158
+      - c2de0566330d46daa592a644d8f55738
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjU3NDA4ZDgtZTM0
-        Yi00MDkzLThmZGQtOTRlNzU3ZTliODU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTUuMjY3NjEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGI5Nzg0OTgtZGMy
+        OS00YjMwLTgwZTQtMmQ5Njg4MzEwNGRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzkuMzcxNDQxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MjNlZDU4NGFiNjI0N2NkODkzMzFlMTY2
-        YjE5OTY4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjU1LjI5
-        OTMzOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NTUuNDM4
-        MTc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZjc1ZDM1NjUzNjU0OGM5YjNiM2M1Njcx
+        NDM4NWQ3ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjM5LjQw
+        Njc5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MzkuNjkx
+        MTEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGY4OTAxOTItZmFkNy00ZTBh
-        LTlkZTUtYjRjODY0ZjAwZTEyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTY3ODUwY2MtMTk1Ny00MDk1
+        LWEwZDUtNWNhYWE5ZWQ1Yjc4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:55 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:39 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/6aee4114-c9f1-411c-83c2-dfb24f316d04/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/34a4271e-c980-4763-b065-57c2f8a11ca6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11583,7 +13092,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11596,7 +13105,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:55 GMT
+      - Fri, 29 Jul 2022 08:59:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -11614,21 +13123,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6fe0cf3e7a6946b69bc3f88784f71f23
+      - 14a434dbebc3482fbb6ce7962192979f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5ZDhkNzNiLTBmZWItNDE2
-        NC04YjZmLWE5MGNjYWMwNDc0Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxZmZiZjQwLTI4ZjktNDY2
+        Yy04OWNjLTczMmIxMTMwZDI0ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:55 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/39d8d73b-0feb-4164-8b6f-a90ccac04746/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/61ffbf40-28f9-466c-89cc-732b1130d24d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11649,51 +13158,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:55 GMT
+      - Fri, 29 Jul 2022 08:59:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 19489b61e07e4c0da513237289193991
+      - adff2757f051402094bf71adc0a9bcaa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzlkOGQ3M2ItMGZl
-        Yi00MTY0LThiNmYtYTkwY2NhYzA0NzQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTUuNzExMzA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjFmZmJmNDAtMjhm
+        OS00NjZjLTg5Y2MtNzMyYjExMzBkMjRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MzkuOTUxMjUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZmUwY2YzZTdhNjk0NmI2OWJjM2Y4ODc4
-        NGY3MWYyMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjU1Ljc1
-        ODQzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NTUuODA0
-        MTI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxNGE0MzRkYmViYzM0ODJmYmI2Y2U3OTYy
+        MTkyOTc5ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjM5Ljk4
+        OTk4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NDAuMDUw
+        MjYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzZhZWU0MTE0LWM5ZjEtNDExYy04M2My
-        LWRmYjI0ZjMxNmQwNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM0YTQyNzFlLWM5ODAtNDc2My1iMDY1
+        LTU3YzJmOGExMWNhNi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:55 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:40 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/5b3d3932-9a8e-4696-9e8b-b3ae40289e35/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/969a674c-2006-4874-a20f-52aecd97d420/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11701,7 +13210,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11714,7 +13223,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:55 GMT
+      - Fri, 29 Jul 2022 08:59:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -11732,21 +13241,74 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5461eaff6d6b4454aa32acd472072e84
+      - 9edbb9713aa04a7cb50b10c56c75f9f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiOWU4MGZkLTk4ODAtNGUw
-        Yy1iZjY2LTU2MmM1MzAwOTFiNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhMGM1ZTY5LTMzMGItNGVi
+        OC1iY2VkLWZlOTBiMzkzOWY4YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:55 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:40 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/03a97993-701e-4a94-a32e-a01b23d87fff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2c33637c8a7248f3b5e5abdfc74a92cd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiMzM5MGU1LWE5MjUtNDkw
+        Ni1iYzUxLThkNGI3NmEwODllYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0b9e80fd-9880-4e0c-bf66-562c530091b7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4b3390e5-a925-4906-bc51-8d4b76a089eb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11767,51 +13329,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:56 GMT
+      - Fri, 29 Jul 2022 08:59:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 764a726669ec46c7b28b505557ea7a17
+      - bfed8269cb6b46339fc2fc413dea63ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGI5ZTgwZmQtOTg4
-        MC00ZTBjLWJmNjYtNTYyYzUzMDA5MWI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTUuOTIxOTg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGIzMzkwZTUtYTky
+        NS00OTA2LWJjNTEtOGQ0Yjc2YTA4OWViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NDAuMjk3NTcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NDYxZWFmZjZkNmI0NDU0YWEzMmFjZDQ3
-        MjA3MmU4NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjU1Ljk1
-        MzUxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NTYuMDgw
-        NDA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyYzMzNjM3YzhhNzI0OGYzYjVlNWFiZGZj
+        NzRhOTJjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjQwLjM0
+        OTMzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NDAuNTg5
+        MTUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWIzZDM5MzItOWE4ZS00Njk2
-        LTllOGItYjNhZTQwMjg5ZTM1LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDNhOTc5OTMtNzAxZS00YTk0
+        LWEzMmUtYTAxYjIzZDg3ZmZmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:40 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/e14bf51e-896b-4bcf-8ecf-c3a9184b9b32/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/e31d5a57-5d36-4824-8a20-6b82d4d82ccf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11819,7 +13381,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11832,7 +13394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:56 GMT
+      - Fri, 29 Jul 2022 08:59:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -11850,21 +13412,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b51e1804589c4184af3dd16c0103d869
+      - af71f20aeb1a45a59f006c81e7b5683f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjYzUzMzNmLTdmYzUtNDk5
-        NS1hMjYyLWVmNGQyOWMwNWYwMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1ODdmZWQ1LTNiNTktNDcz
+        OC1iNmZhLTBhYzM1NDNmMWQ1ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0cc5333f-7fc5-4995-a262-ef4d29c05f00/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b587fed5-3b59-4738-b6fa-0ac3543f1d5e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11885,51 +13447,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:56 GMT
+      - Fri, 29 Jul 2022 08:59:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - beb5038c99784a8ab8a73c54798d9025
+      - 154acb4f194c4b4095bff1bc9a6ddeb3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGNjNTMzM2YtN2Zj
-        NS00OTk1LWEyNjItZWY0ZDI5YzA1ZjAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTYuMjYzNzMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjU4N2ZlZDUtM2I1
+        OS00NzM4LWI2ZmEtMGFjMzU0M2YxZDVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NDAuODQzOTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiNTFlMTgwNDU4OWM0MTg0YWYzZGQxNmMw
-        MTAzZDg2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjU2LjI5
-        MzQwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NTYuMzM1
-        NjEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZjcxZjIwYWViMWE0NWE1OWYwMDZjODFl
+        N2I1NjgzZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjQwLjg4
+        NDk5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NDAuOTQ1
+        ODcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2UxNGJmNTFlLTg5NmItNGJjZi04ZWNm
-        LWMzYTkxODRiOWIzMi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2UzMWQ1YTU3LTVkMzYtNDgyNC04YTIw
+        LTZiODJkNGQ4MmNjZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:41 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1d779197-b913-43bc-a0c0-376221f835eb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/0a8e4e34-f378-4c68-b255-2012ac1211f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -11937,7 +13499,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -11950,7 +13512,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:56 GMT
+      - Fri, 29 Jul 2022 08:59:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -11968,21 +13530,74 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 76b16d7643994b0e8d5c6076b7bcdcd0
+      - b6e24f60ba584c5aa63b49968574a6cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5ODIwZGJlLWZjZGUtNDRk
-        MC04YWYyLTViYjQ0NmZiNzk5NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViNmNjM2E5LWU0YWMtNDhk
+        YS1hNjgzLWQ3NDhjZmI3MWVmZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:41 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d05ac106-1fee-4d43-9995-4aa21a9113d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5c34a38102f045b896b38ac259514eb4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1ZjJkOGUyLTRmZjItNGQ1
+        Yy05NDU1LTY3MWE2MzVjZjgxZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/79820dbe-fcde-44d0-8af2-5bb446fb7995/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/05f2d8e2-4ff2-4d5c-9455-671a635cf81f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -12003,46 +13618,46 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:56 GMT
+      - Fri, 29 Jul 2022 08:59:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 545e9bc0025a4042bd2c7f496729cac5
+      - 7262e955463744f78e05945f23de1b2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzk4MjBkYmUtZmNk
-        ZS00NGQwLThhZjItNWJiNDQ2ZmI3OTk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6NTYuNDUzMzEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDVmMmQ4ZTItNGZm
+        Mi00ZDVjLTk0NTUtNjcxYTYzNWNmODFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NDEuMjA3NjQ0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3NmIxNmQ3NjQzOTk0YjBlOGQ1YzYwNzZi
-        N2JjZGNkMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjU2LjQ4
-        NDAyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6NTYuNjE0
-        MDg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1YzM0YTM4MTAyZjA0NWI4OTZiMzhhYzI1
+        OTUxNGViNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjQxLjI2
+        NTIwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NDEuNDk1
+        MTA2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMWQ3NzkxOTctYjkxMy00M2Jj
-        LWEwYzAtMzc2MjIxZjgzNWViLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDA1YWMxMDYtMWZlZS00ZDQz
+        LTk5OTUtNGFhMjFhOTExM2QwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:41 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_all_no_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_all_no_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b4fdb0b884454febb7e1a3169d264deb
+      - 4c66de60523b40c4803ae98c06e52d6e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85NjgyZjMwOC02MDFmLTQzYTQtYWMwNS1hODAyNTZjYmI1YzEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo1MC4yMTM2Njla
+        cnBtL3JwbS8yMTkyNTdmZS1hMjQwLTQ3MGMtODI1NC1jMDExZTIyNzY5NDEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowMS4xNzAzNjha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85NjgyZjMwOC02MDFmLTQzYTQtYWMwNS1hODAyNTZjYmI1YzEv
+        cnBtL3JwbS8yMTkyNTdmZS1hMjQwLTQ3MGMtODI1NC1jMDExZTIyNzY5NDEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk2ODJm
-        MzA4LTYwMWYtNDNhNC1hYzA1LWE4MDI1NmNiYjVjMS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzIxOTI1
+        N2ZlLWEyNDAtNDcwYy04MjU0LWMwMTFlMjI3Njk0MS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:31 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/219257fe-a240-470c-8254-c011e2276941/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa3dd7a192f44e0f89bdab5af725cffc
+      - ffea71cb00364b119eceae726ad63c49
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyYzVjODM4LTZiNjUtNGY5
-        MS05NGNlLTU0ZDI0ZTAxMzkyNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExYTZmMTA4LWZiOGMtNGFm
+        NS04ZGY3LThiNDMwNTBkNDI4Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ead3bd54d94f4c56b430a6ec2ea8ca46
+      - 6b4eff1a3b304181bd758fc8fa55f62d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/92c5c838-6b65-4f91-94ce-54d24e013924/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/11a6f108-fb8c-4af5-8df7-8b43050d4286/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8069e1e089804bf689b14a1a208b76ad
+      - 75edda13ea3e4d469d9f7b91c3af7b20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTJjNWM4MzgtNmI2
-        NS00ZjkxLTk0Y2UtNTRkMjRlMDEzOTI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTYuMTAxOTI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTFhNmYxMDgtZmI4
+        Yy00YWY1LThkZjctOGI0MzA1MGQ0Mjg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6MzEuMDc5NzI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmYTNkZDdhMTkyZjQ0ZTBmODliZGFiNWFm
-        NzI1Y2ZmYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjU2LjEz
-        MzA3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NTYuMjU1
-        NjgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmZmVhNzFjYjAwMzY0YjExOWVjZWFlNzI2
+        YWQ2M2M0OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjMxLjE3
+        NjcxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6MzEuNTU4
+        MTk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTY4MmYzMDgtNjAxZi00M2E0
-        LWFjMDUtYTgwMjU2Y2JiNWMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjE5MjU3ZmUtYTI0MC00NzBj
+        LTgyNTQtYzAxMWUyMjc2OTQxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ca6792b4718481e91b52a0408e0a2ac
+      - 8bf276e97f1a4ac294badddebe5745db
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b6605c009fa46c6991ba92fff1d8cd7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZWMxMWVlODQtYjA4Ny00MjY5LWE4ZDUtN2MzYjhhOTAyYmE1
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTU6MDguODgzOTU3
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/ec11ee84-b087-4269-a8d5-7c3b8a902ba5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e57558302e4c4875b0217b16290604eb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlkMWU4MThjLTBmZTktNGM5
+        Ni1iNzllLTVhYmM0Yzc2NTUxYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9d1e818c-0fe9-4c96-b79e-5abc4c76551a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e13e0b2cfeea4b32a2d2afafd9202ba3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWQxZTgxOGMtMGZl
+        OS00Yzk2LWI3OWUtNWFiYzRjNzY1NTFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6MzIuMTM4MDQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNTc1NTgzMDJlNGM0ODc1YjAyMTdiMTYy
+        OTA2MDRlYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjMyLjE4
+        NTYyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6MzIuMjI0
+        NjA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa18cb1a00c743d7a2276eac8394ae3c
+      - b3674d6aaf0d44aca4a6fbf77099e791
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a92449a08c394c938553f5bd31897f71
+      - b17d8e966a9546aab3677e6ad28d8bee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5716434cb414d4b881902bea6e4270b
+      - 1426cbb549344a61b87292de30279c86
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7694d379f064acea3fa0e9f7806df6f
+      - a21b5e7e671b4ce18dc13977e33733e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:56 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 55d9476029c84663bdee5ddd7d536933
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0de7343b-51a6-4a52-a44f-833cfb53ebf2/"
+      - "/pulp/api/v3/remotes/rpm/rpm/b2f91bc8-1c30-4a43-80c8-857953317e33/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2d13cd926d443f98fb74fe5aec0a0a4
+      - cc79157adb0f405bb3665e12e8abb7b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBk
-        ZTczNDNiLTUxYTYtNGE1Mi1hNDRmLTgzM2NmYjUzZWJmMi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjU2LjcwMDcwNVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Iy
+        ZjkxYmM4LTFjMzAtNGE0My04MGM4LTg1Nzk1MzMxN2UzMy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU3OjMyLjc2Nzc3NFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjU2LjcwMDcyNVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU3OjMyLjc2NzgwNFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/"
+      - "/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8f33ac2f91664c8390c5bc7f11cf624a
+      - 7d72790ec7754845941295726d126f5c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTc2NjVhODgtYTM2OC00MjY0LWEyZGEtYzkwNWIwZWEzY2Q5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NTYuODQ4MDIyWiIsInZl
+        cG0vYjJmMjc3M2QtMTAzZS00ZTJkLWJiN2MtMGYyZjBlNTI3ZDIyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6MzMuMDM2Njc0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTc2NjVhODgtYTM2OC00MjY0LWEyZGEtYzkwNWIwZWEzY2Q5L3ZlcnNp
+        cG0vYjJmMjc3M2QtMTAzZS00ZTJkLWJiN2MtMGYyZjBlNTI3ZDIyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lNzY2NWE4OC1h
-        MzY4LTQyNjQtYTJkYS1jOTA1YjBlYTNjZDkvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMmYyNzczZC0x
+        MDNlLTRlMmQtYmI3Yy0wZjJmMGU1MjdkMjIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:56 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ace544adfd74d39b4ea145dfb4fb889
+      - 4a5a4100d28d42768041a316cdd94db7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xYjAyMWUwMi04ZTI4LTQ0ODUtYjY5Yy0xNDMyNzE4ZjZlZTAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo1MC45MjAyODNa
+        cnBtL3JwbS9hZmY0MGY1Zi1iY2RkLTQxYTItYjM0ZC02YjQ1ZjVjNThkYjYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowMi4xMjcwOTRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xYjAyMWUwMi04ZTI4LTQ0ODUtYjY5Yy0xNDMyNzE4ZjZlZTAv
+        cnBtL3JwbS9hZmY0MGY1Zi1iY2RkLTQxYTItYjM0ZC02YjQ1ZjVjNThkYjYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzFiMDIx
-        ZTAyLThlMjgtNDQ4NS1iNjljLTE0MzI3MThmNmVlMC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2FmZjQw
+        ZjVmLWJjZGQtNDFhMi1iMzRkLTZiNDVmNWM1OGRiNi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:56 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/aff40f5f-bcdd-41a2-b34d-6b45f5c58db6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c6ea2857440742c08a8a262303985982
+      - 89f2e602c9b642a88cfbfa817e0efd8d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5MTU1NDdmLTZlNzUtNDY2
-        YS1hNjllLTQ1MWVlYjc1ZWY2ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyZDIwZjIwLTE0MWQtNDY2
+        Yy05MmMxLTBmN2QyZTg4Njg1Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '608'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a4fc773703b4fc3b955f5843eae650d
+      - 8a98f1a447c94675ada83c98c9490afd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNzEyNTIyOGUtM2NiNS00OGRmLTgxNWItYWFiMTQyMThmOGJiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NTAuMTAxNjYxWiIsIm5h
-        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
-        ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
-        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
-        cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo1MS4yNDI1MDlaIiwiZG93bmxv
-        YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
-        Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
-        Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
-        InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
-        dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+        cG0vNzE0M2ZiMzQtN2UxOC00MDkwLWI1MjItZWY2MDA4NDI3MmJkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTU6MDEuMDMwMzkzWiIsIm5h
+        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5v
+        cmcvc3JwbS11bnNpZ25lZC8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2Vy
+        dCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjIt
+        MDctMjhUMTY6NTU6MDIuNTQ2MjkzWiIsImRvd25sb2FkX2NvbmN1cnJlbmN5
+        IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRl
+        IiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYw
+        LjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGlt
+        ZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJz
+        bGVzX2F1dGhfdG9rZW4iOm51bGx9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/7125228e-3cb5-48df-815b-aab14218f8bb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/7143fb34-7e18-4090-b522-ef60084272bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4e29d7ce54641cc9f6a996753ccc835
+      - 54791a71e09c45e48196a8d2ff5f2f81
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0NTE3ZDc5LWIyNmQtNGZi
-        Ny04ZmUwLTBiYTM0NjUyODNlNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I0YjZiYjhjLTFlMGEtNDRm
+        NC1hOWI4LWFjNDdiMTVjOWUwYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a915547f-6e75-466a-a69e-451eeb75ef6d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/22d20f20-141d-466c-92c1-0f7d2e88685c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '00258c8aa3244a07976e34f7f87f4844'
+      - 01f521f5a75848829c0192b5b10ee1d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTkxNTU0N2YtNmU3
-        NS00NjZhLWE2OWUtNDUxZWViNzVlZjZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTcuMDA3MzAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjJkMjBmMjAtMTQx
+        ZC00NjZjLTkyYzEtMGY3ZDJlODg2ODVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6MzMuNTcwOTAwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjNmVhMjg1NzQ0MDc0MmMwOGE4YTI2MjMw
-        Mzk4NTk4MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjU3LjAz
-        NzkyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NTcuMTA1
-        NzMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4OWYyZTYwMmM5YjY0MmE4OGNmYmZhODE3
+        ZTBlZmQ4ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjMzLjYx
+        NzYyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6MzMuNzA2
+        Njg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMWIwMjFlMDItOGUyOC00NDg1
-        LWI2OWMtMTQzMjcxOGY2ZWUwLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWZmNDBmNWYtYmNkZC00MWEy
+        LWIzNGQtNmI0NWY1YzU4ZGI2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a4517d79-b26d-4fb7-8fe0-0ba3465283e6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b4b6bb8c-1e0a-44f4-a9b8-ac47b15c9e0a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2ee11325c3f4864b63d314acfb95621
+      - 9b6cd0ab97c84eada9093c226b4dc657
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQ1MTdkNzktYjI2
-        ZC00ZmI3LThmZTAtMGJhMzQ2NTI4M2U2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTcuMTA2MDEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjRiNmJiOGMtMWUw
+        YS00NGY0LWE5YjgtYWM0N2IxNWM5ZTBhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6MzMuNzA2MTcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkNGUyOWQ3Y2U1NDY0MWNjOWY2YTk5Njc1
-        M2NjYzgzNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjU3LjEz
-        ODY4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NTcuMTgy
-        NjM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NDc5MWE3MWUwOWM0NWU0ODE5NmE4ZDJm
+        ZjVmMmY4MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjMzLjc1
+        MTQ4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6MzMuODIx
+        MTUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcxMjUyMjhlLTNjYjUtNDhkZi04MTVi
-        LWFhYjE0MjE4ZjhiYi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcxNDNmYjM0LTdlMTgtNDA5MC1iNTIy
+        LWVmNjAwODQyNzJiZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 521834df0cf544db8765f3913ac68f65
+      - 42748d374f8c40679656b5952ff5241d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a3760142e91d4182a9806b61b04bed35
+      - dec88dbb709143e1aea0773580c78187
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '067248110a544a7da80670be9ea388e7'
+      - 61da85ba222f4735bfdadb7ebd22116a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ed61a4f66b94465a22cb565c38c0af7
+      - d0bc7f5eb0784cd6b182d3ea9bff9cb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e42c82c441a94cbdb9ca721af13896b3
+      - f913c0262092441e84d4c7609a4e11ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 38b62c9139d24858831bd99356074d41
+      - 87a78b638b5343f887e65de5535868c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:34 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fdaf0b1475d64b3abb67ea473e7abe03
+      - 14c876b60e4b40df8f922171325932eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTU5YmRhZGEtNDE0NS00ZTllLThhZGQtYzE2Yzc2Mzg3MDA5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NTcuNTY5MDc1WiIsInZl
+        cG0vZTRmOTA3NTMtN2Q1Yi00ZDQ3LWIxNjgtOTFiN2MxOTgzNzgyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6MzQuMzAwODkwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTU5YmRhZGEtNDE0NS00ZTllLThhZGQtYzE2Yzc2Mzg3MDA5L3ZlcnNp
+        cG0vZTRmOTA3NTMtN2Q1Yi00ZDQ3LWIxNjgtOTFiN2MxOTgzNzgyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xNTliZGFkYS00
-        MTQ1LTRlOWUtOGFkZC1jMTZjNzYzODcwMDkvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lNGY5MDc1My03
+        ZDViLTRkNDctYjE2OC05MWI3YzE5ODM3ODIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:34 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/0de7343b-51a6-4a52-a44f-833cfb53ebf2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b2f91bc8-1c30-4a43-80c8-857953317e33/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:57 GMT
+      - Fri, 29 Jul 2022 08:57:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 805cb7562b9645d1a0c8dfa0fa2a82b9
+      - 0f5732ddd0614943bc6b2bdd7708af1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiMjllZGM3LTVjZjItNGRm
-        NS04MjhhLTllYzZiMzcyMTg5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyOTczNzFiLWI4Y2MtNGNk
+        YS1hMjAzLTE4YTk0MjU0NzcyOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:57 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2b29edc7-5cf2-4df5-828a-9ec6b3721899/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e297371b-b8cc-4cda-a203-18a942547728/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:58 GMT
+      - Fri, 29 Jul 2022 08:57:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11bca568d587499e927f92936e30c18d
+      - a8bcab57d5444b499056440bf436f2e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmIyOWVkYzctNWNm
-        Mi00ZGY1LTgyOGEtOWVjNmIzNzIxODk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTcuODg4NjczWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTI5NzM3MWItYjhj
+        Yy00Y2RhLWEyMDMtMThhOTQyNTQ3NzI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6MzQuNjU5ODk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI4MDVjYjc1NjJiOTY0NWQxYTBjOGRmYTBm
-        YTJhODJiOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjU3Ljky
-        ODA2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NTcuOTUw
-        MzkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwZjU3MzJkZGQwNjE0OTQzYmM2YjJiZGQ3
+        NzA4YWYxYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjM0Ljcw
+        MzM1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6MzQuNzM0
+        NzEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBkZTczNDNiLTUxYTYtNGE1Mi1hNDRm
-        LTgzM2NmYjUzZWJmMi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IyZjkxYmM4LTFjMzAtNGE0My04MGM4
+        LTg1Nzk1MzMxN2UzMy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:58 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:34 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBkZTcz
-        NDNiLTUxYTYtNGE1Mi1hNDRmLTgzM2NmYjUzZWJmMi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IyZjkx
+        YmM4LTFjMzAtNGE0My04MGM4LTg1Nzk1MzMxN2UzMy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:58 GMT
+      - Fri, 29 Jul 2022 08:57:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08b38560ec18481b8ac980d8c8682093'
+      - 21a01652ae5f4d378fc1ae26cbe7f6b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg3MTMyMDkyLTIzMzAtNGUw
-        MS04MDI3LWUwMzZlNTg2YzE4OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3NGE2YzY4LWI3NzItNDM2
+        MC04OGUzLWYwZmRlZGU4ZWIwNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:58 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/87132092-2330-4e01-8027-e036e586c188/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b74a6c68-b772-4360-88e3-f0fdede8eb05/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:00 GMT
+      - Fri, 29 Jul 2022 08:57:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 24e4757b3cd341dab35b72d18c143b4d
+      - 78ac515dae524a8281968be485ad562c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '599'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODcxMzIwOTItMjMz
-        MC00ZTAxLTgwMjctZTAzNmU1ODZjMTg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTguMDY0OTc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjc0YTZjNjgtYjc3
+        Mi00MzYwLTg4ZTMtZjBmZGVkZThlYjA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6MzQuOTEyMzc1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwOGIzODU2MGVjMTg0ODFiOGFj
-        OTgwZDhjODY4MjA5MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjU4LjEwNDkyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MDAuMDQxOTk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyMWEwMTY1MmFlNWY0ZDM3OGZj
+        MWFlMjZjYmU3ZjZiNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3
+        OjM0Ljk2MDQzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6
+        MzguNzg1MTAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZTc2NjVhODgtYTM2OC00MjY0LWEyZGEt
-        YzkwNWIwZWEzY2Q5L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2U3NjY1YTg4LWEzNjgtNDI2NC1hMmRhLWM5MDViMGVhM2NkOS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS8wZGU3MzQzYi01MWE2
-        LTRhNTItYTQ0Zi04MzNjZmI1M2ViZjIvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2IyZjI3NzNkLTEwM2UtNGUyZC1iYjdjLTBm
+        MmYwZTUyN2QyMi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9i
+        MmYyNzczZC0xMDNlLTRlMmQtYmI3Yy0wZjJmMGU1MjdkMjIvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYjJmOTFiYzgtMWMzMC00
+        YTQzLTgwYzgtODU3OTUzMzE3ZTMzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:38 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZTc2NjVhODgtYTM2OC00MjY0LWEyZGEtYzkwNWIwZWEz
-        Y2Q5L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYjJmMjc3M2QtMTAzZS00ZTJkLWJiN2MtMGYyZjBlNTI3
+        ZDIyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:00 GMT
+      - Fri, 29 Jul 2022 08:57:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e4f1028e1324469cb06823cb13bd9f00
+      - 95e2938e23864002bd3cc1a1d6dae7c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExZTA2MGZhLTZmZDctNDQ2
-        ZC04MjczLTBiMDA3ZjI1YWVkOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y1YmQzYjY2LWZmNTgtNDk5
+        NS1hY2U5LWMxNzU3MTJlMjM3Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a1e060fa-6fd7-446d-8273-0b007f25aed9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f5bd3b66-ff58-4995-ace9-c175712e2372/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:00 GMT
+      - Fri, 29 Jul 2022 08:57:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7169ae0016794bb29d3a4b2686c85a2c
+      - 16f11226fc404806a4b089bc868db1c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTFlMDYwZmEtNmZk
-        Ny00NDZkLTgyNzMtMGIwMDdmMjVhZWQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDAuMTkxODc4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjViZDNiNjYtZmY1
+        OC00OTk1LWFjZTktYzE3NTcxMmUyMzcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6MzkuMDMzOTUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImU0ZjEwMjhlMTMyNDQ2OWNiMDY4MjNjYjEz
-        YmQ5ZjAwIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MDAuMjI0
-        MjE2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzowMC40MTUw
-        NTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6Ijk1ZTI5MzhlMjM4NjQwMDJiZDNjYzFhMWQ2
+        ZGFlN2MyIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6MzkuMTA3
+        MDI5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1NzozOS40Mzc0
+        MTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjZlMTNj
-        MjctMTQxMy00NmM4LTg5OTYtYjE5NWZjOTkzZTFiLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYjRiNTA3
+        YTktZmQ0ZC00YzNjLThjMjUtMjY1ZTE4MjEzZDUxLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZTc2NjVhODgtYTM2OC00MjY0LWEyZGEtYzkwNWIw
-        ZWEzY2Q5LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYjJmMjc3M2QtMTAzZS00ZTJkLWJiN2MtMGYyZjBl
+        NTI3ZDIyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:00 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e6437c7fede1475fb42615a23179d1c0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:00 GMT
+      - Fri, 29 Jul 2022 08:57:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f8494307e6e94af9aac9dff586f149bd
+      - 43898eeea0dc4103b95b0a5eecd6a2b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/b4b507a9-fd4d-4c3c-8c25-265e18213d51/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:00 GMT
+      - Fri, 29 Jul 2022 08:57:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 102c0815125047788813d459e1050228
+      - 73ff71a263794abebb1eae8e7ed8eccd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYjRiNTA3YTktZmQ0ZC00YzNjLThjMjUtMjY1ZTE4MjEzZDUxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6MzkuMTQzNTIzWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9iMmYyNzczZC0xMDNlLTRlMmQtYmI3Yy0wZjJmMGU1MjdkMjIv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2IyZjI3NzNkLTEwM2UtNGUyZC1iYjdjLTBmMmYw
+        ZTUyN2QyMi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:39 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9iNGI1MDdhOS1mZDRkLTRjM2MtOGMyNS0yNjVlMTgyMTNkNTEv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 46502005123747d98a594b832a02028c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzNjkyOWEwLTAwMDQtNDZj
+        Ni04MTUyLTU0YjczZDNhNWI1MC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c36929a0-0004-46c6-8152-54b73d3a5b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - eaec6e6827c343b08b3372ea1db2f722
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzM2OTI5YTAtMDAw
+        NC00NmM2LTgxNTItNTRiNzNkM2E1YjUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6MzkuNzY0Mjk0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI0NjUwMjAwNTEyMzc0N2Q5OGE1OTRiODMy
+        YTAyMDI4YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjM5Ljgy
+        MzM0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NDAuMDQ4
+        NzgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDA2
+        MTFkMTYtMTg1My00ZGE3LWIyMmYtNjY5YWQ1MTBiYjllLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/00611d16-1853-4da7-b22f-669ad510bb9e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 781967bdad3f484d912f0e1a8289737a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzAwNjExZDE2LTE4NTMtNGRhNy1iMjJmLTY2OWFkNTEwYmI5ZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU3OjQwLjAyOTI5MloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYjRiNTA3YTktZmQ0ZC00YzNjLThjMjUt
+        MjY1ZTE4MjEzZDUxLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f464b0dc8a234c00b88164566bad04fc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 51d7b52299544fcb85c10047100adf45
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7aa6e63adf3a4a7c989b15d9bf49d581
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:00 GMT
+      - Fri, 29 Jul 2022 08:57:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e52e97c071bb4350b114815ce4bbb22f
+      - 2bace425e8c34dca9f34be576916ba45
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:00 GMT
+      - Fri, 29 Jul 2022 08:57:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8575e2545f774567a07186cbb65f8cb9
+      - 84a693d3b8e94afeb55bcd5e266bc24e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:00 GMT
+      - Fri, 29 Jul 2022 08:57:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 454b0e87f4aa4effa94138c42d1448d7
+      - ef639ad491e24ba8a845a361ffe49c1c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:00 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d553fa65fa74c01accf79a010e9f6c8
+      - 015e4cc0ec8a440c84367a8bf1380946
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad6c7aeb7dc64cb5a2f8e6d8c79767ea
+      - d24c2515eb614606b0d083c1c9c9a71a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4fdfb5b2a6594a129c85382682097b93
+      - aecdec61f49a47d9b451716f0fd4ea51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8bf2faa62fd45e28db84c38c678a7be
+      - 6383cd12bf464642971e6e2e31d9c7e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,89 +3208,89 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08f5be0febde45e5a31f3689108729b8'
+      - 6acb63cf7a2f4156bbf1638be1e1e9d6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyMWUwMTVkLTQyNjktNDlm
-        ZS05MTAwLWVlYjljMWQ0Yzc2NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyMDA1NGFhLWRjYTUtNDQ2
+        Yy1iOWY3LTllOWMxMWNkNmU4OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80ZDYyYjA2Mi01MTkxLTQyZWQtYTU4NC04MWExZDhl
-        NGRhZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NjAxNWRkYzktNWZlOS00ZTgwLTg1OTItMzdjZDg3ZGVhMTQ4LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzhmZDYyODhiLWU2ODMt
-        NDZlZi05Yjk0LWQwZTkwNGI5ZjY4Yi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy85MGE2YzZhMS0zODY1LTQyZGEtYWZhOS01MTU2
-        NTFlOTRjN2YvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3MjMtMGI3NS00
-        ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy8xYTU3NjVlZS03MDc4LTQzMzgtYTAzNi1mZDkyNzMw
-        NDUxOTQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFm
-        MjQ0NjIxLTBjYmItNGJlOC05NjIzLTNiZGRjM2IxMGViMS8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ1ZTY2MTgtMGIwZC00Yjlm
-        LTlkOGQtMTVjNDgxMTg4Yzk1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy8yZDYyY2Y4NC00YzU1LTQ4OTQtOTQ0Zi04NjI3Mzc5NzU2
-        ZDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0Yzhk
-        MGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFl
-        ZTYtOTY0MWZiM2Y1YzUxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02Mjk3NTQ5YjAzODgv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwMWJhMDM3
-        LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEt
-        N2E3YTI4NWIwZDNiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy83NzAyYmFkNi01ZDc2LTQ0YWQtOTlhZi1iMzIwMzUwNDZlYmUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdlZTEyZjljLTE3
-        NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0
-        OGVhZWY1ZmEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUt
-        NGU3Yi04YjBiLWJmMTk4ZGNiNjIxNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvYThjMzk2MzItZWNlOC00MzZiLWJkMDctYjg0MDdh
-        M2VmODcwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9h
-        YWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRkMjgwZjVlZDMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I2NmY3MGRhLTU5ZDgtNDNi
-        Ny04ZGEyLWMyYjExMGExZjFiZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00OGIxLWEwZDYtY2Y3YTk4YWZk
-        YzU1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOGU2
-        NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2YxNGJiYjUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2JhZjI0YzFhLTBlMDctNDE2ZS04
-        NGE3LWVlNDU3MjMyYjA1ZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvYzFkNjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEy
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMzY0ZTky
-        ZS0xNjQxLTRjZWItODBiMC05NDk5OWQyMTljNDQvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NkZTc1MDU0LTQyZDktNDBlZS04ZWU1
-        LTA5NTFkZjMxNzVmYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2Y2ItYzI1M2E2ZmU1NTA5LyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDZiNzk5Ni00
-        MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZm
-        ODUwYjkyNmU1Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZTU3NjA5MGYtZWYwZS00YWVmLWIzYjctMmEzODI2ZDAxZDZjLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5
-        ZDlkMTE2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZWMyN2QzNTktOTM4OC00ODdjLWIyY2EtZGVkM2UyN2ZlNmRhLyJdfQ==
+        cG0vYWR2aXNvcmllcy8yMjUwZjE3YS1iYzE4LTRjZTEtOGM2YS0wN2M0ZjA2
+        ODI1NGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NjZmMzRmMWEtMzcwNC00ODNjLThjNTctMjNiMzllZGE1NWRiLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzc3ZmUyNzVhLTBkZTct
+        NDk5NC1iMGUzLWUzNjE5NmViZjdmZi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFh
+        NDRjZGRlYjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFhOGY5NTIxNThiYi8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMtMTQ4MS00
+        ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDItYWY0My0zODAzMTM2
+        ZDEyMmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgtZjZkZC00NDY3
+        LWI4ZWItNWNjYzBkNmRhNjhhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy8xNWM5MTA0Zi0xMjMzLTQ2YzQtYmY3My03NTE4MThmYzZm
+        MTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzMyZGE5
+        NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzMxOWNmYTAtZGRmYy00M2MwLThh
+        NmUtZDFkOTlkNDFiNmQ4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy80NGU4OTAwZC03MjIxLTQ0MDgtOTAwNS0xM2E5M2IzOTJhMGQv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5M2E0ZWIy
+        LWQ3MzktNDA5Mi04OTZmLTgzNjMwZmYzYzRmYi8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMt
+        NjNkNmJjZWQ3YmIzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy82ZGM4YzA3Ni1kNTFkLTQxZGQtYjQ1NS04MzRjMmY4ZDU4OGMvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZlYjVkZTgxLWQ2
+        MDUtNDkzMS04ZTY0LTQ2ZTAxZjE1MzAwMy8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNmYxYzkwYjAtYTc4Ny00OGNjLTgwY2ItZmNh
+        Mzk4MDAwYzc2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy83MzNhNGEwMC04ODRlLTRhMDEtYjI0MC02ZTM4YzNlZTczYjkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2MjlmMzBhLTE0Zjct
+        NDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvOGFlZjg5YjAtZDNiMy00ZDQyLWJiZTEtZmEwZDg5
+        MDEzMzUxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
+        YjgzYTg5Ny01ODRjLTQ2YTItODI3Zi04YjA3ZGFlOTdiYWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzkyYjY2YWNiLTYwYjktNGVm
+        NC1iNTFhLTlhYjZhNzUwMGY4Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOTliNmFmZWYtZjIxYi00OWY5LWEzNmItODUxODAzM2Yw
+        MzYwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hMGIy
+        ZmZjYi1iMzgwLTRhYjktYmI4Yi00MjljNGY5YmZjN2IvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1i
+        ZDJiLTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvYTVjZGJkZGUtYmNhOC00NTI5LTliNDEtYzdiZTgxZjc5MjQ4
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFm
+        MC01NmY4LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NhZjM4MDc5LWUwNTYtNDRlNy05NjNl
+        LWUyYzIzM2M4ZmY4NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUxN2NkLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJlMC1i
+        ZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4OTFhLWYyMjItNDkyOS1hZjJkLWM5
+        MTAwYTQ4YTZjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTExNzRkYjEtNzYxOS00YzUwLTljYzctMmM4MmFlNzg3ODhjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNDk3ZTBlZS0zYmE5
+        LTRhM2UtYTdiYS1kYjI1MDU5MWIyMzIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzL2U0YTgyMmQ2LTRlZjQtNDZmZS1hMjdjLTIxM2Jm
+        OGVhOWRmNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        ZjJkZmYxM2UtZjg5Mi00Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2878,7 +3303,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2896,21 +3321,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 051f8585dc424b0c923d0f31f1f71980
+      - 65160030a4874737b0801130bb90d1c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlOTNhOGUzLTE4NDktNGRm
-        Ni1hYTk3LTA5MDI3ZGNiZWRmOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1MjgwNTY4LTJlMGUtNDk1
+        NS04ZGM4LTk1NmM5MGEwMWJiMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0e93a8e3-1849-4df6-aa97-09027dcbedf9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b5280568-2e0e-4955-8dc8-956c90a01bb3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2931,53 +3356,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 709b00279a414875a1c7fd2990d66dba
+      - d8d9389c07cf4384a6f81708971e3934
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGU5M2E4ZTMtMTg0
-        OS00ZGY2LWFhOTctMDkwMjdkY2JlZGY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDEuMzUyODc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjUyODA1NjgtMmUw
+        ZS00OTU1LThkYzgtOTU2YzkwYTAxYmIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NDEuNTcxMTE5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNTFmODU4NWRjNDI0YjBjOTIz
-        ZDBmMzFmMWY3MTk4MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjAxLjQ5MzUxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MDEuNjM2MTIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2NTE2MDAzMGE0ODc0NzM3YjA4
+        MDExMzBiYjkwZDFjMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3
+        OjQxLjgwNTA3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6
+        NDIuMDcwNjE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xNTliZGFkYS00MTQ1LTRlOWUtOGFkZC1jMTZjNzYzODcwMDkvdmVyc2lv
+        bS9lNGY5MDc1My03ZDViLTRkNDctYjE2OC05MWI3YzE5ODM3ODIvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTU5YmRhZGEtNDE0NS00ZTll
-        LThhZGQtYzE2Yzc2Mzg3MDA5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTRmOTA3NTMtN2Q1Yi00ZDQ3
+        LWIxNjgtOTFiN2MxOTgzNzgyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2985,7 +3410,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2998,101 +3423,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d6f621f8f676401f9851966907ed873f
+      - 48f4d1a4a6db4595a659127c938d481c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3100,7 +3525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3113,7 +3538,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:01 GMT
+      - Fri, 29 Jul 2022 08:57:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3131,21 +3556,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f15eb32ba724ed48d2a591d27eb9b2b
+      - 14a6e2358b8143c6b51ef6f0cdd77ef5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:01 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3153,7 +3578,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3166,37 +3591,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:02 GMT
+      - Fri, 29 Jul 2022 08:57:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb6f107412384cc4bc67ef59fbb07f7d
+      - dceb2e797c7942a9a9287d1743d9bff6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3212,8 +3637,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3241,8 +3666,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3270,8 +3695,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3289,10 +3714,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:02 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,7 +3738,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:02 GMT
+      - Fri, 29 Jul 2022 08:57:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3331,21 +3756,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5418704f5bd44d23af45902c0a4b0615
+      - 21cb85a1d8f14f4e9ede883fc52b1620
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:02 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3353,7 +3778,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3366,7 +3791,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:02 GMT
+      - Fri, 29 Jul 2022 08:57:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3384,21 +3809,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d7ccbd24e6145518de23d24ab445fd0
+      - 0c0a4b11ffc24c35a5fd2eb85c03e6c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:02 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3406,7 +3831,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3419,7 +3844,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:02 GMT
+      - Fri, 29 Jul 2022 08:57:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3437,16 +3862,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6379c6924a3349799abba8ac138cb90f
+      - 9c8f42fab4574dee87ab05ed345b85cb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:02 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:42 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_all_no_filter_rules_without_dependency_solving.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_all_no_filter_rules_without_dependency_solving.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5021dd19c864ef89d09bd456b4d3d77
+      - f7e9d2cebe684e3098bb77301d53fbd7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMmZiMmE5OS0xNzVmLTRjYWItOWZmYi01YjE5NGI1MWRjNDIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoxOC42MTU4NDVa
+        cnBtL3JwbS84NTUxOTE4YS1kMjhmLTQxOWQtYWQzZC1jZWIxMDFjMGRhOGUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODowNy43MTM4MTha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMmZiMmE5OS0xNzVmLTRjYWItOWZmYi01YjE5NGI1MWRjNDIv
+        cnBtL3JwbS84NTUxOTE4YS1kMjhmLTQxOWQtYWQzZC1jZWIxMDFjMGRhOGUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UyZmIy
-        YTk5LTE3NWYtNGNhYi05ZmZiLTViMTk0YjUxZGM0Mi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzg1NTE5
+        MThhLWQyOGYtNDE5ZC1hZDNkLWNlYjEwMWMwZGE4ZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b9f347466a54ba6b0c309c70994ce7d
+      - d2f02888a23e4d588afb2484dc6924b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyMWQyNWNjLTgxMmUtNDJk
-        Zi1iODM5LWFhNDI2ZjcxMjBkOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1NjlmZjEzLWMyZGItNGE3
+        My05YTAzLWUxODEyNGIwZjk5Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f71f5341dbc7423f836d6afc7558247a
+      - 16c6af1b41b649bfb2a723360fa4e4f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b21d25cc-812e-42df-b839-aa426f7120d9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b569ff13-c2db-4a73-9a03-e18124b0f992/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39532232016f4db08c644fd1b1ab9344
+      - 2c9f8772f5a74134bbd5abd2c979b403
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjIxZDI1Y2MtODEy
-        ZS00MmRmLWI4MzktYWE0MjZmNzEyMGQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjQuNDU3NjMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjU2OWZmMTMtYzJk
+        Yi00YTczLTlhMDMtZTE4MTI0YjBmOTkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MTguMjE3MzUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzYjlmMzQ3NDY2YTU0YmE2YjBjMzA5Yzcw
-        OTk0Y2U3ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjI0LjQ5
-        NTQwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MjQuNjE5
-        MTEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkMmYwMjg4OGEyM2U0ZDU4OGFmYjI0ODRk
+        YzY5MjRiMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjE4LjI2
+        ODIwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MTguNTEw
+        MTQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTJmYjJhOTktMTc1Zi00Y2Fi
-        LTlmZmItNWIxOTRiNTFkYzQyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODU1MTkxOGEtZDI4Zi00MTlk
+        LWFkM2QtY2ViMTAxYzBkYThlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bad671a40e364c0da85872ded00b08e6
+      - b2e04c0afcca44c292e87193219ac5ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9785c426e96344e5bc543a9842daf611
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNGM2ZmUxOGItZjVjYy00OTY5LWE4MDUtMWI1OTIwYTA3NDE0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MTQuMjc2MTc1
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4c6fe18b-f5cc-4969-a805-1b5920a07414/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7066d0aa78b145a28331aacc488b1186
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwZGYzMjFkLTdiNTgtNDY5
+        ZC05YjBkLTk5MGI1MjM1Njk2Yi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c0df321d-7b58-469d-9b0d-990b5235696b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6e05c6168ff8455fb5a2d86aa603807e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzBkZjMyMWQtN2I1
+        OC00NjlkLTliMGQtOTkwYjUyMzU2OTZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MTguNjkwODQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MDY2ZDBhYTc4YjE0NWEyODMzMWFhY2M0
+        ODhiMTE4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjE4Ljcy
+        Nzg4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MTguNzc2
+        MTE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a42d36d421a4c49af3683bc0ca3552b
+      - 1cad4d98a1bc41a797f855aa0a932bd5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d432147f4c87471dabccf60b0728e56a
+      - 0275bf383b18495d8f7ded053bac42aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cbe50c113388487caa5036e8261198ea
+      - '0790e3483ca34c42b4d5aab56ec3705c'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:24 GMT
+      - Fri, 29 Jul 2022 08:58:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10a99768f3954f609e5ba4440199e0f8
+      - 7bbfda4795784656bffe9e11e64417fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:24 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 843cfdc6b35145b7b3c93a748c923930
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:24 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/66fc5ba8-f789-4f96-8643-f69196c419e2/"
+      - "/pulp/api/v3/remotes/rpm/rpm/cf940319-3f44-4083-bc54-7d920ad1ef6d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f47e01bec81d4fc599f1ff4a28de7e6c
+      - ccd533ce099f40eaa348fbcec7a343a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzY2
-        ZmM1YmE4LWY3ODktNGY5Ni04NjQzLWY2OTE5NmM0MTllMi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjI1LjAxNDQzOFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Nm
+        OTQwMzE5LTNmNDQtNDA4My1iYzU0LTdkOTIwYWQxZWY2ZC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjE5LjA5NjUxMloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjI1LjAxNDQ1OVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjE5LjA5NjUzNFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/"
+      - "/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e6be27c2e1b8410eb3b4d11e970e75f3
+      - 58b19c3f61fd4964b0f5a6bef94acd32
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZjdkN2QzOTktNTM4Yy00YjhlLTk5YzUtZTc1MTJkNzE4YmZkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MjUuMjAzNzc4WiIsInZl
+        cG0vMzI4YWVjN2EtMDUwNC00ZTk2LWFkNjAtODRiMzFmNTY0MDI5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MTkuMjQ4NDg4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZjdkN2QzOTktNTM4Yy00YjhlLTk5YzUtZTc1MTJkNzE4YmZkL3ZlcnNp
+        cG0vMzI4YWVjN2EtMDUwNC00ZTk2LWFkNjAtODRiMzFmNTY0MDI5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mN2Q3ZDM5OS01
-        MzhjLTRiOGUtOTljNS1lNzUxMmQ3MThiZmQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMjhhZWM3YS0w
+        NTA0LTRlOTYtYWQ2MC04NGIzMWY1NjQwMjkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cef8538666314731a91388208bbbb4a4
+      - fb7f556bcf614be194a1a5d398ade5ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMzg3YzhiZS05NjIyLTQxYTUtOGU1Yy03YzNhZTRlYWUzMjEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoxOS4zMjQwMTFa
+        cnBtL3JwbS8xMTA5YzUwYy0wMDIwLTRmMDQtYjcwMy03MGVmMmZmNTkwMDUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODowOC42NDYyMjNa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMzg3YzhiZS05NjIyLTQxYTUtOGU1Yy03YzNhZTRlYWUzMjEv
+        cnBtL3JwbS8xMTA5YzUwYy0wMDIwLTRmMDQtYjcwMy03MGVmMmZmNTkwMDUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzEzODdj
-        OGJlLTk2MjItNDFhNS04ZTVjLTdjM2FlNGVhZTMyMS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzExMDlj
+        NTBjLTAwMjAtNGYwNC1iNzAzLTcwZWYyZmY1OTAwNS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d9aa983572b4eff990a60bd19c2c134
+      - ec0fb608bbfb41c6a1e28e08fe91434d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU0MmM4ZTZlLTMxMmMtNDhh
-        Ni1hOGZmLWQwNjMxMWU0M2M4Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3MjFhZWJlLTNhYzMtNGY3
+        YS1iZjYwLTQzMTJhZDI2YmZhOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9ed5a70ab6454c9cb3652bf3ba21a632
+      - 431b71c228894d43b47b5ea698e02831
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vODdlMjA2MzYtNjlkMy00ZWE2LWJiYmEtNDgzNGFkNmIwMWZmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MTguNDQ0NTc0WiIsIm5h
+        cG0vYjExMzUzZmQtMzkzNy00NDg5LTgwOTMtNTgxNDc2ZmU4NzczLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MDcuNTY3NzIyWiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoxOS43MTE0NjdaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODowOS4wOTAxMTdaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/87e20636-69d3-4ea6-bbba-4834ad6b01ff/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b11353fd-3937-4489-8093-581476fe8773/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8c5193a09c154e8eb807d16e45d81a89
+      - c7f97c6d3b2844aa8b004a7967409e5b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiOGI2ODZmLTQxMjMtNDM1
-        My04ZTFiLTgwMmI2OGUxNTZiOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwOTIxYzc4LTc5Y2UtNDYy
+        OC05MjAxLWZhZGQ3OGQ1ZjE3Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/542c8e6e-312c-48a6-a8ff-d06311e43c8b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e721aebe-3ac3-4f7a-bf60-4312ad26bfa8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95c132eccf0543c88cce6639ece2e68a
+      - cafe4693803d48e49e2ee19b5f769426
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTQyYzhlNmUtMzEy
-        Yy00OGE2LWE4ZmYtZDA2MzExZTQzYzhiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjUuNDE2MjY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTcyMWFlYmUtM2Fj
+        My00ZjdhLWJmNjAtNDMxMmFkMjZiZmE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MTkuNDU4NjAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3ZDlhYTk4MzU3MmI0ZWZmOTkwYTYwYmQx
-        OWMyYzEzNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjI1LjQ0
-        NzQ4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MjUuNTA0
-        OTE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlYzBmYjYwOGJiZmI0MWM2YTFlMjhlMDhm
+        ZTkxNDM0ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjE5LjUw
+        MDE5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MTkuNTk0
+        ODAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTM4N2M4YmUtOTYyMi00MWE1
-        LThlNWMtN2MzYWU0ZWFlMzIxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTEwOWM1MGMtMDAyMC00ZjA0
+        LWI3MDMtNzBlZjJmZjU5MDA1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cb8b686f-4123-4353-8e1b-802b68e156b8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/90921c78-79ce-4628-9201-fadd78d5f176/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0afe41452a3f498eba5d1ab4f8a775fa
+      - 650d184b4dbd4741b2494bfab65f24bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2I4YjY4NmYtNDEy
-        My00MzUzLThlMWItODAyYjY4ZTE1NmI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjUuNTA0ODk0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTA5MjFjNzgtNzlj
+        ZS00NjI4LTkyMDEtZmFkZDc4ZDVmMTc2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MTkuNTg4MTY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4YzUxOTNhMDljMTU0ZThlYjgwN2QxNmU0
-        NWQ4MWE4OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjI1LjUz
-        NjY5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MjUuNTc5
-        MDYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjN2Y5N2M2ZDNiMjg0NGFhOGIwMDRhNzk2
+        NzQwOWU1YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjE5LjYz
+        MTk4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MTkuNjkz
+        MTY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3ZTIwNjM2LTY5ZDMtNGVhNi1iYmJh
-        LTQ4MzRhZDZiMDFmZi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IxMTM1M2ZkLTM5MzctNDQ4OS04MDkz
+        LTU4MTQ3NmZlODc3My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc020fb3e8814b108f1bd5f7131e9246
+      - bdb3fde35b804f6183049ad641b18a60
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a8e2a02bc6574e7e9f61918daf243f9b
+      - e5a30bba1fd8401797d32405d1fc3fd2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - adc7bac77af24bf48d4db7654845e182
+      - b9d22163349a4aef8a152e5a289676de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6e6fabb39c1647089c6c1903e9251430
+      - 1c45a3f5760e4a35a425e9db3566774c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b1ea128b5a2468c94295fc4f41c0138
+      - ae92e49f936c4fde8eaa2987d8a77505
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:25 GMT
+      - Fri, 29 Jul 2022 08:58:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e03aa86787814fb3b020ff513e518664
+      - 2a6ab375232244edbb2c7bb362b7ac65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:25 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:26 GMT
+      - Fri, 29 Jul 2022 08:58:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/"
+      - "/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - afca047c5ef848b38d4471f30cb185ed
+      - 69937ae7d1d54dc5af96787c3b9bc304
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmE3YTkzN2MtYTc3ZC00ZWZjLThmNmYtZGIwNDZjODFiYzViLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MjYuMDMzODQ0WiIsInZl
+        cG0vNjQzMjIwMjctZjU3OS00OGQzLTlmZTgtODM1MTFjYmVkMzI1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MjAuMTU2MjU3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmE3YTkzN2MtYTc3ZC00ZWZjLThmNmYtZGIwNDZjODFiYzViL3ZlcnNp
+        cG0vNjQzMjIwMjctZjU3OS00OGQzLTlmZTgtODM1MTFjYmVkMzI1L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iYTdhOTM3Yy1h
-        NzdkLTRlZmMtOGY2Zi1kYjA0NmM4MWJjNWIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82NDMyMjAyNy1m
+        NTc5LTQ4ZDMtOWZlOC04MzUxMWNiZWQzMjUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:26 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:20 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/66fc5ba8-f789-4f96-8643-f69196c419e2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/cf940319-3f44-4083-bc54-7d920ad1ef6d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:26 GMT
+      - Fri, 29 Jul 2022 08:58:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3232b519905547e3a3d7b480fe9b7801
+      - 62ed748f7006496e8ad20d33ed2c3c9e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1Y2E5MzA2LTg2ZTctNGM0
-        Ni05Mjk0LTc3NjhkMzEzMzVlZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5ODA3NDFlLWY4ZTktNDIx
+        Ni1iZTQwLTFlNTg1YzhlNzc1My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:26 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b5ca9306-86e7-4c46-9294-7768d31335ed/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a980741e-f8e9-4216-be40-1e585c8e7753/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:26 GMT
+      - Fri, 29 Jul 2022 08:58:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4574e8f82d9148418def0f3be10d20c2
+      - ffc86adb27f547e0b8800a942f09827f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjVjYTkzMDYtODZl
-        Ny00YzQ2LTkyOTQtNzc2OGQzMTMzNWVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjYuMzAzODI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTk4MDc0MWUtZjhl
+        OS00MjE2LWJlNDAtMWU1ODVjOGU3NzUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MjAuNTExMjQ0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIzMjMyYjUxOTkwNTU0N2UzYTNkN2I0ODBm
-        ZTliNzgwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjI2LjM2
-        MjE4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MjYuMzg5
-        NDU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2MmVkNzQ4ZjcwMDY0OTZlOGFkMjBkMzNl
+        ZDJjM2M5ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjIwLjU0
+        NjE4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MjAuNTc0
+        NjI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzY2ZmM1YmE4LWY3ODktNGY5Ni04NjQz
-        LWY2OTE5NmM0MTllMi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NmOTQwMzE5LTNmNDQtNDA4My1iYzU0
+        LTdkOTIwYWQxZWY2ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:26 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:20 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzY2ZmM1
-        YmE4LWY3ODktNGY5Ni04NjQzLWY2OTE5NmM0MTllMi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NmOTQw
+        MzE5LTNmNDQtNDA4My1iYzU0LTdkOTIwYWQxZWY2ZC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:26 GMT
+      - Fri, 29 Jul 2022 08:58:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 99d09c1d6c924b2cb78ec4e5f9399585
+      - d8e63c7469a640cbbf1958d3e8a4e39a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxZGI2ZTlkLTI1YzgtNGQx
-        Mi05YmEyLWM2YWU2MmE3NmU5Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjZTdhZjQ5LTBmNzAtNDZh
+        ZS05NjIwLTViY2M1MTM1NTE4MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:26 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/91db6e9d-25c8-4d12-9ba2-c6ae62a76e9c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ace7af49-0f70-46ae-9620-5bcc51355181/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,82 +1787,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:28 GMT
+      - Fri, 29 Jul 2022 08:58:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73c41d659ea74fa8b0cffdc5933b5347
+      - b413ac68c5b946dcb978dd7ad459b719
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '599'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTFkYjZlOWQtMjVj
-        OC00ZDEyLTliYTItYzZhZTYyYTc2ZTljLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjYuNTE1ODc3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNlN2FmNDktMGY3
+        MC00NmFlLTk2MjAtNWJjYzUxMzU1MTgxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MjAuNjkxNjY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI5OWQwOWMxZDZjOTI0YjJjYjc4
-        ZWM0ZTVmOTM5OTU4NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjI2LjU0NjY0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MjguMDk1NTQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkOGU2M2M3NDY5YTY0MGNiYmYx
+        OTU4ZDNlOGE0ZTM5YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjIwLjc0NjE4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        MjQuODI5OTU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
         IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZjdkN2QzOTktNTM4Yy00YjhlLTk5YzUt
-        ZTc1MTJkNzE4YmZkL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2Y3ZDdkMzk5LTUzOGMtNGI4ZS05OWM1LWU3NTEyZDcxOGJmZC8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS82NmZjNWJhOC1mNzg5
-        LTRmOTYtODY0My1mNjkxOTZjNDE5ZTIvIl19
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBh
+        Y2thZ2VzIiwiY29kZSI6InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJz
+        eW5jLnBhcnNpbmcuYWR2aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        VW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
+        b25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5n
+        IENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzMyOGFlYzdhLTA1MDQtNGU5Ni1hZDYwLTg0
+        YjMxZjU2NDAyOS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8z
+        MjhhZWM3YS0wNTA0LTRlOTYtYWQ2MC04NGIzMWY1NjQwMjkvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vY2Y5NDAzMTktM2Y0NC00
+        MDgzLWJjNTQtN2Q5MjBhZDFlZjZkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:24 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZjdkN2QzOTktNTM4Yy00YjhlLTk5YzUtZTc1MTJkNzE4
-        YmZkL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMzI4YWVjN2EtMDUwNC00ZTk2LWFkNjAtODRiMzFmNTY0
+        MDI5L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:28 GMT
+      - Fri, 29 Jul 2022 08:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dca402cea49f471aa5de79461b77d12c
+      - 454807826f8d47508c46152b23d48091
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1Nzg1M2I5LTU3ZjktNDUz
-        ZS04YjM3LTgzNTZjMzgwNzQyMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiNzJkZGM5LWQ3NGItNDkx
+        OS1hN2I5LWE1NTY4ZThjNWJhMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d57853b9-57f9-453e-8b37-8356c3807422/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ab72ddc9-d74b-4919-a7b9-a5568e8c5ba1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:28 GMT
+      - Fri, 29 Jul 2022 08:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3439f933d8064558bae12dfbe223203c
+      - 41ec67fadd6f4490a0a57aca6e69d54e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDU3ODUzYjktNTdm
-        OS00NTNlLThiMzctODM1NmMzODA3NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjguMjQ0NTM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWI3MmRkYzktZDc0
+        Yi00OTE5LWE3YjktYTU1NjhlOGM1YmExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MjUuMDU5ODg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImRjYTQwMmNlYTQ5ZjQ3MWFhNWRlNzk0NjFi
-        NzdkMTJjIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MjguMjc0
-        NjM1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzoyOC40NTc2
-        ODBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjQ1NDgwNzgyNmY4ZDQ3NTA4YzQ2MTUyYjIz
+        ZDQ4MDkxIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MjUuMTE4
+        NTIxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1ODoyNS40MDcy
+        NjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMzUzN2Yw
-        Y2UtYTg4Yi00ODhjLWIxOTAtYjY0YmVhNTFkOTNiLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYWFlZWM4
+        NDgtYTc0NS00NzVmLTg3ZjYtMjcyNzhiMGMyYWMzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZjdkN2QzOTktNTM4Yy00YjhlLTk5YzUtZTc1MTJk
-        NzE4YmZkLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMzI4YWVjN2EtMDUwNC00ZTk2LWFkNjAtODRiMzFm
+        NTY0MDI5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:28 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2afb37438cfd4a11aa406a35de6920f8
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:28 GMT
+      - Fri, 29 Jul 2022 08:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e917888c3faf4d43a3dc0503922cb7d9
+      - eb98c84416e847a8aca66a5bbe521d56
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/aaeec848-a745-475f-87f6-27278b0c2ac3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:28 GMT
+      - Fri, 29 Jul 2022 08:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - adf90b42cd62499daf9ebf3362d4abd5
+      - 162f5434f75649b49e3b71ffe61e1723
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYWFlZWM4NDgtYTc0NS00NzVmLTg3ZjYtMjcyNzhiMGMyYWMzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MjUuMTQxODA2WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8zMjhhZWM3YS0wNTA0LTRlOTYtYWQ2MC04NGIzMWY1NjQwMjkv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzMyOGFlYzdhLTA1MDQtNGU5Ni1hZDYwLTg0YjMx
+        ZjU2NDAyOS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:25 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9hYWVlYzg0OC1hNzQ1LTQ3NWYtODdmNi0yNzI3OGIwYzJhYzMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c48df09a9b2c42e5b3a1b0fbce5c3d3d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhMjY5YzRkLTdhMzctNGQz
+        Ni1hOTM2LTIzYzZmMDI5YjQ0ZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:25 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fa269c4d-7a37-4d36-a936-23c6f029b44e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f7dc2c8b58484a1097382c97c3fd70e4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmEyNjljNGQtN2Ez
+        Ny00ZDM2LWE5MzYtMjNjNmYwMjliNDRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MjUuNzExMTIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJjNDhkZjA5YTliMmM0MmU1YjNhMWIwZmJj
+        ZTVjM2QzZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjI1Ljc2
+        MzY4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MjUuOTgy
+        MDk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vOTNj
+        ZWYxZDMtMDhmNS00MzBkLWI1MWEtY2NjMmNkNzJjMjQ2LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/93cef1d3-08f5-430d-b51a-ccc2cd72c246/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fb6aa8a3c5fa4275939840328d8686b6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzkzY2VmMWQzLTA4ZjUtNDMwZC1iNTFhLWNjYzJjZDcyYzI0Ni8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjI1Ljk2MjI1N1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYWFlZWM4NDgtYTc0NS00NzVmLTg3ZjYt
+        MjcyNzhiMGMyYWMzLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ac93e7599f4745d483d70c898a18f82b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 58d9a13015fc40bb95c0cbcd7c7cc893
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7314dcb969eb4fa4aea162097b40a809
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:28 GMT
+      - Fri, 29 Jul 2022 08:58:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 272c7b3904eb42e096be3e42a65d24bd
+      - fa3f5e72039e43559906c3fda3b41869
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:28 GMT
+      - Fri, 29 Jul 2022 08:58:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0630cda2a4ee41c6b21c5d98e5e96b44
+      - 57e1d05be86b4165af33fcf64ee20dfa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:28 GMT
+      - Fri, 29 Jul 2022 08:58:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7bd684c0a99c492a8a6c78425eef1775
+      - 53fee95e1faf4a118cf7277f46141c59
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:29 GMT
+      - Fri, 29 Jul 2022 08:58:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e9ecb71f30d74350b87d4c5c481ae515
+      - 8c2095c928b240518de72c5e70591037
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:29 GMT
+      - Fri, 29 Jul 2022 08:58:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b31b6a57a72c4eeeb90c1be8952018ec
+      - 15f253e424d04f20a632066dc87d6a33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:29 GMT
+      - Fri, 29 Jul 2022 08:58:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2d0576001e54240878be9c6ab81d410
+      - caec7073d0bd4d54a15979f2843889b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:29 GMT
+      - Fri, 29 Jul 2022 08:58:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41e2f46290654af38a8b57e754d31346
+      - 67805d4985464230bb5a2e9c124cd279
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:27 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:29 GMT
+      - Fri, 29 Jul 2022 08:58:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,32 +3208,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a1663e94e014faba8790cf1233332cd
+      - c51bbb3a51164a61a7b376aa1862cf35
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjMGViODJkLTc0YmYtNDFj
-        ZS04MWRmLWE5MWJjNTRkN2RhNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxOTNkMmI2LTQ2MmItNGNm
+        Yi1iYmUyLTlmN2RjMjQ5NTBiMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:27 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2
-        ZTVjLyJdfQ==
+        cG0vcGFja2FnZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMw
+        YzRjLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2821,7 +3246,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:29 GMT
+      - Fri, 29 Jul 2022 08:58:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2839,21 +3264,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2fc11c23530c4d50bdfc63a1d8089994
+      - 6a2a0027e169427aaa698177a3ead663
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1ODliMTYzLTZjMGItNDZl
-        Ny1hNTdhLWY3N2RjNTM4ZTAxZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5ODJhODU5LWE3ZDgtNDUx
+        Ny04MmM0LTNhNDIxYTY2ZGQ2Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4589b163-6c0b-46e7-a57a-f77dc538e01f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5982a859-a7d8-4517-82c4-3a421a66dd67/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2874,53 +3299,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:29 GMT
+      - Fri, 29 Jul 2022 08:58:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21539b159a9e4ad19d6346fe8429aaea
+      - 7164958e0608450bad96fd486ec916a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '387'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDU4OWIxNjMtNmMw
-        Yi00NmU3LWE1N2EtZjc3ZGM1MzhlMDFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjkuNDI1NTU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTk4MmE4NTktYTdk
+        OC00NTE3LTgyYzQtM2E0MjFhNjZkZDY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MjcuNDA5NjU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyZmMxMWMyMzUzMGM0ZDUwYmRm
-        YzYzYTFkODA4OTk5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjI5LjU3NjQ3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MjkuNzA5MDc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2YTJhMDAyN2UxNjk0MjdhYWE2
+        OTgxNzdhM2VhZDY2MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjI3LjcyNTEyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        MjcuOTQ4NzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iYTdhOTM3Yy1hNzdkLTRlZmMtOGY2Zi1kYjA0NmM4MWJjNWIvdmVyc2lv
+        bS82NDMyMjAyNy1mNTc5LTQ4ZDMtOWZlOC04MzUxMWNiZWQzMjUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE3YTkzN2MtYTc3ZC00ZWZj
-        LThmNmYtZGIwNDZjODFiYzViLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjQzMjIwMjctZjU3OS00OGQz
+        LTlmZTgtODM1MTFjYmVkMzI1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2928,7 +3353,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2941,41 +3366,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:29 GMT
+      - Fri, 29 Jul 2022 08:58:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d5eea0ab01e4bf9baa09fb247efbff3
+      - 6a19e0ddceb5440191d80efb89233a28
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMv
+        YWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQyYi05MDMzNmRkMzBjNGMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2983,7 +3408,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2996,7 +3421,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:30 GMT
+      - Fri, 29 Jul 2022 08:58:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3014,21 +3439,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 598db704c2f7410ab0424bfabd88fe4e
+      - d099f417a6f046848fe0ed3d6e70618d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3036,7 +3461,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3049,7 +3474,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:30 GMT
+      - Fri, 29 Jul 2022 08:58:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3067,21 +3492,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 896d9e419f0c437687a34f4e536cf56e
+      - 7a7611953a064c45ade184f74680819c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3089,7 +3514,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3102,7 +3527,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:30 GMT
+      - Fri, 29 Jul 2022 08:58:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3120,21 +3545,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5bdc94682c9449129ca52f15a7f2224f
+      - d9081886a2af4f00811bd0cdfbb66458
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3142,7 +3567,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3155,7 +3580,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:30 GMT
+      - Fri, 29 Jul 2022 08:58:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3173,21 +3598,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f08ae50a71ca46fcbd74041d762d4b56
+      - 13a4c074de3748998c7c7571de105af2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3195,7 +3620,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3208,7 +3633,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:30 GMT
+      - Fri, 29 Jul 2022 08:58:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3226,16 +3651,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39e52aca43124046a83e5d9c0739eda0
+      - eb7f095149eb42d5b24a388f3926b52a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:28 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_nonmatching_package_exclusion_filter_copies_everything.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_nonmatching_package_exclusion_filter_copies_everything.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef80993997b5467d9ee5f8a420ed317d
+      - ecc367b4f48d4a6e90faf84fd1fe4d5c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '314'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mN2Q3ZDM5OS01MzhjLTRiOGUtOTljNS1lNzUxMmQ3MThiZmQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoyNS4yMDM3Nzha
+        cnBtL3JwbS8zMjhhZWM3YS0wNTA0LTRlOTYtYWQ2MC04NGIzMWY1NjQwMjkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODoxOS4yNDg0ODha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mN2Q3ZDM5OS01MzhjLTRiOGUtOTljNS1lNzUxMmQ3MThiZmQv
+        cnBtL3JwbS8zMjhhZWM3YS0wNTA0LTRlOTYtYWQ2MC04NGIzMWY1NjQwMjkv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Y3ZDdk
-        Mzk5LTUzOGMtNGI4ZS05OWM1LWU3NTEyZDcxOGJmZC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMyOGFl
+        YzdhLTA1MDQtNGU5Ni1hZDYwLTg0YjMxZjU2NDAyOS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/f7d7d399-538c-4b8e-99c5-e7512d718bfd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/328aec7a-0504-4e96-ad60-84b31f564029/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc0c43a0e6d9408a94039465c21e43e4
+      - e5d30728633a417c9c3cc01e32fbaed8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzMzkzYmYyLTFiMDMtNDkz
-        Ny04ZjYyLWUxZjdiOWNlOTllNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFkNTBmODc3LTcxMzgtNDdm
+        My05MDFhLWJmYTk0YTY0NjMzZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e0a574969086429cb2172058418f5aa0
+      - 6a309f490715452296f928e0d60af67d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b3393bf2-1b03-4937-8f62-e1f7b9ce99e7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1d50f877-7138-47f3-901a-bfa94a64633f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fba6cda3dd714571a1e3be261e26288a
+      - b7072c777e694b58ac0eaa10865402dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjMzOTNiZjItMWIw
-        My00OTM3LThmNjItZTFmN2I5Y2U5OWU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzEuMTA1MzAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWQ1MGY4NzctNzEz
+        OC00N2YzLTkwMWEtYmZhOTRhNjQ2MzNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MzAuMTMzNzIyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiYzBjNDNhMGU2ZDk0MDhhOTQwMzk0NjVj
-        MjFlNDNlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjMxLjEz
-        NzM1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzEuMjU2
-        NDMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNWQzMDcyODYzM2E0MTdjOWMzY2MwMWUz
+        MmZiYWVkOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjMwLjE4
+        NjAwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MzAuMzg2
+        MjUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjdkN2QzOTktNTM4Yy00Yjhl
-        LTk5YzUtZTc1MTJkNzE4YmZkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzI4YWVjN2EtMDUwNC00ZTk2
+        LWFkNjAtODRiMzFmNTY0MDI5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 99a8c3bfd94e46e19fb99e8716a30580
+      - 36775573be55437aaa02d1eebbcc5875
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a559f20fed2d48eba718bd4ab4205d95
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vOTNjZWYxZDMtMDhmNS00MzBkLWI1MWEtY2NjMmNkNzJjMjQ2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MjUuOTYyMjU3
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/93cef1d3-08f5-430d-b51a-ccc2cd72c246/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9054b13b5fb04c2aa4e97076f18ed57d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2ZTJiYmYzLTFiYTYtNDlh
+        ZC05YTYyLWUzOGZhMzFkNjM0NC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e6e2bbf3-1ba6-49ad-9a62-e38fa31d6344/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2ad1800223c3452d99d4e64344ee83ce
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTZlMmJiZjMtMWJh
+        Ni00OWFkLTlhNjItZTM4ZmEzMWQ2MzQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MzAuNTYzMzgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5MDU0YjEzYjVmYjA0YzJhYTRlOTcwNzZm
+        MThlZDU3ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjMwLjYw
+        NjY1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MzAuNjQx
+        NDM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 63e461010342476c93ca71bdcb458836
+      - b8051e5c5fe345ccbd189fa7a4e48dc6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f0b0b74b1d3a427a8c0859dc1b3ceb00
+      - 89f6ee9e8086478f99c164c6e7646b98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f633aadb56e49fa821112329f5add02
+      - 95895bbca04b4de98ec96c89a3950900
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ba580f9abd7488f897b5b0799923632
+      - 758274cf331b457181cc065e57b287ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:31 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d7c30273142240389ffb76dfdcd3a122
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/61c58349-2c02-4d87-b701-0c402b88b956/"
+      - "/pulp/api/v3/remotes/rpm/rpm/eaa34ddb-813c-422d-9997-95ebe481eead/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 994a35f45fdf4df6b75f3c347f582704
+      - b5d5ec6a1b7b497fa0da70d488717549
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYx
-        YzU4MzQ5LTJjMDItNGQ4Ny1iNzAxLTBjNDAyYjg4Yjk1Ni8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjMxLjY0OTk0MVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Vh
+        YTM0ZGRiLTgxM2MtNDIyZC05OTk3LTk1ZWJlNDgxZWVhZC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjMwLjk1MzQxM1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjMxLjY0OTk2MVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjMwLjk1MzQzNVoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:30 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/"
+      - "/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cdaa29bd6a494cdbba1d43d54288ab76
+      - efe993dde221491285b13d0872a4cbd7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZjU5ZjYxM2EtMTM0MS00MzUyLWEwMjEtYzE2YzcxNTdkN2IwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MzEuNzYyNzk2WiIsInZl
+        cG0vNWFkNzg5YjAtYjU2My00NmVkLTlhOTEtOWE4NDY5ODY5YmFhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MzEuMTcxNTU0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZjU5ZjYxM2EtMTM0MS00MzUyLWEwMjEtYzE2YzcxNTdkN2IwL3ZlcnNp
+        cG0vNWFkNzg5YjAtYjU2My00NmVkLTlhOTEtOWE4NDY5ODY5YmFhL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mNTlmNjEzYS0x
-        MzQxLTQzNTItYTAyMS1jMTZjNzE1N2Q3YjAvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81YWQ3ODliMC1i
+        NTYzLTQ2ZWQtOWE5MS05YTg0Njk4NjliYWEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed7eb55c128d4316916a2499939e5f0e
+      - 5d9ca88d02c4495cb58fc8fca9d091c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iYTdhOTM3Yy1hNzdkLTRlZmMtOGY2Zi1kYjA0NmM4MWJjNWIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoyNi4wMzM4NDRa
+        cnBtL3JwbS82NDMyMjAyNy1mNTc5LTQ4ZDMtOWZlOC04MzUxMWNiZWQzMjUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODoyMC4xNTYyNTda
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iYTdhOTM3Yy1hNzdkLTRlZmMtOGY2Zi1kYjA0NmM4MWJjNWIv
+        cnBtL3JwbS82NDMyMjAyNy1mNTc5LTQ4ZDMtOWZlOC04MzUxMWNiZWQzMjUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JhN2E5
-        MzdjLWE3N2QtNGVmYy04ZjZmLWRiMDQ2YzgxYmM1Yi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY0MzIy
+        MDI3LWY1NzktNDhkMy05ZmU4LTgzNTExY2JlZDMyNS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ba7a937c-a77d-4efc-8f6f-db046c81bc5b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/64322027-f579-48d3-9fe8-83511cbed325/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f3e1864a83c74861a233afd8ab341ef1
+      - '084e190ff8c44518979eb84a2d9bbadc'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzllZmJmMzZiLTliZTEtNDE5
-        ZS04NDJlLTU2OTAwMjlhNzhiMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxMjU3YjAwLTQ3OWEtNDMw
+        Yi1iMzczLTFmMjI3NmYxYTQxMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:31 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a4b35ccc4cc42518a26deae9284efe7
+      - 67da1c201bb540499176d38d35c69019
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNjZmYzViYTgtZjc4OS00Zjk2LTg2NDMtZjY5MTk2YzQxOWUyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MjUuMDE0NDM4WiIsIm5h
+        cG0vY2Y5NDAzMTktM2Y0NC00MDgzLWJjNTQtN2Q5MjBhZDFlZjZkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MTkuMDk2NTEyWiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoyNi4zODQ5MDVaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODoyMC41NjUyMzdaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/66fc5ba8-f789-4f96-8643-f69196c419e2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/cf940319-3f44-4083-bc54-7d920ad1ef6d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0aa218f459784f0ba23c1ef95d737744
+      - e7632889f31b4928917aa57f39a9e022
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2Yjc0MjcyLTlmYmEtNGMz
-        ZS04YzdlLTVlZWQyODNkNDAyNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1OGQ5YmRiLTE2YzctNDlk
+        ZS04MjJhLTgyMTg3NGMxMjkxMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9efbf36b-9be1-419e-842e-5690029a78b3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f1257b00-479a-430b-b373-1f2276f1a413/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 966d910f20ec4b818568b8eab178dfa5
+      - 8654ca45c5644988a1d723d80f104213
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWVmYmYzNmItOWJl
-        MS00MTllLTg0MmUtNTY5MDAyOWE3OGIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzEuOTIwMTkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjEyNTdiMDAtNDc5
+        YS00MzBiLWIzNzMtMWYyMjc2ZjFhNDEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MzEuNTAwNjY3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmM2UxODY0YTgzYzc0ODYxYTIzM2FmZDhh
-        YjM0MWVmMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjMxLjk1
-        MDEwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzIuMDA5
-        NDIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwODRlMTkwZmY4YzQ0NTE4OTc5ZWI4NGEy
+        ZDliYmFkYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjMxLjU1
+        MDM3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MzEuNjQ2
+        NTQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE3YTkzN2MtYTc3ZC00ZWZj
-        LThmNmYtZGIwNDZjODFiYzViLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjQzMjIwMjctZjU3OS00OGQz
+        LTlmZTgtODM1MTFjYmVkMzI1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/86b74272-9fba-4c3e-8c7e-5eed283d4027/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/358d9bdb-16c7-49de-822a-821874c12912/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8c33b93ac275488f9d88628ea7f1d606
+      - 8cd84ff26b0a44d6bbc343e6bfe7c35b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODZiNzQyNzItOWZi
-        YS00YzNlLThjN2UtNWVlZDI4M2Q0MDI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzIuMDA3MzUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzU4ZDliZGItMTZj
+        Ny00OWRlLTgyMmEtODIxODc0YzEyOTEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MzEuNjI3NjI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwYWEyMThmNDU5Nzg0ZjBiYTIzYzFlZjk1
-        ZDczNzc0NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjMyLjAz
-        ODgxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzIuMDgz
-        MDY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNzYzMjg4OWYzMWI0OTI4OTE3YWE1N2Yz
+        OWE5ZTAyMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjMxLjY3
+        OTQwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MzEuNzM0
+        NTEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzY2ZmM1YmE4LWY3ODktNGY5Ni04NjQz
-        LWY2OTE5NmM0MTllMi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NmOTQwMzE5LTNmNDQtNDA4My1iYzU0
+        LTdkOTIwYWQxZWY2ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2219b15813b74142b7cae326a322cd08
+      - 6b1945f327f6405bab0368e75ac1bf58
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 44c6b298140b4d2593bb973e00c87cc3
+      - b435b92cd656410882c953c2bbcb7867
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57ae046a6f264e3998874e84d9401ec4
+      - 51dbdc4dd26d44b8b246922f5269c377
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd126b18c4c84dd59506935cb2902c55
+      - e418c5a39cb44b1987999f1f28408760
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 92e8014cc00f4643af2a6bd13efc26b1
+      - 2d788ec3d47c459b9737bbef9535d9b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b40dd5c23f3e4ed79fce16f492efc194
+      - 4e047ec61e7649a782da53fe9aa5a850
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/"
+      - "/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 01cfb106798f46cd805a9b1af6741da5
+      - 89e2fe91b3e84c0bbfdde55e6ba0a608
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2E2N2RkNmItZjAyYy00MGI2LWExOWMtZjE0OWNkZDA2NjNlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MzIuNDUxNDIxWiIsInZl
+        cG0vZGNhM2MzNzQtOWFmYS00NzUyLWIyODUtYzUzYmNkYTJhZDQyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MzIuMjIwMzAwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2E2N2RkNmItZjAyYy00MGI2LWExOWMtZjE0OWNkZDA2NjNlL3ZlcnNp
+        cG0vZGNhM2MzNzQtOWFmYS00NzUyLWIyODUtYzUzYmNkYTJhZDQyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83YTY3ZGQ2Yi1m
-        MDJjLTQwYjYtYTE5Yy1mMTQ5Y2RkMDY2M2UvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kY2EzYzM3NC05
+        YWZhLTQ3NTItYjI4NS1jNTNiY2RhMmFkNDIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:32 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/61c58349-2c02-4d87-b701-0c402b88b956/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/eaa34ddb-813c-422d-9997-95ebe481eead/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 958c539ff9f84642ae11e128636da66f
+      - 70e356d4603d4282b6500d6bda08c56c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg5YjFiNDYxLTVlYzAtNDFh
-        NS1iYmE1LWRmZWQ3NjA2ODg0OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzljZTg0ZTJlLTgzZTQtNDM3
+        Yy04MjBjLTI5OTJjN2RkMGIyMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/89b1b461-5ec0-41a5-bba5-dfed76068849/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9ce84e2e-83e4-437c-820c-2992c7dd0b23/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 40313806e70448589c5827aeb1f1facd
+      - c4b430af9f6d40f8a6a74f44e8ac9e1c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODliMWI0NjEtNWVj
-        MC00MWE1LWJiYTUtZGZlZDc2MDY4ODQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzIuNzEyNTg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWNlODRlMmUtODNl
+        NC00MzdjLTgyMGMtMjk5MmM3ZGQwYjIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MzIuNjE0NzQ4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI5NThjNTM5ZmY5Zjg0NjQyYWUxMWUxMjg2
-        MzZkYTY2ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjMyLjc0
-        NDkxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzIuNzY3
-        MjQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3MGUzNTZkNDYwM2Q0MjgyYjY1MDBkNmJk
+        YTA4YzU2YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjMyLjY1
+        ODU3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MzIuNjgz
+        OTUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYxYzU4MzQ5LTJjMDItNGQ4Ny1iNzAx
-        LTBjNDAyYjg4Yjk1Ni8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2VhYTM0ZGRiLTgxM2MtNDIyZC05OTk3
+        LTk1ZWJlNDgxZWVhZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYxYzU4
-        MzQ5LTJjMDItNGQ4Ny1iNzAxLTBjNDAyYjg4Yjk1Ni8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2VhYTM0
+        ZGRiLTgxM2MtNDIyZC05OTk3LTk1ZWJlNDgxZWVhZC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:32 GMT
+      - Fri, 29 Jul 2022 08:58:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ba4dd3b3f1f444238bc9dad964b52b87
+      - b9a4e785f6ee4f16aca2b8c3a503b855
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RiMzE5ZDhiLWMyZTUtNGM2
-        NC05NjA1LTliY2ViNjgwYzI1MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc4NmVlOWRhLTU2M2EtNDFk
+        NS1iMzI4LTU3NmNiMmFkZmFiZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/db319d8b-c2e5-4c64-9605-9bceb680c250/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/786ee9da-563a-41d5-b328-576cb2adfabd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:34 GMT
+      - Fri, 29 Jul 2022 08:58:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7bfafde5d434a2dba881b9a19de956a
+      - 01d91a788c8a49779f94b3f5598b86c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '599'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGIzMTlkOGItYzJl
-        NS00YzY0LTk2MDUtOWJjZWI2ODBjMjUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzIuODg4ODE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzg2ZWU5ZGEtNTYz
+        YS00MWQ1LWIzMjgtNTc2Y2IyYWRmYWJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MzIuNzgwOTU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJiYTRkZDNiM2YxZjQ0NDIzOGJj
-        OWRhZDk2NGI1MmI4NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjMyLjkzODIzOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MzQuNTI4OTI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJiOWE0ZTc4NWY2ZWU0ZjE2YWNh
+        MmI4YzNhNTAzYjg1NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjMyLjgyOTc3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        NDAuMjIyNjI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZjU5ZjYxM2EtMTM0MS00MzUyLWEwMjEt
-        YzE2YzcxNTdkN2IwL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2Y1OWY2MTNhLTEzNDEtNDM1Mi1hMDIxLWMxNmM3MTU3ZDdiMC8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS82MWM1ODM0OS0yYzAy
-        LTRkODctYjcwMS0wYzQwMmI4OGI5NTYvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzVhZDc4OWIwLWI1NjMtNDZlZC05YTkxLTlh
+        ODQ2OTg2OWJhYS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81
+        YWQ3ODliMC1iNTYzLTQ2ZWQtOWE5MS05YTg0Njk4NjliYWEvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZWFhMzRkZGItODEzYy00
+        MjJkLTk5OTctOTVlYmU0ODFlZWFkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:40 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZjU5ZjYxM2EtMTM0MS00MzUyLWEwMjEtYzE2YzcxNTdk
-        N2IwL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNWFkNzg5YjAtYjU2My00NmVkLTlhOTEtOWE4NDY5ODY5
+        YmFhL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:34 GMT
+      - Fri, 29 Jul 2022 08:58:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d057af4a3104a47b138ea217273e5a2
+      - 6096bf0e356a49e09332cd4eb93ce640
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlNWUzMWI1LTNlNTQtNDg5
-        Yy04MTQ1LWZlNWExM2UxOWEwYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3ZTg2NzFlLTQ3NjUtNGJh
+        Yi1iZTdlLWNhZDVmNDk1NTgxMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5e5e31b5-3e54-489c-8145-fe5a13e19a0c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e7e8671e-4765-4bab-be7e-cad5f4955812/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:34 GMT
+      - Fri, 29 Jul 2022 08:58:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ef8c8c25e5848488b3013a43833f158
+      - 86f20eeec47145218f278c9f14e5fe7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '473'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWU1ZTMxYjUtM2U1
-        NC00ODljLTgxNDUtZmU1YTEzZTE5YTBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzQuNjc2MzI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTdlODY3MWUtNDc2
+        NS00YmFiLWJlN2UtY2FkNWY0OTU1ODEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDAuNTEyNTQyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjdkMDU3YWY0YTMxMDRhNDdiMTM4ZWEyMTcy
-        NzNlNWEyIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MzQuNzA2
-        Mjg2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzozNC44ODEy
-        MTRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjYwOTZiZjBlMzU2YTQ5ZTA5MzMyY2Q0ZWI5
+        M2NlNjQwIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NDAuNTYx
+        OTk4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1ODo0MC44ODYx
+        MDJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vM2ExMGY4
-        MGYtMmRjNi00ZTI1LTkyM2QtNTNkZGFmOTVlZTgxLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNWRlMTlj
+        MTMtNTUyZi00YTkyLWIxNDAtYTA1MGViMDlkZmNiLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZjU5ZjYxM2EtMTM0MS00MzUyLWEwMjEtYzE2Yzcx
-        NTdkN2IwLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNWFkNzg5YjAtYjU2My00NmVkLTlhOTEtOWE4NDY5
+        ODY5YmFhLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e27beee84a904bd4a0b722749ecf2790
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39ccc1167c9747c5bd9eee817c37f350
+      - c0aa244c952545a491bf4d4ee2d1f1ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/5de19c13-552f-4a92-b140-a050eb09dfcb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 87d3e332e31849bc94f4a322d00a845d
+      - dc86c591b94c487f8acb482b215ea04a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNWRlMTljMTMtNTUyZi00YTkyLWIxNDAtYTA1MGViMDlkZmNiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NDAuNTg3MzE3WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS81YWQ3ODliMC1iNTYzLTQ2ZWQtOWE5MS05YTg0Njk4NjliYWEv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzVhZDc4OWIwLWI1NjMtNDZlZC05YTkxLTlhODQ2
+        OTg2OWJhYS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:41 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS81ZGUxOWMxMy01NTJmLTRhOTItYjE0MC1hMDUwZWIwOWRmY2Iv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ebbab0fec1c340d180d64739ab199248
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyNDFhODNiLTI4MmUtNDk2
+        Zi1iMTA2LThhMzhmZmNlYjZjNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e241a83b-282e-496f-b106-8a38ffceb6c4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a4a203db6dbe4de4b3fa237107a50ae0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTI0MWE4M2ItMjgy
+        ZS00OTZmLWIxMDYtOGEzOGZmY2ViNmM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDEuMjE3NjEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlYmJhYjBmZWMxYzM0MGQxODBkNjQ3Mzlh
+        YjE5OTI0OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjQxLjI1
+        NjU2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NDEuNTA1
+        MTMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZmU5
+        YmMzMzYtMzUyYS00ODMxLTk2OGUtOTA5OTFlNTcxMmIwLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/fe9bc336-352a-4831-968e-90991e5712b0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8d78b68f25c44d619e02ee4b14f541d0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2ZlOWJjMzM2LTM1MmEtNDgzMS05NjhlLTkwOTkxZTU3MTJiMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjQxLjQ4NDUwMVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNWRlMTljMTMtNTUyZi00YTkyLWIxNDAt
+        YTA1MGViMDlkZmNiLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fa17df12b8b34d05bc7343d39a82b04b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9c29053e00274366b62c024677a95b90
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 95fd1aba5a9a4c9d9a35da8f2e242035
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 23a3f757c8b14e6da285d2248a385685
+      - 21ae8e998dab428cb4322ef7b130884c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fad687d562694dee834557689168e423
+      - 7fefd8f71484407b8f008416d7c593c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a467f359081e4371b0ec6ec6a3ac81bf
+      - 41d25e6e4b39401da57362c7b905bdaa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c653f5c9dd9e411ab725a9865c891421
+      - 6aa11f0b21bf4e2a87eb16c9eec86c32
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a18c989daccb43fe9910350360dc8ea0
+      - e6a98a385c474db79c15dd52bb3526c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 529d530bebc640e4860002a7c93daf5e
+      - 6711cfa5500843d3bda5d0b815f114f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f59f613a-1341-4352-a021-c16c7157d7b0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ead70d17267744a19a5bf06cb8f16865
+      - 3b76becb3d5846c495692605e92a747f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,89 +3208,89 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6e32385d5fac41b09406447822bb4126
+      - f3c468fe2999470c99aca8c95829e986
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2NTI4MmQ0LTdhZDYtNDU0
-        OC05ODYyLWE4NWIxYTBkOGJiMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMxMmNmNmQ2LWZhNmItNDc5
+        Zi04OWM0LWFlODU4MDYwNjI5ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80ZDYyYjA2Mi01MTkxLTQyZWQtYTU4NC04MWExZDhl
-        NGRhZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NjAxNWRkYzktNWZlOS00ZTgwLTg1OTItMzdjZDg3ZGVhMTQ4LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzhmZDYyODhiLWU2ODMt
-        NDZlZi05Yjk0LWQwZTkwNGI5ZjY4Yi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy85MGE2YzZhMS0zODY1LTQyZGEtYWZhOS01MTU2
-        NTFlOTRjN2YvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3MjMtMGI3NS00
-        ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy8xYTU3NjVlZS03MDc4LTQzMzgtYTAzNi1mZDkyNzMw
-        NDUxOTQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFm
-        MjQ0NjIxLTBjYmItNGJlOC05NjIzLTNiZGRjM2IxMGViMS8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ1ZTY2MTgtMGIwZC00Yjlm
-        LTlkOGQtMTVjNDgxMTg4Yzk1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy8yZDYyY2Y4NC00YzU1LTQ4OTQtOTQ0Zi04NjI3Mzc5NzU2
-        ZDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0Yzhk
-        MGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFl
-        ZTYtOTY0MWZiM2Y1YzUxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02Mjk3NTQ5YjAzODgv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwMWJhMDM3
-        LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEt
-        N2E3YTI4NWIwZDNiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy83NzAyYmFkNi01ZDc2LTQ0YWQtOTlhZi1iMzIwMzUwNDZlYmUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdlZTEyZjljLTE3
-        NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0
-        OGVhZWY1ZmEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUt
-        NGU3Yi04YjBiLWJmMTk4ZGNiNjIxNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvYThjMzk2MzItZWNlOC00MzZiLWJkMDctYjg0MDdh
-        M2VmODcwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9h
-        YWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRkMjgwZjVlZDMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I2NmY3MGRhLTU5ZDgtNDNi
-        Ny04ZGEyLWMyYjExMGExZjFiZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00OGIxLWEwZDYtY2Y3YTk4YWZk
-        YzU1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOGU2
-        NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2YxNGJiYjUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2JhZjI0YzFhLTBlMDctNDE2ZS04
-        NGE3LWVlNDU3MjMyYjA1ZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvYzFkNjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEy
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMzY0ZTky
-        ZS0xNjQxLTRjZWItODBiMC05NDk5OWQyMTljNDQvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NkZTc1MDU0LTQyZDktNDBlZS04ZWU1
-        LTA5NTFkZjMxNzVmYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2Y2ItYzI1M2E2ZmU1NTA5LyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDZiNzk5Ni00
-        MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZm
-        ODUwYjkyNmU1Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZTU3NjA5MGYtZWYwZS00YWVmLWIzYjctMmEzODI2ZDAxZDZjLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5
-        ZDlkMTE2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZWMyN2QzNTktOTM4OC00ODdjLWIyY2EtZGVkM2UyN2ZlNmRhLyJdfQ==
+        cG0vYWR2aXNvcmllcy8yMjUwZjE3YS1iYzE4LTRjZTEtOGM2YS0wN2M0ZjA2
+        ODI1NGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NjZmMzRmMWEtMzcwNC00ODNjLThjNTctMjNiMzllZGE1NWRiLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzc3ZmUyNzVhLTBkZTct
+        NDk5NC1iMGUzLWUzNjE5NmViZjdmZi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFh
+        NDRjZGRlYjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFhOGY5NTIxNThiYi8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMtMTQ4MS00
+        ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDItYWY0My0zODAzMTM2
+        ZDEyMmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgtZjZkZC00NDY3
+        LWI4ZWItNWNjYzBkNmRhNjhhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy8xNWM5MTA0Zi0xMjMzLTQ2YzQtYmY3My03NTE4MThmYzZm
+        MTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzMyZGE5
+        NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzMxOWNmYTAtZGRmYy00M2MwLThh
+        NmUtZDFkOTlkNDFiNmQ4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy80NGU4OTAwZC03MjIxLTQ0MDgtOTAwNS0xM2E5M2IzOTJhMGQv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5M2E0ZWIy
+        LWQ3MzktNDA5Mi04OTZmLTgzNjMwZmYzYzRmYi8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMt
+        NjNkNmJjZWQ3YmIzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy82ZGM4YzA3Ni1kNTFkLTQxZGQtYjQ1NS04MzRjMmY4ZDU4OGMvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZlYjVkZTgxLWQ2
+        MDUtNDkzMS04ZTY0LTQ2ZTAxZjE1MzAwMy8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNmYxYzkwYjAtYTc4Ny00OGNjLTgwY2ItZmNh
+        Mzk4MDAwYzc2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy83MzNhNGEwMC04ODRlLTRhMDEtYjI0MC02ZTM4YzNlZTczYjkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2MjlmMzBhLTE0Zjct
+        NDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvOGFlZjg5YjAtZDNiMy00ZDQyLWJiZTEtZmEwZDg5
+        MDEzMzUxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
+        YjgzYTg5Ny01ODRjLTQ2YTItODI3Zi04YjA3ZGFlOTdiYWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzkyYjY2YWNiLTYwYjktNGVm
+        NC1iNTFhLTlhYjZhNzUwMGY4Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOTliNmFmZWYtZjIxYi00OWY5LWEzNmItODUxODAzM2Yw
+        MzYwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hMGIy
+        ZmZjYi1iMzgwLTRhYjktYmI4Yi00MjljNGY5YmZjN2IvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1i
+        ZDJiLTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvYTVjZGJkZGUtYmNhOC00NTI5LTliNDEtYzdiZTgxZjc5MjQ4
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFm
+        MC01NmY4LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NhZjM4MDc5LWUwNTYtNDRlNy05NjNl
+        LWUyYzIzM2M4ZmY4NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUxN2NkLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJlMC1i
+        ZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4OTFhLWYyMjItNDkyOS1hZjJkLWM5
+        MTAwYTQ4YTZjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTExNzRkYjEtNzYxOS00YzUwLTljYzctMmM4MmFlNzg3ODhjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNDk3ZTBlZS0zYmE5
+        LTRhM2UtYTdiYS1kYjI1MDU5MWIyMzIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzL2U0YTgyMmQ2LTRlZjQtNDZmZS1hMjdjLTIxM2Jm
+        OGVhOWRmNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        ZjJkZmYxM2UtZjg5Mi00Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2878,7 +3303,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:35 GMT
+      - Fri, 29 Jul 2022 08:58:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2896,21 +3321,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4f1f57752ca4c2a82bd62e3e7cffccb
+      - 2bfe7871618d42b7ae2fb22b6072716a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiODkxOWYwLTVhZWQtNGUx
-        NS1iOTY2LTAwNmYyMjZmNDlmZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1ODYzYWZjLTcwYTktNDA3
+        Ny1iYzRjLWEwNGYyNTg3MmVhMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3b8919f0-5aed-4e15-b966-006f226f49ff/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/45863afc-70a9-4077-bc4c-a04f25872ea1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2931,53 +3356,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:36 GMT
+      - Fri, 29 Jul 2022 08:58:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ee8a63ca1434f2ead935491b9c1d0f1
+      - 23c762399eb64366a104e251a040a07a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2I4OTE5ZjAtNWFl
-        ZC00ZTE1LWI5NjYtMDA2ZjIyNmY0OWZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MzUuODUwMDE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDU4NjNhZmMtNzBh
+        OS00MDc3LWJjNGMtYTA0ZjI1ODcyZWExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDIuOTYzMDU3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNGYxZjU3NzUyY2E0YzJhODJi
-        ZDYyZTNlN2NmZmNjYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjM2LjAwMDcyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MzYuMTQ2NDk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyYmZlNzg3MTYxOGQ0MmI3YWUy
+        ZmIyMmI2MDcyNzE2YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjQzLjE5NDIwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        NDMuNDIzMDMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83YTY3ZGQ2Yi1mMDJjLTQwYjYtYTE5Yy1mMTQ5Y2RkMDY2M2UvdmVyc2lv
+        bS9kY2EzYzM3NC05YWZhLTQ3NTItYjI4NS1jNTNiY2RhMmFkNDIvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2E2N2RkNmItZjAyYy00MGI2
-        LWExOWMtZjE0OWNkZDA2NjNlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGNhM2MzNzQtOWFmYS00NzUy
+        LWIyODUtYzUzYmNkYTJhZDQyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2985,7 +3410,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2998,101 +3423,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:36 GMT
+      - Fri, 29 Jul 2022 08:58:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fcf58cccc49f4dbb812ccb57d44f1786
+      - e3f6f4aa5ab345cf9830752de3c3520a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3100,7 +3525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3113,7 +3538,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:36 GMT
+      - Fri, 29 Jul 2022 08:58:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3131,21 +3556,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e10a2d4085e042d78434ea5375f690ae
+      - 21bff8f4a9d245a2983f593a1130d143
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3153,7 +3578,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3166,37 +3591,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:36 GMT
+      - Fri, 29 Jul 2022 08:58:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb4c152f6003422b856b3c89791832a1
+      - d490d70228cb4c608abcb52dae2c8eb8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3212,8 +3637,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3241,8 +3666,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3270,8 +3695,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3289,10 +3714,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,7 +3738,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:36 GMT
+      - Fri, 29 Jul 2022 08:58:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3331,21 +3756,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b2e4910d1b442adbb2078b454a15273
+      - 1105e129ec374de286b99802d34418c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3353,7 +3778,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3366,7 +3791,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:36 GMT
+      - Fri, 29 Jul 2022 08:58:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3384,21 +3809,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 77cf7eda3cff4022b864610002efcbf3
+      - dab792bcdf0f48ee8728494c77425efd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7a67dd6b-f02c-40b6-a19c-f149cdd0663e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3406,7 +3831,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3419,7 +3844,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:36 GMT
+      - Fri, 29 Jul 2022 08:58:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3437,16 +3862,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5219dc09963c40f78a3ccc6405cacf2e
+      - cf521b20d1bb4ccba6f202818ed42bd8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:44 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_nonmatching_package_includion_filter_copies_no_content.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_nonmatching_package_includion_filter_copies_no_content.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 627d96f7ac384ec39eef10b5efaede2d
+      - 6d5b9019fa204a40af9d4d8798dd18c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '313'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iMzdhOGFjZS1hZTE5LTRjMjItODIzZC03YTcwZDFlMmY1YWUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMTo0OC43OTc4OTBa
+        cnBtL3JwbS81YzE2Y2U3NS01NmJhLTQ1ZDUtYmJhZS0xMjZjNmMzOGM0ODQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1Nzo0NS4xNzQ0NDBa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iMzdhOGFjZS1hZTE5LTRjMjItODIzZC03YTcwZDFlMmY1YWUv
+        cnBtL3JwbS81YzE2Y2U3NS01NmJhLTQ1ZDUtYmJhZS0xMjZjNmMzOGM0ODQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IzN2E4
-        YWNlLWFlMTktNGMyMi04MjNkLTdhNzBkMWUyZjVhZS92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzVjMTZj
+        ZTc1LTU2YmEtNDVkNS1iYmFlLTEyNmM2YzM4YzQ4NC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:55 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b37a8ace-ae19-4c22-823d-7a70d1e2f5ae/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58ba1cd5e8524b58ad46b979f3c88788
+      - 0e8df11642c54deab418d1323aeb50ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjNjY2YjNjLWJjOWMtNDkw
-        OS1iMjcxLTdmNDg4ZjI4OTk3NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4YjdmYWNlLTUwMWEtNGU2
+        ZC1hNjUwLWZiZTRkY2ZmMzMxZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66b96517647548448944e6e0a24bba4d
+      - 37cdd13d7c51461ea2a2c6a7f8260419
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3c666b3c-bc9c-4909-b271-7f488f289974/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/08b7face-501a-4e6d-a650-fbe4dcff331d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f712c7e5fff84870b793cc5ecf19631b
+      - ccbdbdafcab84a0aaed7f81dc9df5263
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2M2NjZiM2MtYmM5
-        Yy00OTA5LWIyNzEtN2Y0ODhmMjg5OTc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjIuMDU5ODE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDhiN2ZhY2UtNTAx
+        YS00ZTZkLWE2NTAtZmJlNGRjZmYzMzFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTYuMDA0NDgzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1OGJhMWNkNWU4NTI0YjU4YWQ0NmI5Nzlm
-        M2M4ODc4OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjIyLjA5
-        MzMxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MjIuMTQ0
-        NzQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZThkZjExNjQyYzU0ZGVhYjQxOGQxMzIz
+        YWViNTBjZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjU2LjA0
+        ODA4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NTYuMjUw
+        MDI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjM3YThhY2UtYWUxOS00YzIy
-        LTgyM2QtN2E3MGQxZTJmNWFlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWMxNmNlNzUtNTZiYS00NWQ1
+        LWJiYWUtMTI2YzZjMzhjNDg0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 237c02838dbb4ce9aa69d3fd6db4fd4f
+      - 5cb9c45ef7934f76b495b015c562de90
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 51337f369e69456c9433e9083552cace
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vOTZkNTgyNWEtMWY3Yi00OTcwLTg1YTUtYWM0ZDQ1NDdlNzEz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NTIuMTI2NzYz
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/96d5825a-1f7b-4970-85a5-ac4d4547e713/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5ac32cb4268b42dc9919558981cab586
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2ZWU0MGNlLWFiMDMtNDdj
+        OS1hNDZkLTM3MmFmYWUzMTFkMi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b6ee40ce-ab03-47c9-a46d-372afae311d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e9cbe25b7cd94ee38193111c5d11fb99
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjZlZTQwY2UtYWIw
+        My00N2M5LWE0NmQtMzcyYWZhZTMxMWQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTYuNDUzMzE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1YWMzMmNiNDI2OGI0MmRjOTkxOTU1ODk4
+        MWNhYjU4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjU2LjQ5
+        NjM1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NTYuNTI5
+        ODkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 55a4660aa4af46beb38252fdd6331ba3
+      - cc7e8e88efc54fb4980be6688926c19f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 879d7973090d4ab88b2300cc91fd9283
+      - 100aeef5ee9d477e96b38c0a53cfd331
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f9cb3f4118d640e2adecb9a68b8fd35d
+      - a6962647388d4561bb63edd6daaf0152
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db8c6cef6750410da506b77a1f18130e
+      - e0c4c8cd0b534ae2963cbcfc4f96ba2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:22 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - c69797e1c65249c0b14e7a72502dbcea
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/1451ac7d-c81e-44dd-9ec6-e1c264630cf0/"
+      - "/pulp/api/v3/remotes/rpm/rpm/f227e26e-4caf-4367-a8ec-39a18a6f6930/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3322bdce527e41259492f702edb0ac20
+      - e2efb9a75dd34d529ad7c0a2f60c1a2d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE0
-        NTFhYzdkLWM4MWUtNDRkZC05ZWM2LWUxYzI2NDYzMGNmMC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjIyLjUwNzYzM1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Yy
+        MjdlMjZlLTRjYWYtNDM2Ny1hOGVjLTM5YTE4YTZmNjkzMC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU3OjU2LjgzMDYwNVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjIyLjUwNzY1NFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU3OjU2LjgzMDYyNloiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/"
+      - "/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - acfb0c85e74745a1b6db29416bd66dc5
+      - 85aec5ac0f924ad2a7156072432f296e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vODVkMDQ4MzktMmQ4Mi00MWZhLWI1MDMtMTZlMWVhZjlkZGVmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjIuNjIzMzM3WiIsInZl
+        cG0vNTA3YWEyMjItZThmNC00OTJiLThlYzUtOTAyZGY5OGQ5YTUxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NTYuOTc3NTk0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vODVkMDQ4MzktMmQ4Mi00MWZhLWI1MDMtMTZlMWVhZjlkZGVmL3ZlcnNp
+        cG0vNTA3YWEyMjItZThmNC00OTJiLThlYzUtOTAyZGY5OGQ5YTUxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84NWQwNDgzOS0y
-        ZDgyLTQxZmEtYjUwMy0xNmUxZWFmOWRkZWYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81MDdhYTIyMi1l
+        OGY0LTQ5MmItOGVjNS05MDJkZjk4ZDlhNTEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a90653814dd4147aaf106f0eefb6bb9
+      - 34835440b1c4432d820990681c656a6d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMWU3N2UwZS01ZDM4LTQ1Y2EtOTZhYS05NDI0YTE5YmE1ZmMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMTo0OS40ODY5MTda
+        cnBtL3JwbS84YTQyNjZkYS1lZDg5LTRhNzMtOWViNS1jYWU1OTBhZTlhMTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1Nzo0Ni4xODIxMjFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMWU3N2UwZS01ZDM4LTQ1Y2EtOTZhYS05NDI0YTE5YmE1ZmMv
+        cnBtL3JwbS84YTQyNjZkYS1lZDg5LTRhNzMtOWViNS1jYWU1OTBhZTlhMTEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMxZTc3
-        ZTBlLTVkMzgtNDVjYS05NmFhLTk0MjRhMTliYTVmYy92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzhhNDI2
+        NmRhLWVkODktNGE3My05ZWI1LWNhZTU5MGFlOWExMS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/31e77e0e-5d38-45ca-96aa-9424a19ba5fc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eda4a45b645a4625af5389f95069fe2f
+      - 9ff4e4f79b1c452bb0d5ee768bf43f2d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmMDc2NWMwLTMwNDYtNGYw
-        OC1hNGNlLTE5Y2EzZjVhODc0ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgxMWFhNWRjLTVmODMtNDRm
+        YS1hYmY3LTE2ZTBhNTJiMmY0ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc80051145bd4484ae612bfd79e4a126
+      - cc181875c7ba456ea2ea53ae7ec18810
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYTgzNzM1NTktMDhjOC00ZjM5LWE2NmQtMjUwNTIzZDM2M2EwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjE6NDguNjgxMTIwWiIsIm5h
-        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
-        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
-        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
-        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyMTo0OS44NDYxNThaIiwiZG93bmxvYWRfY29uY3VycmVu
-        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
-        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
-        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
-        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
-        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+        cG0vMTA1YmY5YjctY2RlNi00MWNhLWFmOGMtNTI3YWZlNTZhOGM2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NDUuMDE4ODQyWiIsIm5h
+        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
+        ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
+        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
+        cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1Nzo0Ni43NDU5OTlaIiwiZG93bmxv
+        YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
+        Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
+        Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
+        InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
+        dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a8373559-08c8-4f39-a66d-250523d363a0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/105bf9b7-cde6-41ca-af8c-527afe56a8c6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9445f7b421d946a6818109220899f057
+      - 1888778259784fcb94c3f048225b6253
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmYjU2YTMwLTUyY2EtNGM2
-        Ny1iZTRlLTRlYmMxY2MyZDNlZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFhMjlkODQ0LTYxYjQtNDI1
+        Ny05MzZjLWRmMzQ4NDBmOGE5NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1f0765c0-3046-4f08-a4ce-19ca3f5a874d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/811aa5dc-5f83-44fa-abf7-16e0a52b2f4e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:22 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b667edc879e947fba100b084c8c7d5f6
+      - 0a85cf7179f446ba9cc5a82689f56c39
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWYwNzY1YzAtMzA0
-        Ni00ZjA4LWE0Y2UtMTljYTNmNWE4NzRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjIuODIzOTQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODExYWE1ZGMtNWY4
+        My00NGZhLWFiZjctMTZlMGE1MmIyZjRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTcuMjI0MDQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlZGE0YTQ1YjY0NWE0NjI1YWY1Mzg5Zjk1
-        MDY5ZmUyZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjIyLjg1
-        NTIzOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MjIuOTA3
-        MTMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5ZmY0ZTRmNzliMWM0NTJiYjBkNWVlNzY4
+        YmY0M2YyZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjU3LjI2
+        MzI4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NTcuMzU4
+        ODM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzFlNzdlMGUtNWQzOC00NWNh
-        LTk2YWEtOTQyNGExOWJhNWZjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGE0MjY2ZGEtZWQ4OS00YTcz
+        LTllYjUtY2FlNTkwYWU5YTExLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1fb56a30-52ca-4c67-be4e-4ebc1cc2d3ef/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1a29d844-61b4-4257-936c-df34840f8a95/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e8281956933411d8d9ddb501ca9c506
+      - 19c427df0e194f7bb6ddef762b3b8eff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWZiNTZhMzAtNTJj
-        YS00YzY3LWJlNGUtNGViYzFjYzJkM2VmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjIuOTEyOTIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWEyOWQ4NDQtNjFi
+        NC00MjU3LTkzNmMtZGYzNDg0MGY4YTk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTcuMzQxMjQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NDQ1ZjdiNDIxZDk0NmE2ODE4MTA5MjIw
-        ODk5ZjA1NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjIyLjk0
-        OTE0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MjIuOTg0
-        NTg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxODg4Nzc4MjU5Nzg0ZmNiOTRjM2YwNDgy
+        MjViNjI1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjU3LjQx
+        NjQ4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NTcuNDcw
+        NjgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E4MzczNTU5LTA4YzgtNGYzOS1hNjZk
-        LTI1MDUyM2QzNjNhMC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzEwNWJmOWI3LWNkZTYtNDFjYS1hZjhj
+        LTUyN2FmZTU2YThjNi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aae4a98b98e641f198ff6ec7b20a0861
+      - f1b63f5cb2934c0db700678282dbaf44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c0ec2d5fe9a841ada446d7e14a78f2db
+      - 84d387c231f047ceb43c2b8acfa85a93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4167037183154dc89f7013d41cbb4046
+      - 959f8d1ba12b4744b010453bb16b3ae6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf5a0998c126496aaa69e9d7fc128d95
+      - 9cf073bd0df7461dba04a5c7d71e25cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa165af13dcc459694285d81237fa915
+      - 7d71236ba4c34053bc4e5159d4ac3f8f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a877c70c3ef45bfab77609171c60555
+      - 3908759283af4a9b90dcdc3c3c291ae7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/"
+      - "/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33c780010cf44834906cb72a56792571
+      - b570f61978314f5ab0285d8ec8105e1e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZGMxZjVlZDQtZTc4MS00NWEyLTk1YzYtZGExMjZhZmE5ZjY5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjMuMzU4MDU0WiIsInZl
+        cG0vNjkxMjMzODUtNWJlYi00Mjg0LWI3M2MtOWUzNWQ1YWJhOGNkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NTcuOTAxMzg0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZGMxZjVlZDQtZTc4MS00NWEyLTk1YzYtZGExMjZhZmE5ZjY5L3ZlcnNp
+        cG0vNjkxMjMzODUtNWJlYi00Mjg0LWI3M2MtOWUzNWQ1YWJhOGNkL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kYzFmNWVkNC1l
-        NzgxLTQ1YTItOTVjNi1kYTEyNmFmYTlmNjkvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82OTEyMzM4NS01
+        YmViLTQyODQtYjczYy05ZTM1ZDVhYmE4Y2QvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:57 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/1451ac7d-c81e-44dd-9ec6-e1c264630cf0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/f227e26e-4caf-4367-a8ec-39a18a6f6930/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab22726a09ca47fbb1dd1efc643f7ecf
+      - 99e672220fee44289d95e6effb5c33c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FhYjViZjM2LTY3ZDItNDhj
-        OC1iZjUzLTU3MGZmNjJmNWZlNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VhZjVjYzM4LTg4MGMtNDRi
+        YS1iYTUxLTIyM2U4OWIzMjE0Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/aab5bf36-67d2-48c8-bf53-570ff62f5fe7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/eaf5cc38-880c-44ba-ba51-223e89b3214c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 703d747a440d42098fcfbadd9b07690d
+      - 0ee3cf436f67479c99403d2edd00dd00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWFiNWJmMzYtNjdk
-        Mi00OGM4LWJmNTMtNTcwZmY2MmY1ZmU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjMuNjI4MDQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWFmNWNjMzgtODgw
+        Yy00NGJhLWJhNTEtMjIzZTg5YjMyMTRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTguMjU4MjczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJhYjIyNzI2YTA5Y2E0N2ZiYjFkZDFlZmM2
-        NDNmN2VjZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjIzLjY1
-        ODQyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MjMuNjc5
-        NjYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5OWU2NzIyMjBmZWU0NDI4OWQ5NWU2ZWZm
+        YjVjMzNjMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjU4LjI5
+        NTEyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NTguMzE5
+        Mzg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE0NTFhYzdkLWM4MWUtNDRkZC05ZWM2
-        LWUxYzI2NDYzMGNmMC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2YyMjdlMjZlLTRjYWYtNDM2Ny1hOGVj
+        LTM5YTE4YTZmNjkzMC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE0NTFh
-        YzdkLWM4MWUtNDRkZC05ZWM2LWUxYzI2NDYzMGNmMC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2YyMjdl
+        MjZlLTRjYWYtNDM2Ny1hOGVjLTM5YTE4YTZmNjkzMC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:23 GMT
+      - Fri, 29 Jul 2022 08:57:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2e742d62f0de4367a9cf2c1a64bb265f
+      - db52c9ccf95640069d72202b0223e13e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0OWI3MWFlLTEzYTktNDgz
-        Ny04MTg1LWUxODM4MmE4MDI1MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2NTBkZjc0LWM3ZjMtNDNj
+        ZC05MDU2LTFkOWMxZjhmZTU3ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a49b71ae-13a9-4837-8185-e18382a80250/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6650df74-c7f3-43cd-9056-1d9c1f8fe57d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,82 +1787,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:26 GMT
+      - Fri, 29 Jul 2022 08:58:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f85f0ccb789c4e72bb2afb2581450a51
+      - d48931ac21f0404289308084ba4de229
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '599'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQ5YjcxYWUtMTNh
-        OS00ODM3LTgxODUtZTE4MzgyYTgwMjUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjMuODA3ODI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjY1MGRmNzQtYzdm
+        My00M2NkLTkwNTYtMWQ5YzFmOGZlNTdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTguNDI1NTM2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyZTc0MmQ2MmYwZGU0MzY3YTlj
-        ZjJjMWE2NGJiMjY1ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjIzLjgzODk1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        MjYuMzM3MzgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkYjUyYzljY2Y5NTY0MDA2OWQ3
+        MjIwMmIwMjIzZTEzZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3
+        OjU4LjQ3MTA3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        MDIuMjM1Njg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
         IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0
-        aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUi
-        OiJzeW5jLnBhcnNpbmcucGFja2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
-        InRvdGFsIjpudWxsLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3Nh
-        Z2UiOiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcu
-        YWR2aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRv
-        bmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZm
-        aXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtLzg1ZDA0ODM5LTJkODItNDFmYS1iNTAz
-        LTE2ZTFlYWY5ZGRlZi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJj
-        ZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS84NWQwNDgzOS0yZDgyLTQxZmEtYjUwMy0xNmUxZWFmOWRkZWYvIiwic2hh
-        cmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMTQ1MWFjN2QtYzgx
-        ZS00NGRkLTllYzYtZTFjMjY0NjMwY2YwLyJdfQ==
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzUwN2FhMjIyLWU4ZjQtNDkyYi04ZWM1LTkw
+        MmRmOThkOWE1MS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81
+        MDdhYTIyMi1lOGY0LTQ5MmItOGVjNS05MDJkZjk4ZDlhNTEvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZjIyN2UyNmUtNGNhZi00
+        MzY3LWE4ZWMtMzlhMThhNmY2OTMwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:26 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:02 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vODVkMDQ4MzktMmQ4Mi00MWZhLWI1MDMtMTZlMWVhZjlk
-        ZGVmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNTA3YWEyMjItZThmNC00OTJiLThlYzUtOTAyZGY5OGQ5
+        YTUxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:26 GMT
+      - Fri, 29 Jul 2022 08:58:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 835e2c6346174ead9343c4f556de5601
+      - 83b88557786541298118e301979bc546
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiYjc1ODZkLTI4MTYtNDEw
-        OC1hOGUxLTQ4MTMxOTQ3MDc2NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIxMjc4YTUzLTE0YjctNDNi
+        OC1iYTU1LTJmNmY0ZDM3NzNhNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:26 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cbb7586d-2816-4108-a8e1-481319470765/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/21278a53-14b7-43b8-ba55-2f6f4d3773a4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:26 GMT
+      - Fri, 29 Jul 2022 08:58:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22cc6898ca8649e9bf42c9431875ecfd
+      - 0c3311b1e031456995737c85fafc62c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2JiNzU4NmQtMjgx
-        Ni00MTA4LWE4ZTEtNDgxMzE5NDcwNzY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjYuNTczODI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjEyNzhhNTMtMTRi
+        Ny00M2I4LWJhNTUtMmY2ZjRkMzc3M2E0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDIuNTExMzc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjgzNWUyYzYzNDYxNzRlYWQ5MzQzYzRmNTU2
-        ZGU1NjAxIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuNjA0
-        NTM4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMjoyNi44MDEx
-        MjBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjgzYjg4NTU3Nzg2NTQxMjk4MTE4ZTMwMTk3
+        OWJjNTQ2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MDIuNTU1
+        MTU2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1ODowMi44NjM3
+        MjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNzJhNzM3
-        YjAtMTdiYy00YWM0LWE4OWQtNmY4ZDVkYTBmN2Q3LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTZmZWY4
+        YTEtMWIxOC00ZDAwLWExOWQtOWFmNDgzODAzYjdhLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vODVkMDQ4MzktMmQ4Mi00MWZhLWI1MDMtMTZlMWVh
-        ZjlkZGVmLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNTA3YWEyMjItZThmNC00OTJiLThlYzUtOTAyZGY5
+        OGQ5YTUxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:26 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:27 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0d9faa0642fa4d83a2256936abc89caf
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:27 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:27 GMT
+      - Fri, 29 Jul 2022 08:58:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 402f0c65035a4688891ac9b1c8c8e4e5
+      - '09f536ed79ce4bc4bf86844419ace0c7'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:27 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/a6fef8a1-1b18-4d00-a19d-9af483803b7a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:27 GMT
+      - Fri, 29 Jul 2022 08:58:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d687078a10ad406984829a23bd75bf09
+      - f231e320bbea4c9aab938eb01498eec5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYTZmZWY4YTEtMWIxOC00ZDAwLWExOWQtOWFmNDgzODAzYjdhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MDIuNTc5MjA3WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS81MDdhYTIyMi1lOGY0LTQ5MmItOGVjNS05MDJkZjk4ZDlhNTEv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzUwN2FhMjIyLWU4ZjQtNDkyYi04ZWM1LTkwMmRm
+        OThkOWE1MS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:03 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9hNmZlZjhhMS0xYjE4LTRkMDAtYTE5ZC05YWY0ODM4MDNiN2Ev
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4ed5a3fca3be4f69af5006cfb6934e83
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlZTBkMThmLTQ3ZWUtNGI4
+        Yy04NGZiLTI3ZmUxMzQxY2IwMi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1ee0d18f-47ee-4b8c-84fb-27fe1341cb02/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 73b1432c490c467c96323b762052fd94
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWVlMGQxOGYtNDdl
+        ZS00YjhjLTg0ZmItMjdmZTEzNDFjYjAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDMuMjI4NTAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI0ZWQ1YTNmY2EzYmU0ZjY5YWY1MDA2Y2Zi
+        NjkzNGU4MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjAzLjI3
+        NTg1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MDMuNDg2
+        OTk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNjU2
+        ZGY2ZjQtYmVlOC00NmI5LWI0MTItYTJkMjkyNzBlZDU5LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/656df6f4-bee8-46b9-b412-a2d29270ed59/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 46d2033642114409a22c1b6a6763afc1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzY1NmRmNmY0LWJlZTgtNDZiOS1iNDEyLWEyZDI5MjcwZWQ1OS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjAzLjQ2NjY2NFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYTZmZWY4YTEtMWIxOC00ZDAwLWExOWQt
+        OWFmNDgzODAzYjdhLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4f99790e7f3046429cbe713ce2869b8b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 67b5f06ccf4941028da4bd5f966982e0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a3dc6d443a704eb199e363a96531216d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:27 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:27 GMT
+      - Fri, 29 Jul 2022 08:58:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ff983898b72447092e9d1d854719959
+      - 1a25628159dd4491bdf148509cc4df34
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:27 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:27 GMT
+      - Fri, 29 Jul 2022 08:58:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c203edcadecb4169ae8fca9ede7df24e
+      - ee375ca10800410382863b3c97639506
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:27 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:27 GMT
+      - Fri, 29 Jul 2022 08:58:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 253bb699920c4e7c9737b2b67f3abc6b
+      - 54b0533bda06429fbb574a32b4161a79
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:27 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2540,7 +2965,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2553,7 +2978,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:27 GMT
+      - Fri, 29 Jul 2022 08:58:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2571,21 +2996,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f818d59f4d0344c19a05aa0d4ccb72fe
+      - 003cb2f328a642b19f42bde9563febff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkMGQxNmU2LTg0MGEtNDg2
-        OC04NThiLWI2NTk0M2VjMmRjOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyNjRiZTZlLWExNmEtNGMw
+        OS1iZDFhLTM1MzhmZjYyYmI0MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:27 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ed0d16e6-840a-4868-858b-b65943ec2dc8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7264be6e-a16a-4c09-bd1a-3538ff62bb41/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2606,51 +3031,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:27 GMT
+      - Fri, 29 Jul 2022 08:58:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7e3ceeef7d8a4ba9a8b696e458f48604
+      - 53aa3ca85a0a42c5b2a7f27009c6aa7d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWQwZDE2ZTYtODQw
-        YS00ODY4LTg1OGItYjY1OTQzZWMyZGM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjcuNjA5MjMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzI2NGJlNmUtYTE2
+        YS00YzA5LWJkMWEtMzUzOGZmNjJiYjQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDQuNTIxNDYxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmODE4ZDU5ZjRkMDM0NGMxOWEw
-        NWFhMGQ0Y2NiNzJmZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjI3LjY0ODUzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        MjcuNzc5NDMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwMDNjYjJmMzI4YTY0MmIxOWY0
+        MmJkZTk1NjNmZWJmZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjA0LjU2MzU0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        MDQuNzY1NzY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGMxZjVlZDQtZTc4
-        MS00NWEyLTk1YzYtZGExMjZhZmE5ZjY5LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjkxMjMzODUtNWJl
+        Yi00Mjg0LWI3M2MtOWUzNWQ1YWJhOGNkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:27 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2658,7 +3083,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2671,7 +3096,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:28 GMT
+      - Fri, 29 Jul 2022 08:58:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2689,21 +3114,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd8f6ba4bd284aebbe1a8df284b876cc
+      - 4c0d5aa79c8140aba20f30f52984bcd5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2711,7 +3136,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2724,7 +3149,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:28 GMT
+      - Fri, 29 Jul 2022 08:58:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2742,21 +3167,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f4e042d3178047d18474c934edc5b213
+      - 53aad7e22f45451dbd906fea61b791c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2764,7 +3189,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2777,7 +3202,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:28 GMT
+      - Fri, 29 Jul 2022 08:58:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2795,21 +3220,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e2f68387bad1489995fd5806801095e9
+      - aefcc88e38eb4044b59f2671a6768ef6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2817,7 +3242,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2830,7 +3255,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:28 GMT
+      - Fri, 29 Jul 2022 08:58:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2848,21 +3273,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a878f8ea4b8f4d718998876b891bf53e
+      - d6e4ba4a326e414483649ecc1ee4c501
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2870,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2883,7 +3308,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:28 GMT
+      - Fri, 29 Jul 2022 08:58:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2901,21 +3326,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9d04d836fa84094ba263083f3c793ff
+      - 85b5c09cabcd40939a808a715e5b3879
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2923,7 +3348,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2936,7 +3361,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:28 GMT
+      - Fri, 29 Jul 2022 08:58:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2954,16 +3379,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ced1a0632ac47c8bf5d43c6a3082d11
+      - 478d18002de642e784839fb98fd817da
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:28 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:05 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_duplicate_content.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_duplicate_content.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,127 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 54e75198167949f7831b56da0b3b3d66
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lNzY2NWE4OC1hMzY4LTQyNjQtYTJkYS1jOTA1YjBlYTNjZDkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo1Ni44NDgwMjJa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lNzY2NWE4OC1hMzY4LTQyNjQtYTJkYS1jOTA1YjBlYTNjZDkv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U3NjY1
-        YTg4LWEzNjgtNDI2NC1hMmRhLWM5MDViMGVhM2NkOS92ZXJzaW9ucy8xLyIs
-        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
-        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
-        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
-        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
-        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
-        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
-        ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e7665a88-a368-4264-a2da-c905b0ea3cd9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 7bceb085a55b4e5ebea4462cdd472068
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RhZWI2NzM1LWFhM2MtNGQy
-        NS1iZTY1LTAwYjUzNWNhN2U4Mi8ifQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +41,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1f256925489a4915b55966481c5a03ef
+      - 9724567a0da045d58c390467d98423fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/daeb6735-aa3c-4d25-be65-00b535ca7e82/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -183,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -196,72 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1d6fd9c12e9c4b65b1d7dd953ddcdccf
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGFlYjY3MzUtYWEz
-        Yy00ZDI1LWJlNjUtMDBiNTM1Y2E3ZTgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDMuMDY2ODc4WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3YmNlYjA4NWE1NWI0ZTVlYmVhNDQ2MmNk
-        ZDQ3MjA2OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjAzLjA5
-        ODMyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MDMuMjE1
-        OTM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTc2NjVhODgtYTM2OC00MjY0
-        LWEyZGEtYzkwNWIwZWEzY2Q5LyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +94,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4bd6af37b8b84dc993ee754126c83d15
+      - 8e1c86ce964a4def930134ad6efad7d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +147,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2a69fb75fa4f4fc0a6cb80ace06de2b9
+      - 62a3570af14a42a791bf7f6be326e69c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +200,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c81f6e4e25648138a786622d8d93fa2
+      - ae31db6a02e84db783b1811c3b21a369
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +222,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +235,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +253,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e12490416714717b49410700e5d570f
+      - 2867c6d267244d0599ec066d7298b274
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +275,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +288,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,21 +306,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73af24dc50bd41778bdff103107f162e
+      - d2d0f2696de34fc385599db339eb79c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -513,7 +328,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -526,7 +341,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -544,21 +359,74 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 676dfdd9620941aa81ff72940297010c
+      - 2de427d0158d456ab4d2db1c46bfc9ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 762a437369e6476eae840e08cc31f990
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +443,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +456,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/26bc707c-481d-47c7-aa18-364d118e8041/"
+      - "/pulp/api/v3/remotes/rpm/rpm/3bea4e12-9505-45b7-b70c-3a18dc9d7380/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +476,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f3f289f352c49f6af489f87f5b7f74d
+      - f3ddbeebd5a549e78fb95e0962bcbef9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzI2
-        YmM3MDdjLTQ4MWQtNDdjNy1hYTE4LTM2NGQxMThlODA0MS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjAzLjY4MTUwMloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzNi
+        ZWE0ZTEyLTk1MDUtNDViNy1iNzBjLTNhMThkYzlkNzM4MC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjQzLjYwNDAyNloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjAzLjY4MTUyMVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjQzLjYwNDA1MVoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +511,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +524,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +544,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c63db8b04f9e4dd5952ff4ba9fff730e
+      - 645341ad3857401480b82306f616682d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOThiMDMwNjAtZDY5Zi00MTEwLTg4YTktN2MyNTc0OWY5YTNlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MDMuNzk4OTE4WiIsInZl
+        cG0vZTJkMzEzY2EtOGE0Mi00NDM4LTg4YjgtZjFhNDA5MGE5ZGYwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6NDMuNzQ5NzQzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOThiMDMwNjAtZDY5Zi00MTEwLTg4YTktN2MyNTc0OWY5YTNlL3ZlcnNp
+        cG0vZTJkMzEzY2EtOGE0Mi00NDM4LTg4YjgtZjFhNDA5MGE5ZGYwL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85OGIwMzA2MC1k
-        NjlmLTQxMTAtODhhOS03YzI1NzQ5ZjlhM2UvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMmQzMTNjYS04
+        YTQyLTQ0MzgtODhiOC1mMWE0MDkwYTlkZjAvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +568,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +579,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +592,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c1e174f0b1547fa885c3b2e926fcb52
+      - cb0e6dabb9944e2b9213b84f88d5812c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xNTliZGFkYS00MTQ1LTRlOWUtOGFkZC1jMTZjNzYzODcwMDkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo1Ny41NjkwNzVa
+        cnBtL3JwbS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1OToxMS4yOTg2ODla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xNTliZGFkYS00MTQ1LTRlOWUtOGFkZC1jMTZjNzYzODcwMDkv
+        cnBtL3JwbS83MTQ1YWFlOS1hNzIyLTRmMGItOWNkNS01ZjFmYTNkZjgyMWMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzE1OWJk
-        YWRhLTQxNDUtNGU5ZS04YWRkLWMxNmM3NjM4NzAwOS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcxNDVh
+        YWU5LWE3MjItNGYwYi05Y2Q1LTVmMWZhM2RmODIxYy92ZXJzaW9ucy82LyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +634,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/159bdada-4145-4e9e-8add-c16c76387009/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7145aae9-a722-4f0b-9cd5-5f1fa3df821c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +645,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +658,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:03 GMT
+      - Fri, 29 Jul 2022 08:59:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +676,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e4ec169324f445b393706d4893a2bfb6
+      - 5d1b419c273e4fa9b420cd13dfad8a2f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5MTc1ZWYzLWM0M2UtNDUz
-        Yi05ZjU0LWE1YmJkMmY0ZTE2OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE0MmIzY2UwLTM4ODAtNDMz
+        NC1iNmRiLTU1ZmMwODM4Y2IzNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:03 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +698,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,72 +711,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 8e414c65b6cc4968943e961381e58a50
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMGRlNzM0M2ItNTFhNi00YTUyLWE0NGYtODMzY2ZiNTNlYmYyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NTYuNzAwNzA1WiIsIm5h
-        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
-        ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
-        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
-        cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo1Ny45NDU4NTNaIiwiZG93bmxv
-        YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
-        Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
-        Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
-        InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
-        dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/0de7343b-51a6-4a52-a44f-833cfb53ebf2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -916,31 +719,31 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '67'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf1a87fce8d54e6b8fdfcd30f5336acb
+      - 7414f4f88d694e94894caa39e007d7d5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjOTFjZWZiLWY0ZmMtNDgx
-        Yi04NGFhLTliYTcwNjUyNTFjOS8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/59175ef3-c43e-453b-9f54-a5bbd2f4e168/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/142b3ce0-3880-4334-b6db-55fc0838cb37/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +764,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d65c7def020042538be6c2a85e4a33e7
+      - 891b55c8f86046d89f7bd07eee494717
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTkxNzVlZjMtYzQz
-        ZS00NTNiLTlmNTQtYTViYmQyZjRlMTY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDMuOTU3ODIxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTQyYjNjZTAtMzg4
+        MC00MzM0LWI2ZGItNTVmYzA4MzhjYjM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NDMuOTc1MzgzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNGVjMTY5MzI0ZjQ0NWIzOTM3MDZkNDg5
-        M2EyYmZiNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjAzLjk4
-        ODY3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MDQuMDQ4
-        OTA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1ZDFiNDE5YzI3M2U0ZmE5YjQyMGNkMTNk
+        ZmFkOGEyZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjQ0LjAz
+        MTMwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NDQuMTM2
+        MTc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTU5YmRhZGEtNDE0NS00ZTll
-        LThhZGQtYzE2Yzc2Mzg3MDA5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzE0NWFhZTktYTcyMi00ZjBi
+        LTljZDUtNWYxZmEzZGY4MjFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4c91cefb-f4fc-481b-84aa-9ba7065251c9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1013,7 +816,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1026,72 +829,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - b88b99903a3d46078d272cb743aea0ac
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGM5MWNlZmItZjRm
-        Yy00ODFiLTg0YWEtOWJhNzA2NTI1MWM5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDQuMDQ3NzE0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjZjFhODdmY2U4ZDU0ZTZiOGZkZmNkMzBm
-        NTMzNmFjYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjA0LjA3
-        ODc0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MDQuMTIy
-        NTA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBkZTczNDNiLTUxYTYtNGE1Mi1hNDRm
-        LTgzM2NmYjUzZWJmMi8iXX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +847,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d40eb65f08342d2b1cde9ff08aa421a
+      - 98360cb581184bf787ce2cde7b8715f8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +869,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +882,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +900,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ee705f3b65b041c8afc0a26a082078fe
+      - 5a11f4646e74415eb833a20dcc594bf5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +922,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +935,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +953,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e4f1bf24f0984c7285603510b13b07fe
+      - 0fbfda891bd34f90a42c19f86d5eed80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +975,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +988,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1006,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 437a996c498543f09484436929259270
+      - 44e4e70a5a124adfaae170d45fcdbe5e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1041,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1059,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b313d6c5c4f44ac2913b5faad3c41a92
+      - 47e8beca26c34a0e90a2cdd70b906050
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1081,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1094,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1112,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf3cc19e53934562b2fe594c1619fe5e
+      - bb391da04693433eaca66e9786416f01
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1136,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1149,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/"
+      - "/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1169,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b74d8fb5df314ee0bac926096795534e
+      - 4bcf003aa0b144e190fd7b1f40d1d789
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYWY0NjdkMzQtZGIwOC00OTBhLWIxZWItNTMxOWIyOGQxYTBmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MDQuNTA0NjAyWiIsInZl
+        cG0vNmExMWE0MTQtYzVlMy00NTFmLWI5YWYtM2RhNTRhYmVjNTY0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6NDQuNzAwNzI5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYWY0NjdkMzQtZGIwOC00OTBhLWIxZWItNTMxOWIyOGQxYTBmL3ZlcnNp
+        cG0vNmExMWE0MTQtYzVlMy00NTFmLWI5YWYtM2RhNTRhYmVjNTY0L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hZjQ2N2QzNC1k
-        YjA4LTQ5MGEtYjFlYi01MzE5YjI4ZDFhMGYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82YTExYTQxNC1j
+        NWUzLTQ1MWYtYjlhZi0zZGE1NGFiZWM1NjQvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1192,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:44 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/26bc707c-481d-47c7-aa18-364d118e8041/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/3bea4e12-9505-45b7-b70c-3a18dc9d7380/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1212,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1225,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1243,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7204bba13a124241909e5099511af219
+      - 2c0d14a77f9b4a63a6c23c70a15c784b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjMDhlNWFiLTY5ZTgtNDQy
-        MC1hNjQ3LTljNmFlYTU4ODQzNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlMTRiMWI3LWRiNjgtNDdm
+        OC05NjBjLTc5ZGY1OTMxMjkyOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0c08e5ab-69e8-4420-a647-9c6aea588437/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0e14b1b7-db68-47f8-960c-79df59312928/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1278,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:04 GMT
+      - Fri, 29 Jul 2022 08:59:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f961051fae064d9f94c2e9a540b02f7f
+      - 541dc43e4e264260812da7d6df4e80c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGMwOGU1YWItNjll
-        OC00NDIwLWE2NDctOWM2YWVhNTg4NDM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDQuNzgwODkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGUxNGIxYjctZGI2
+        OC00N2Y4LTk2MGMtNzlkZjU5MzEyOTI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NDUuMDcyNjY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI3MjA0YmJhMTNhMTI0MjQxOTA5ZTUwOTk1
-        MTFhZjIxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjA0Ljgx
-        MjM0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MDQuODM0
-        NzAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyYzBkMTRhNzdmOWI0YTYzYTZjMjNjNzBh
+        MTVjNzg0YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjQ1LjEy
+        MjkzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NDUuMTQ5
+        MzQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzI2YmM3MDdjLTQ4MWQtNDdjNy1hYTE4
-        LTM2NGQxMThlODA0MS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzNiZWE0ZTEyLTk1MDUtNDViNy1iNzBj
+        LTNhMThkYzlkNzM4MC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:04 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzI2YmM3
-        MDdjLTQ4MWQtNDdjNy1hYTE4LTM2NGQxMThlODA0MS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzNiZWE0
+        ZTEyLTk1MDUtNDViNy1iNzBjLTNhMThkYzlkNzM4MC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1347,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:05 GMT
+      - Fri, 29 Jul 2022 08:59:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1365,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd276024cfe14936aa815e93167ce2a2
+      - 5d20753d76c544d1ba0f74acda6ab926
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyZGNhMzQ2LWI4YzUtNGE5
-        Zi1iZmY3LWIwYjE0YTE4OGNjZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzYjM2MmMxLWMzN2EtNGYz
+        NS1iNGNhLTI4NTFiMjhiOTQ0My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:05 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/92dca346-b8c5-4a9f-bff7-b0b14a188ccd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a3b362c1-c37a-4f35-b4ca-2851b28b9443/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1400,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:06 GMT
+      - Fri, 29 Jul 2022 08:59:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 07ba6cff6b3f42d0a81112d8d1abce37
+      - 3cc9404080ac403481dea7419d70a99f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '597'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTJkY2EzNDYtYjhj
-        NS00YTlmLWJmZjctYjBiMTRhMTg4Y2NkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDUuMDI3Mjc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTNiMzYyYzEtYzM3
+        YS00ZjM1LWI0Y2EtMjg1MWIyOGI5NDQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NDUuMzE3MzQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmZDI3NjAyNGNmZTE0OTM2YWE4
-        MTVlOTMxNjdjZTJhMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjA1LjA1ODAzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MDYuNjgxODUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI1ZDIwNzUzZDc2YzU0NGQxYmEw
+        Zjc0YWNkYTZhYjkyNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjQ1LjM2MTMyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        NDkuMjkyMjc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1447,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vOThiMDMwNjAtZDY5Zi00MTEwLTg4YTkt
-        N2MyNTc0OWY5YTNlL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        Lzk4YjAzMDYwLWQ2OWYtNDExMC04OGE5LTdjMjU3NDlmOWEzZS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS8yNmJjNzA3Yy00ODFk
-        LTQ3YzctYWExOC0zNjRkMTE4ZTgwNDEvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2UyZDMxM2NhLThhNDItNDQzOC04OGI4LWYx
+        YTQwOTBhOWRmMC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9l
+        MmQzMTNjYS04YTQyLTQ0MzgtODhiOC1mMWE0MDkwYTlkZjAvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vM2JlYTRlMTItOTUwNS00
+        NWI3LWI3MGMtM2ExOGRjOWQ3MzgwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:06 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:49 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOThiMDMwNjAtZDY5Zi00MTEwLTg4YTktN2MyNTc0OWY5
-        YTNlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZTJkMzEzY2EtOGE0Mi00NDM4LTg4YjgtZjFhNDA5MGE5
+        ZGYwL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1488,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:06 GMT
+      - Fri, 29 Jul 2022 08:59:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1506,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9ac1fef933d43c8a76d208203f9e52a
+      - 73abd3c5699040eaa5a55ab2c5c80590
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyMmVhZGEyLTFkMjktNGU0
-        ZS05MmIxLWNkYzcxNGMyNjhmMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg1ZTVjNzc5LWEzOGItNGJm
+        Yy1iNWJjLTAxMzY5NzA4ZDJjOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:06 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/322eada2-1d29-4e4e-92b1-cdc714c268f3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/85e5c779-a38b-4bfc-b5bc-01369708d2c9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1541,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ff0d4309e2140c486970bed45ad4c1d
+      - 6d9ad08d088f4db5bf10ca463d4eea68
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzIyZWFkYTItMWQy
-        OS00ZTRlLTkyYjEtY2RjNzE0YzI2OGYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDYuOTU5NTQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODVlNWM3NzktYTM4
+        Yi00YmZjLWI1YmMtMDEzNjk3MDhkMmM5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NDkuNTY3MTYxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImM5YWMxZmVmOTMzZDQzYzhhNzZkMjA4MjAz
-        ZjllNTJhIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MDYuOTkz
-        NTQ5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzowNy4xNzQ4
-        MzlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjczYWJkM2M1Njk5MDQwZWFhNWE1NWFiMmM1
+        YzgwNTkwIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NDkuNjE2
+        ODEzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1OTo0OS45Njkz
+        MzFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNWEwNTBk
-        NmYtNzM5Yy00OTkzLWI4ODUtNjM3NmM4NjJjOTFlLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMGI4MjI4
+        NjQtMjc2NS00M2RlLWIxOWItOTk3MTZiYzk0ZTdkLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOThiMDMwNjAtZDY5Zi00MTEwLTg4YTktN2MyNTc0
-        OWY5YTNlLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZTJkMzEzY2EtOGE0Mi00NDM4LTg4YjgtZjFhNDA5
+        MGE5ZGYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1598,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,35 +1611,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c0330cfd782d4359af8cc32acd0fa0a9
+      - 0f5b94a45cbe4407bb8027aada723b7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/0b822864-2765-43de-b19b-99716bc94e7d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4609171c218543e08c0e1a9f7e822308
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMGI4MjI4NjQtMjc2NS00M2RlLWIxOWItOTk3MTZiYzk0ZTdkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6NDkuNjQ2NTUyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMmQzMTNjYS04YTQyLTQ0MzgtODhiOC1mMWE0MDkwYTlkZjAv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2UyZDMxM2NhLThhNDItNDQzOC04OGI4LWYxYTQw
+        OTBhOWRmMC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:50 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8wYjgyMjg2NC0yNzY1LTQzZGUtYjE5Yi05OTcxNmJjOTRlN2Qv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a2db20a5ef0e48faa2eb5715d9e44759
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0MTc0ZGJjLTIxMzItNDBl
+        ZC04ZTY4LTIzOGUwNmUwNmIyNi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/94174dbc-2132-40ed-8e68-238e06e06b26/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 060f30ec011e46aebaddcc2b637f16e8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQxNzRkYmMtMjEz
+        Mi00MGVkLThlNjgtMjM4ZTA2ZTA2YjI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTAuMjc4NTg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhMmRiMjBhNWVmMGU0OGZhYTJlYjU3MTVk
+        OWU0NDc1OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjUwLjMy
+        MDg2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NTAuNTQx
+        MjI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNWE2
+        NjVkOGQtYmNiOC00MWEzLWJjMTYtNTIwZDk0ZTM0OGYxLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/5a665d8d-bcb8-41a3-bc16-520d94e348f1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0cbbf35bd4a94a03a5be32517262283d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzVhNjY1ZDhkLWJjYjgtNDFhMy1iYzE2LTUyMGQ5NGUzNDhmMS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjUwLjUyMTcwMloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMGI4MjI4NjQtMjc2NS00M2RlLWIxOWIt
+        OTk3MTZiYzk0ZTdkLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 542cd12bf9304b18b5d6360d28c30d46
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
         LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
         YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
@@ -1909,24 +1947,24 @@ http_interactions:
         IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
         cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
         X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
         aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
         SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
         YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
         cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
         bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
         Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
         NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
         QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
         YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
         MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
         cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
         LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
         ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
@@ -1934,244 +1972,244 @@ http_interactions:
         dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
         dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
         OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
         LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
         OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
         Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
         ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
         b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
         LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
         YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
         Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2179,7 +2217,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2192,7 +2230,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2248,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 887236b144a94a5a9d5b208ef2630d0e
+      - f84be88f786547bb8d2524f0c0c368c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2270,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2283,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9abf424b4fa64b65ab0e8035df220d45
+      - 406f6ca7462a4e469c15ba033a37b8c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2329,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2358,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2387,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2406,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2417,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2430,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2448,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0371f0ac1c1a4d549410bc024ef9a43c
+      - 541cd716995e4c0287131649861aef3b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2470,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2483,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2501,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 04244c6f28c54d069898876b55912def
+      - 28452c1b925c458cbab5895c2d39bbd8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2536,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2554,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e20301f6d2c542c88f3d32ca504681d2
+      - 9d938c39b17a4845ae5c0b9faa1c16e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2576,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2589,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2607,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e55c586f75fd4360be698c266f0841ed
+      - 4de4f1f107f94a359450520e1bccafc6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +2629,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +2642,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:07 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +2660,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d2178ebe6f4640c0a922e437fd6601ab
+      - 231afc118171479c8bbcec6d99a8d1ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:07 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +2695,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +2713,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d092a04146a048bbaf81c33523b14ae6
+      - 86d7fb9db0a84a5595e0ad4fa6fb9588
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +2735,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +2748,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +2766,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95bbe9a22f3549bba43fe8089a405386
+      - d33339f7ff72427a9ad67f23a8b8dd2f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +2790,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +2803,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,89 +2821,89 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e08247b621744a1b092eaccf0a7a115
+      - 34796aca983e493a9ef2bad141c153d8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2ZjEyYWNjLTg2OWUtNDYw
-        Ny04OTJmLTNkNWJiNjc0MjllYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlZWQxNjA0LTlkNTAtNGJk
+        Yi05MWQ5LTY2ZTM5Zjg2MWY5ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80ZDYyYjA2Mi01MTkxLTQyZWQtYTU4NC04MWExZDhl
-        NGRhZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NjAxNWRkYzktNWZlOS00ZTgwLTg1OTItMzdjZDg3ZGVhMTQ4LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzhmZDYyODhiLWU2ODMt
-        NDZlZi05Yjk0LWQwZTkwNGI5ZjY4Yi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy85MGE2YzZhMS0zODY1LTQyZGEtYWZhOS01MTU2
-        NTFlOTRjN2YvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3MjMtMGI3NS00
-        ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy8xYTU3NjVlZS03MDc4LTQzMzgtYTAzNi1mZDkyNzMw
-        NDUxOTQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFm
-        MjQ0NjIxLTBjYmItNGJlOC05NjIzLTNiZGRjM2IxMGViMS8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ1ZTY2MTgtMGIwZC00Yjlm
-        LTlkOGQtMTVjNDgxMTg4Yzk1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy8yZDYyY2Y4NC00YzU1LTQ4OTQtOTQ0Zi04NjI3Mzc5NzU2
-        ZDIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0Yzhk
-        MGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFl
-        ZTYtOTY0MWZiM2Y1YzUxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02Mjk3NTQ5YjAzODgv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwMWJhMDM3
-        LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEt
-        N2E3YTI4NWIwZDNiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy83NzAyYmFkNi01ZDc2LTQ0YWQtOTlhZi1iMzIwMzUwNDZlYmUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdlZTEyZjljLTE3
-        NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0
-        OGVhZWY1ZmEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUt
-        NGU3Yi04YjBiLWJmMTk4ZGNiNjIxNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvYThjMzk2MzItZWNlOC00MzZiLWJkMDctYjg0MDdh
-        M2VmODcwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9h
-        YWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRkMjgwZjVlZDMvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I2NmY3MGRhLTU5ZDgtNDNi
-        Ny04ZGEyLWMyYjExMGExZjFiZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00OGIxLWEwZDYtY2Y3YTk4YWZk
-        YzU1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOGU2
-        NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2YxNGJiYjUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2JhZjI0YzFhLTBlMDctNDE2ZS04
-        NGE3LWVlNDU3MjMyYjA1ZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvYzFkNjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEy
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMzY0ZTky
-        ZS0xNjQxLTRjZWItODBiMC05NDk5OWQyMTljNDQvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NkZTc1MDU0LTQyZDktNDBlZS04ZWU1
-        LTA5NTFkZjMxNzVmYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2Y2ItYzI1M2E2ZmU1NTA5LyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDZiNzk5Ni00
-        MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZm
-        ODUwYjkyNmU1Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZTU3NjA5MGYtZWYwZS00YWVmLWIzYjctMmEzODI2ZDAxZDZjLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5
-        ZDlkMTE2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZWMyN2QzNTktOTM4OC00ODdjLWIyY2EtZGVkM2UyN2ZlNmRhLyJdfQ==
+        cG0vYWR2aXNvcmllcy8yMjUwZjE3YS1iYzE4LTRjZTEtOGM2YS0wN2M0ZjA2
+        ODI1NGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NjZmMzRmMWEtMzcwNC00ODNjLThjNTctMjNiMzllZGE1NWRiLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzc3ZmUyNzVhLTBkZTct
+        NDk5NC1iMGUzLWUzNjE5NmViZjdmZi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFh
+        NDRjZGRlYjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFhOGY5NTIxNThiYi8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMtMTQ4MS00
+        ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDItYWY0My0zODAzMTM2
+        ZDEyMmEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgtZjZkZC00NDY3
+        LWI4ZWItNWNjYzBkNmRhNjhhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy8xNWM5MTA0Zi0xMjMzLTQ2YzQtYmY3My03NTE4MThmYzZm
+        MTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzMyZGE5
+        NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzMxOWNmYTAtZGRmYy00M2MwLThh
+        NmUtZDFkOTlkNDFiNmQ4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy80NGU4OTAwZC03MjIxLTQ0MDgtOTAwNS0xM2E5M2IzOTJhMGQv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5M2E0ZWIy
+        LWQ3MzktNDA5Mi04OTZmLTgzNjMwZmYzYzRmYi8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMt
+        NjNkNmJjZWQ3YmIzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy82ZGM4YzA3Ni1kNTFkLTQxZGQtYjQ1NS04MzRjMmY4ZDU4OGMvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZlYjVkZTgxLWQ2
+        MDUtNDkzMS04ZTY0LTQ2ZTAxZjE1MzAwMy8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNmYxYzkwYjAtYTc4Ny00OGNjLTgwY2ItZmNh
+        Mzk4MDAwYzc2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy83MzNhNGEwMC04ODRlLTRhMDEtYjI0MC02ZTM4YzNlZTczYjkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2MjlmMzBhLTE0Zjct
+        NDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvOGFlZjg5YjAtZDNiMy00ZDQyLWJiZTEtZmEwZDg5
+        MDEzMzUxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
+        YjgzYTg5Ny01ODRjLTQ2YTItODI3Zi04YjA3ZGFlOTdiYWYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzkyYjY2YWNiLTYwYjktNGVm
+        NC1iNTFhLTlhYjZhNzUwMGY4Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOTliNmFmZWYtZjIxYi00OWY5LWEzNmItODUxODAzM2Yw
+        MzYwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hMGIy
+        ZmZjYi1iMzgwLTRhYjktYmI4Yi00MjljNGY5YmZjN2IvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1i
+        ZDJiLTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvYTVjZGJkZGUtYmNhOC00NTI5LTliNDEtYzdiZTgxZjc5MjQ4
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFm
+        MC01NmY4LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NhZjM4MDc5LWUwNTYtNDRlNy05NjNl
+        LWUyYzIzM2M4ZmY4NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUxN2NkLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJlMC1i
+        ZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4OTFhLWYyMjItNDkyOS1hZjJkLWM5
+        MTAwYTQ4YTZjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTExNzRkYjEtNzYxOS00YzUwLTljYzctMmM4MmFlNzg3ODhjLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNDk3ZTBlZS0zYmE5
+        LTRhM2UtYTdiYS1kYjI1MDU5MWIyMzIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzL2U0YTgyMmQ2LTRlZjQtNDZmZS1hMjdjLTIxM2Jm
+        OGVhOWRmNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        ZjJkZmYxM2UtZjg5Mi00Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2878,7 +2916,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2896,21 +2934,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e95deb049c5c43acb186b2a7d91ab787
+      - 4b25791629e84622b828949d5a931066
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwMjY4NjdkLTAzOTYtNDU2
-        MC04NmM0LWNiNmU0MTgwMWYzNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0YjdmYzZiLWQ5OWQtNDk3
+        ZC05N2UxLTRkMWYyYjRmNzdiYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6026867d-0396-4560-86c4-cb6e41801f34/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f4b7fc6b-d99d-497d-97e1-4d1f2b4f77bc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2931,53 +2969,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 92d50b2602a840c6979aea5154b170a4
+      - 9f8f1194c5f14156a3b53bd053ddcf62
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjAyNjg2N2QtMDM5
-        Ni00NTYwLTg2YzQtY2I2ZTQxODAxZjM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDguMTQ1MTY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjRiN2ZjNmItZDk5
+        ZC00OTdkLTk3ZTEtNGQxZjJiNGY3N2JjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTIuMDQ3Mzg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlOTVkZWIwNDljNWM0M2FjYjE4
-        NmIyYTdkOTFhYjc4NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjA4LjI5MjA3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MDguNDM1MTYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0YjI1NzkxNjI5ZTg0NjIyYjgy
+        ODk0OWQ1YTkzMTA2NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjUyLjI2MjcyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        NTIuNDk5MDU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hZjQ2N2QzNC1kYjA4LTQ5MGEtYjFlYi01MzE5YjI4ZDFhMGYvdmVyc2lv
+        bS82YTExYTQxNC1jNWUzLTQ1MWYtYjlhZi0zZGE1NGFiZWM1NjQvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWY0NjdkMzQtZGIwOC00OTBh
-        LWIxZWItNTMxOWIyOGQxYTBmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmExMWE0MTQtYzVlMy00NTFm
+        LWI5YWYtM2RhNTRhYmVjNTY0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2985,7 +3023,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2998,101 +3036,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8e3ba19937d84a3ca59f39ee90018ddc
+      - ef6bcd4fffae46c198f79951fef61248
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3100,7 +3138,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3113,7 +3151,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3131,21 +3169,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ed9e7bf45b042b3bb9e88ef34402be0
+      - 4549221c2ab742bbb29c255f5b7ce646
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3153,7 +3191,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3166,37 +3204,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eac253f1270f4c7b900aaa1a57b88313
+      - b90ae5d5028f4b809358ddc70bc4fc5e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3212,8 +3250,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3241,8 +3279,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3270,8 +3308,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3289,10 +3327,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3338,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,7 +3351,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3331,21 +3369,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b31b1e754b17460b95bfedce6ffc59c2
+      - 6db4611199d34720a3af4a515db94327
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3353,7 +3391,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3366,7 +3404,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:08 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3384,21 +3422,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7fd0d8d804f94f44b4823d0444c31bf9
+      - '0315080558b04db68f03c32da11bbdff'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:08 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3406,7 +3444,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3419,7 +3457,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:09 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3437,21 +3475,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb18515e646e468996cbac09b27afc06
+      - bfc61af733f84ec9a7def8a1de84decf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:09 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3459,7 +3497,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3472,7 +3510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:09 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3490,21 +3528,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 40ff1e2d675b487c93f3efd1f5bf6800
+      - 0db1c1f523384cfabe146bda776ffa56
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:09 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3512,7 +3550,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3525,7 +3563,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:09 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3543,21 +3581,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3aae9e00c4f54ebebc06f0fc06d506d5
+      - f180bdaf802348c0bbf574f5074f6217
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:09 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3565,7 +3603,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3578,7 +3616,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:09 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3596,21 +3634,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 19ae81b398084418b0d788933e465dd5
+      - 73fede04c2914c4dbc5b9b61c33b136b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:09 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3618,7 +3656,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3631,7 +3669,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:09 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3649,21 +3687,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bdbf84abc40144efbca6d0145c2066d2
+      - 799f61e632e64d60bfdd9f97f7a405f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:09 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3673,7 +3711,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3686,7 +3724,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:09 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3704,32 +3742,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21690ccd8c7943ab8b4b009e329cbac2
+      - 1568e8c638924aa18d03eaf4190100de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1MWViMzk3LWNhMGQtNGNm
-        NS05ZDIxLWJkODU3Y2Q2Y2FmNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IwYWZkMmIzLTdmMGMtNDFl
+        My05OWExLWE5ODIxZTNiNzRkNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:09 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvZTVjYWUzZjMtYjJkMC00MjJjLTllOTEtOGVkZDlkOWQx
-        MTYyLyJdfQ==
+        cG0vcGFja2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUx
+        N2NkLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3742,7 +3780,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:09 GMT
+      - Fri, 29 Jul 2022 08:59:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3760,21 +3798,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 586833dbd70e4a839c03ad7dbfce2e42
+      - 40746db1f51c4b6f86ebfdb43112757c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4YThjNzMwLTZhMDQtNDMy
-        NS05MGYwLWY2OTRhMTNkNTFlZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwOGM5NDg5LTExZjEtNGE5
+        ZC04MjE2LWZjOTQ2ZDYxZThmYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:09 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/18a8c730-6a04-4325-90f0-f694a13d51ef/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/908c9489-11f1-4a9d-8216-fc946d61e8fb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3795,53 +3833,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:09 GMT
+      - Fri, 29 Jul 2022 08:59:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 167562f9c1674d628f7779b2628df52f
+      - 01e7a0556f324e85845cbe26ba2f7368
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMThhOGM3MzAtNmEw
-        NC00MzI1LTkwZjAtZjY5NGExM2Q1MWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MDkuNDY3MTAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTA4Yzk0ODktMTFm
+        MS00YTlkLTgyMTYtZmM5NDZkNjFlOGZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTMuNzc1OTg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ODY4MzNkYmQ3MGU0YTgzOWMw
-        M2FkN2RiZmNlMmU0MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjA5LjYyNDI3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MDkuNzYxMTMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0MDc0NmRiMWY1MWM0YjZmODZl
+        YmZkYjQzMTEyNzU3YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjU0LjAzMjI4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        NTQuMjcwODEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hZjQ2N2QzNC1kYjA4LTQ5MGEtYjFlYi01MzE5YjI4ZDFhMGYvdmVyc2lv
+        bS82YTExYTQxNC1jNWUzLTQ1MWYtYjlhZi0zZGE1NGFiZWM1NjQvdmVyc2lv
         bnMvMy8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWY0NjdkMzQtZGIwOC00OTBh
-        LWIxZWItNTMxOWIyOGQxYTBmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmExMWE0MTQtYzVlMy00NTFm
+        LWI5YWYtM2RhNTRhYmVjNTY0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:09 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3849,7 +3887,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3862,41 +3900,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:10 GMT
+      - Fri, 29 Jul 2022 08:59:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb54082210ce4bbe8c7d5f04d08d4b22
+      - e9a1124a48e7477caf8ff1cb40601650
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDExNjIv
+        YWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3Y2Qv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:10 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3904,7 +3942,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3917,7 +3955,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:10 GMT
+      - Fri, 29 Jul 2022 08:59:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3935,21 +3973,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 79af471cf9964e2aa94836f37bdd35c1
+      - d5de62168e394b0d8f18a5fe719c6cb6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:10 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3957,7 +3995,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3970,7 +4008,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:10 GMT
+      - Fri, 29 Jul 2022 08:59:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3988,21 +4026,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 670007c2cf6944a2ad82cdd669ab248d
+      - 9ac558c0f5b44ea8ad2e5fb0f96bceea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:10 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4010,7 +4048,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4023,7 +4061,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:10 GMT
+      - Fri, 29 Jul 2022 08:59:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4041,21 +4079,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9a7d4f3f51ab46598407016795c99aa8
+      - 7b0def93ec2a4115bed3824bc5b5cdf6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:10 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4063,7 +4101,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4076,7 +4114,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:10 GMT
+      - Fri, 29 Jul 2022 08:59:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4094,21 +4132,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 467b1de219ea483198b2948a1ed25685
+      - fd88c2700b7749ef9ca9c72acbd49bef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:10 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4116,7 +4154,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4129,7 +4167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:10 GMT
+      - Fri, 29 Jul 2022 08:59:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4147,16 +4185,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 154bdfa3c57046a58e1a498392947023
+      - ed594c06176342e59dced9f9df84c46c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:10 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:54 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_errata_exclusion_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_errata_exclusion_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db682a3c4e2e4d2aaae8e76b64cdcc9e
+      - 61c7354afd7249b4b131e94e4478d72a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85OGIwMzA2MC1kNjlmLTQxMTAtODhhOS03YzI1NzQ5ZjlhM2Uv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzowMy43OTg5MTha
+        cnBtL3JwbS81YWQ3ODliMC1iNTYzLTQ2ZWQtOWE5MS05YTg0Njk4NjliYWEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODozMS4xNzE1NTRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85OGIwMzA2MC1kNjlmLTQxMTAtODhhOS03YzI1NzQ5ZjlhM2Uv
+        cnBtL3JwbS81YWQ3ODliMC1iNTYzLTQ2ZWQtOWE5MS05YTg0Njk4NjliYWEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk4YjAz
-        MDYwLWQ2OWYtNDExMC04OGE5LTdjMjU3NDlmOWEzZS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzVhZDc4
+        OWIwLWI1NjMtNDZlZC05YTkxLTlhODQ2OTg2OWJhYS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:45 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/98b03060-d69f-4110-88a9-7c25749f9a3e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/5ad789b0-b563-46ed-9a91-9a8469869baa/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 665371e790474ec598b31a8c3316d756
+      - ecf3e373209e4ace86e1d4dfcfc6406b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2YzllMThmLWM5MjUtNGJk
-        NC04ZTU0LWRlNjc0YzE4NzRlMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyNTJiOWJlLWY2MTUtNDAw
+        Yi1iMmIxLTU0OTU1MDFkMDIyNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f3e04bf6f5bb4abeb1300cdaf08b3a8e
+      - 0c70b1d8b27b4f0d95be43d5d2d5ac11
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/86c9e18f-c925-4bd4-8e54-de674c1874e0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f252b9be-f615-400b-b2b1-5495501d0225/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 61f710437e6247c48fbf286fcdb85c64
+      - a6279ff2fb3b4cfe92c886d5dde965c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODZjOWUxOGYtYzky
-        NS00YmQ0LThlNTQtZGU2NzRjMTg3NGUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTEuMzM5MjIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjI1MmI5YmUtZjYx
+        NS00MDBiLWIyYjEtNTQ5NTUwMWQwMjI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDUuNTUxMjk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NjUzNzFlNzkwNDc0ZWM1OThiMzFhOGMz
-        MzE2ZDc1NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjExLjM3
-        NDY5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTEuNDk1
-        MzEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlY2YzZTM3MzIwOWU0YWNlODZlMWQ0ZGZj
+        ZmM2NDA2YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjQ1LjU5
+        Njc1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NDUuODIx
+        OTgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOThiMDMwNjAtZDY5Zi00MTEw
-        LTg4YTktN2MyNTc0OWY5YTNlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWFkNzg5YjAtYjU2My00NmVk
+        LTlhOTEtOWE4NDY5ODY5YmFhLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d89389a6c7374c0a89fdf460b9536c98
+      - c11ee610a77e4c00b59b0136cfb6eecc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 88b2cb24a885442c9518c2f4b8f422db
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZmU5YmMzMzYtMzUyYS00ODMxLTk2OGUtOTA5OTFlNTcxMmIw
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NDEuNDg0NTAx
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:45 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/fe9bc336-352a-4831-968e-90991e5712b0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f2eb6ba88d4146508d52f7d57233521f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgxN2M0N2Q4LWYzY2QtNDE3
+        ZC1hZTI2LWQ5ZmNkM2NiOGViNi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/817c47d8-f3cd-417d-ae26-d9fcd3cb8eb6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b702c44643a4941bebdcea181978765
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODE3YzQ3ZDgtZjNj
+        ZC00MTdkLWFlMjYtZDlmY2QzY2I4ZWI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDYuMDMzNDUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmMmViNmJhODhkNDE0NjUwOGQ1MmY3ZDU3
+        MjMzNTIxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjQ2LjA5
+        OTUyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NDYuMTYx
+        NTA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3c52c5aa5cf4429c911412c901c6b9b6
+      - 04d8cd8568404335a35b863f55eb11f5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 85d7af6870744b64ada16e472b65fb87
+      - 39699d1abb0b4c91bc4bf8cb823fa504
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e24928aa0e641fca28a46f11bc96d1b
+      - 2eee2afadf2e4b02baf48785b987c31e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e5862e694a74c6dab10d3f0dc57378a
+      - ba9a8fc5a790432b99112256713e6045
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:11 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1c918f21088349f9bedcefb0c43e6057
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:11 GMT
+      - Fri, 29 Jul 2022 08:58:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/4f82845d-0436-4945-ac98-e294ec14a2ba/"
+      - "/pulp/api/v3/remotes/rpm/rpm/19a1ab2d-6374-4fee-8f32-c6e2b0217786/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ffce17c33e445a9a9a8fa695774518e
+      - c2bab87d1a7c499591fe9d660d907536
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRm
-        ODI4NDVkLTA0MzYtNDk0NS1hYzk4LWUyOTRlYzE0YTJiYS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjExLjg5NjU5NVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE5
+        YTFhYjJkLTYzNzQtNGZlZS04ZjMyLWM2ZTJiMDIxNzc4Ni8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjQ2Ljc0NTQxMVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjExLjg5NjYxNVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjQ2Ljc0NTQzOFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:11 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/"
+      - "/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b67d6af877e4c6e80469b6dd5090e4a
+      - 9e238cb6adc74d168584b1878ac4f811
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzVjNGRlNmQtMzc5ZC00NjNhLWE5ODMtZDZiZDNjYmZlNjA4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MTIuMDA2NDI3WiIsInZl
+        cG0vMzY5MTc5NGYtMDJlNC00ZTFhLWE0ODMtZDE3ODJmZGRkMjA5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NDYuODkwNzQzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzVjNGRlNmQtMzc5ZC00NjNhLWE5ODMtZDZiZDNjYmZlNjA4L3ZlcnNp
+        cG0vMzY5MTc5NGYtMDJlNC00ZTFhLWE0ODMtZDE3ODJmZGRkMjA5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNWM0ZGU2ZC0z
-        NzlkLTQ2M2EtYTk4My1kNmJkM2NiZmU2MDgvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNjkxNzk0Zi0w
+        MmU0LTRlMWEtYTQ4My1kMTc4MmZkZGQyMDkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8012ea17f5f844d6807b7dd72b5942f1
+      - 3bbbac26236d4830adb0249903bc87be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hZjQ2N2QzNC1kYjA4LTQ5MGEtYjFlYi01MzE5YjI4ZDFhMGYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzowNC41MDQ2MDJa
+        cnBtL3JwbS9kY2EzYzM3NC05YWZhLTQ3NTItYjI4NS1jNTNiY2RhMmFkNDIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODozMi4yMjAzMDBa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hZjQ2N2QzNC1kYjA4LTQ5MGEtYjFlYi01MzE5YjI4ZDFhMGYv
+        cnBtL3JwbS9kY2EzYzM3NC05YWZhLTQ3NTItYjI4NS1jNTNiY2RhMmFkNDIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2FmNDY3
-        ZDM0LWRiMDgtNDkwYS1iMWViLTUzMTliMjhkMWEwZi92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2RjYTNj
+        Mzc0LTlhZmEtNDc1Mi1iMjg1LWM1M2JjZGEyYWQ0Mi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/af467d34-db08-490a-b1eb-5319b28d1a0f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/dca3c374-9afa-4752-b285-c53bcda2ad42/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 414bb42c299b446c905c633ac64e1417
+      - e25afe95c6b74b0fb0f507f61abb65e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAyNmU4MTgyLWExYjEtNDdk
-        NC04ZDM2LTcyMTA4NmZjNmIyNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhOWMwMTI0LTMxOWItNDU1
+        Yy1hNjRjLTdkZDdmM2QzY2U0Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aea41aa13d7841f88bea55723240d7a4
+      - 5125f36538844ae1a6feb37b55f8511a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMjZiYzcwN2MtNDgxZC00N2M3LWFhMTgtMzY0ZDExOGU4MDQxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MDMuNjgxNTAyWiIsIm5h
+        cG0vZWFhMzRkZGItODEzYy00MjJkLTk5OTctOTVlYmU0ODFlZWFkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MzAuOTUzNDEzWiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzowNC44MzAxNDlaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODozMi42NzkzODFaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/26bc707c-481d-47c7-aa18-364d118e8041/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/eaa34ddb-813c-422d-9997-95ebe481eead/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4c2a451fcfaf4534bada3e03725e32d8
+      - 393e35ad138f465cb47468db40a3ef61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzZGZkY2NhLTBiN2YtNDdl
-        Ny05N2M0LTY4NTFmNTJjMTdjNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IxYzc4MGZlLTRmZDItNDQ3
+        MS1hNTBmLTUyNTUwZTE0ZjU0OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/026e8182-a1b1-47d4-8d36-721086fc6b27/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3a9c0124-319b-455c-a64c-7dd7f3d3ce46/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fad236e9b63e4fd78cff0695953af7df
+      - e41136e28e5f468aa5b58e5d4d967e54
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDI2ZTgxODItYTFi
-        MS00N2Q0LThkMzYtNzIxMDg2ZmM2YjI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTIuMTgwMzQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2E5YzAxMjQtMzE5
+        Yi00NTVjLWE2NGMtN2RkN2YzZDNjZTQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDcuMTA0MjY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0MTRiYjQyYzI5OWI0NDZjOTA1YzYzM2Fj
-        NjRlMTQxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjEyLjIx
-        MTEyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTIuMjcw
-        NDQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlMjVhZmU5NWM2Yjc0YjBmYjBmNTA3ZjYx
+        YWJiNjVlNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjQ3LjE0
+        NDc1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NDcuMjM0
+        NzQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWY0NjdkMzQtZGIwOC00OTBh
-        LWIxZWItNTMxOWIyOGQxYTBmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGNhM2MzNzQtOWFmYS00NzUy
+        LWIyODUtYzUzYmNkYTJhZDQyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/83dfdcca-0b7f-47e7-97c4-6851f52c17c5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b1c780fe-4fd2-4471-a50f-52550e14f549/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a3ba0252bc124e7d96cdfd543ba30047
+      - 68fa260e2f2c48849d1898fa81ba5a8d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODNkZmRjY2EtMGI3
-        Zi00N2U3LTk3YzQtNjg1MWY1MmMxN2M1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTIuMjY2MzgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjFjNzgwZmUtNGZk
+        Mi00NDcxLWE1MGYtNTI1NTBlMTRmNTQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDcuMjMxMjMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0YzJhNDUxZmNmYWY0NTM0YmFkYTNlMDM3
-        MjVlMzJkOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjEyLjI5
-        ODk2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTIuMzQ2
-        OTU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzOTNlMzVhZDEzOGY0NjVjYjQ3NDY4ZGI0
+        MGEzZWY2MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjQ3LjI3
+        MjM4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NDcuMzI5
+        MDQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzI2YmM3MDdjLTQ4MWQtNDdjNy1hYTE4
-        LTM2NGQxMThlODA0MS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2VhYTM0ZGRiLTgxM2MtNDIyZC05OTk3
+        LTk1ZWJlNDgxZWVhZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a880a26e2e2e4ea78d75698faadd5566
+      - 0f7103f4448842d78ffbc959c8f4b372
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae973028bef449a4ac529205f97c008d
+      - feefed5d195d4963a6adaf6e1348a325
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c97d0eb7066742f58d1674c1929893c7
+      - 584fe86477724481aaaab4403d2939e0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 70786f95a997493592eceeed4a844e5a
+      - 428650cb5d2b4082b43096bdc4185576
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e0b2526b36b04bf7a82a3a15de6f91a2
+      - 4beda39dd3f5487ab8ff53b4998db6eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '085d6bb44b1f40959e370b7d14770026'
+      - a7d4718b9580441ebe46df9ae3b6a9f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:12 GMT
+      - Fri, 29 Jul 2022 08:58:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/"
+      - "/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1aca70ca93c0426ca45ab5c6ede78f39
+      - 23b35ba8eb574e55a24b7868c09f7ae8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzQyYmY1NDYtZDgzZi00YTNmLWI1MzAtMGJlMWFiMDVhMWQ0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MTIuNzUwNTA4WiIsInZl
+        cG0vZGVlODg3OGItN2ZmZS00OGVjLTgzZmEtMDdlYzk1ZDcxYjg4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NDcuNzg3MTIzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzQyYmY1NDYtZDgzZi00YTNmLWI1MzAtMGJlMWFiMDVhMWQ0L3ZlcnNp
+        cG0vZGVlODg3OGItN2ZmZS00OGVjLTgzZmEtMDdlYzk1ZDcxYjg4L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jNDJiZjU0Ni1k
-        ODNmLTRhM2YtYjUzMC0wYmUxYWIwNWExZDQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZWU4ODc4Yi03
+        ZmZlLTQ4ZWMtODNmYS0wN2VjOTVkNzFiODgvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:12 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:47 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/4f82845d-0436-4945-ac98-e294ec14a2ba/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/19a1ab2d-6374-4fee-8f32-c6e2b0217786/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:13 GMT
+      - Fri, 29 Jul 2022 08:58:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dc890251c6714e52b0670c68e126cbfb
+      - 05d39a6573fb4c6fb40b023648faa95b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjNTViMTFjLWZjNGQtNGVi
-        Yi05MzczLWRlYTY0NTFkNGU1YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJmMDYwYWJkLTBhN2ItNDZk
+        Ny1hYjgwLWRhNWVlZjZlOTM4OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:13 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2c55b11c-fc4d-4ebb-9373-dea6451d4e5a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2f060abd-0a7b-46d7-ab80-da5eef6e9389/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:13 GMT
+      - Fri, 29 Jul 2022 08:58:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e14a1a65eed84d1b9e8bf96cf7ddc2bc
+      - ad5fc6595b14461bb7a1f3daf7778bc7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmM1NWIxMWMtZmM0
-        ZC00ZWJiLTkzNzMtZGVhNjQ1MWQ0ZTVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTMuMDg2OTM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmYwNjBhYmQtMGE3
+        Yi00NmQ3LWFiODAtZGE1ZWVmNmU5Mzg5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDguMTU2ODUzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJkYzg5MDI1MWM2NzE0ZTUyYjA2NzBjNjhl
-        MTI2Y2JmYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjEzLjEx
-        NzU3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTMuMTQx
-        NTAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwNWQzOWE2NTczZmI0YzZmYjQwYjAyMzY0
+        OGZhYTk1YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjQ4LjE5
+        OTY1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NDguMjI4
+        ODIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmODI4NDVkLTA0MzYtNDk0NS1hYzk4
-        LWUyOTRlYzE0YTJiYS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE5YTFhYjJkLTYzNzQtNGZlZS04ZjMy
+        LWM2ZTJiMDIxNzc4Ni8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:13 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:48 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmODI4
-        NDVkLTA0MzYtNDk0NS1hYzk4LWUyOTRlYzE0YTJiYS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE5YTFh
+        YjJkLTYzNzQtNGZlZS04ZjMyLWM2ZTJiMDIxNzc4Ni8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:13 GMT
+      - Fri, 29 Jul 2022 08:58:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 30f0af5c567a4446a199c46b0b6bdc4c
+      - 04d41ec4515e4e599c30d9227aa60684
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQzZGI2Y2RmLTFiNmMtNGFh
-        My1hYWYwLTkzMGMwNTI1NGVhYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M4MGI3MzVhLTY0YjQtNDU0
+        Yi05OTRmLWFjNmUxYTNmMWQyYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:13 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/43db6cdf-1b6c-4aa3-aaf0-930c05254eaa/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c80b735a-64b4-454b-994f-ac6e1a3f1d2c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:14 GMT
+      - Fri, 29 Jul 2022 08:58:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08ff7c91001a45e5a54524587832bfcd'
+      - 2298a700a6004b6f9ee16fa3e7667443
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '597'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDNkYjZjZGYtMWI2
-        Yy00YWEzLWFhZjAtOTMwYzA1MjU0ZWFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTMuMjYzNzk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzgwYjczNWEtNjRi
+        NC00NTRiLTk5NGYtYWM2ZTFhM2YxZDJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NDguMzI4MzMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzMGYwYWY1YzU2N2E0NDQ2YTE5
-        OWM0NmIwYjZiZGM0YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjEzLjI5NTMyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MTQuODc0ODU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwNGQ0MWVjNDUxNWU0ZTU5OWMz
+        MGQ5MjI3YWE2MDY4NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjQ4LjM3MjEyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        NTIuMzU3NDk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMzVjNGRlNmQtMzc5ZC00NjNhLWE5ODMt
-        ZDZiZDNjYmZlNjA4L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzM1YzRkZTZkLTM3OWQtNDYzYS1hOTgzLWQ2YmQzY2JmZTYwOC8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS80ZjgyODQ1ZC0wNDM2
-        LTQ5NDUtYWM5OC1lMjk0ZWMxNGEyYmEvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzM2OTE3OTRmLTAyZTQtNGUxYS1hNDgzLWQx
+        NzgyZmRkZDIwOS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8z
+        NjkxNzk0Zi0wMmU0LTRlMWEtYTQ4My1kMTc4MmZkZGQyMDkvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMTlhMWFiMmQtNjM3NC00
+        ZmVlLThmMzItYzZlMmIwMjE3Nzg2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:14 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:52 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMzVjNGRlNmQtMzc5ZC00NjNhLWE5ODMtZDZiZDNjYmZl
-        NjA4L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMzY5MTc5NGYtMDJlNC00ZTFhLWE0ODMtZDE3ODJmZGRk
+        MjA5L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:15 GMT
+      - Fri, 29 Jul 2022 08:58:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f870172ee1194d279caf4cc799c60ddd
+      - f1c2479485754aa099111c9b9022e932
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExZDAzZThiLWU4YjYtNGIw
-        My1hYzFkLTdiYjY1YTJkY2ZhZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3Y2VkODhlLWNkNTItNGM2
+        My1hMGU5LWZhNzI5MDAyYmJlNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/11d03e8b-e8b6-4b03-ac1d-7bb65a2dcfad/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/37ced88e-cd52-4c63-a0e9-fa729002bbe4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:15 GMT
+      - Fri, 29 Jul 2022 08:58:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aba0ef169efa410fa47aabb9c366ea35
+      - 35fcbbc5f0df4d36bbdc591060a0b0ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTFkMDNlOGItZThi
-        Ni00YjAzLWFjMWQtN2JiNjVhMmRjZmFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTUuMDM1MjY5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzdjZWQ4OGUtY2Q1
+        Mi00YzYzLWEwZTktZmE3MjkwMDJiYmU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NTIuNjI2MjczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImY4NzAxNzJlZTExOTRkMjc5Y2FmNGNjNzk5
-        YzYwZGRkIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTUuMDY2
-        NDU4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzoxNS4yNDM0
-        MDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImYxYzI0Nzk0ODU3NTRhYTA5OTExMWM5Yjkw
+        MjJlOTMyIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NTIuNjc2
+        OTA1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1ODo1Mi45NjMw
+        NDJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjgyNmZh
-        YTAtN2M2Yi00MzBhLTkzYzctN2ViYTU1YmU2NmQ4LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGZmODY4
+        ZmQtYzdjMy00ZWM4LTlmMzItYzg4NzIzZGFiMDMxLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMzVjNGRlNmQtMzc5ZC00NjNhLWE5ODMtZDZiZDNj
-        YmZlNjA4LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMzY5MTc5NGYtMDJlNC00ZTFhLWE0ODMtZDE3ODJm
+        ZGRkMjA5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - feab508b11034069b14d5b369be3e5e3
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:15 GMT
+      - Fri, 29 Jul 2022 08:58:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 05b88fbe93d54d3391d7785b9a979a29
+      - 7b254fe64a9441c0b8638a7ca6fface5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/8ff868fd-c7c3-4ec8-9f32-c88723dab031/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:15 GMT
+      - Fri, 29 Jul 2022 08:58:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66a42f14ef8f4b3295d30f4bc6a93751
+      - 88773feaff6d459aa75e59351c85078c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vOGZmODY4ZmQtYzdjMy00ZWM4LTlmMzItYzg4NzIzZGFiMDMxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NTIuNzAwNzExWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8zNjkxNzk0Zi0wMmU0LTRlMWEtYTQ4My1kMTc4MmZkZGQyMDkv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzM2OTE3OTRmLTAyZTQtNGUxYS1hNDgzLWQxNzgy
+        ZmRkZDIwOS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:53 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS84ZmY4NjhmZC1jN2MzLTRlYzgtOWYzMi1jODg3MjNkYWIwMzEv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 23d3341463014b32970b11732560af15
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2ODU1NDI4LTQ2YjctNDE3
+        MC1hMzY5LTZhZTczYzI3YjY0Ny8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e6855428-46b7-4170-a369-6ae73c27b647/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 878b041aa88b4b2b8933e2603dc27ba8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTY4NTU0MjgtNDZi
+        Ny00MTcwLWEzNjktNmFlNzNjMjdiNjQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NTMuMTg5OTY5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyM2QzMzQxNDYzMDE0YjMyOTcwYjExNzMy
+        NTYwYWYxNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjUzLjIz
+        MDk1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NTMuNDc1
+        MzE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNGIy
+        NmUyZTYtNTg4YS00MjA5LThjM2QtMjg4MWVmMWI4NDdmLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4b26e2e6-588a-4209-8c3d-2881ef1b847f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e037d819d05f4fb594607c668047ff9b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzRiMjZlMmU2LTU4OGEtNDIwOS04YzNkLTI4ODFlZjFiODQ3Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjUzLjQ1MzgwMVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vOGZmODY4ZmQtYzdjMy00ZWM4LTlmMzIt
+        Yzg4NzIzZGFiMDMxLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fec1299b94574d76bd34f6a9316c1468
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6f8668e175de45328a4254f90611b673
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 816f80ed15094ad5a62a3fe8a4bf18a9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:15 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94c568e78d294fcfaf70ea1825d3550b
+      - de8d13b10ba84899853fa499fb27b27a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:15 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd0728c60fa94331a643f97a4f5c8a58
+      - ed4a7fc4fdbc4c7c8e5045ed100681ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:15 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 107a64699ecf4acd96c15f9da39fdde2
+      - 7b2abf2c243f4dbfbbb60c53c397e99e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:15 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7cd73242df9b4c69948ad25afde9dca3
+      - 70b40c7360eb4a4f932ae7b1c066a67d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:15 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 81724ac609e1436789e8f5f9685cafc8
+      - d71d9a792aed46bb8f336590132d7c5d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74129e69f4774429b2d76b91d40bb438
+      - 48285d3df9e747a58fc5a6c8da1ba683
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ac634d846e2b4a5e887e91b7288dcef7
+      - 9fcb4f27b4cf4fc0bc50437e5469dfe4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,83 +3208,83 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 55f5ca2c65a644798dba960db1b19672
+      - 8155955b9b31468b9fefadb1b94aff76
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAzYmRhY2ViLWE5MzEtNDZm
-        NS05NWIzLWZmMmY5NGQwN2QzYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwM2U1MTcwLTdjYTQtNGMw
+        Ny1hMWFiLTRiNTY3NWI2N2E4ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy80ZDYyYjA2Mi01MTkxLTQyZWQtYTU4NC04MWExZDhl
-        NGRhZTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzkwYTZjNmExLTM4NjUt
-        NDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMGI0NmU0OTAtYjM1Ny00YjRmLWIxYWQtOTg3MDNi
-        NWU3ZDEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8x
-        OWIzOTcyMy0wYjc1LTRkZmUtYWMzZi03NmZhZWJlODFmYjUvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFhNTc2NWVlLTcwNzgtNDMz
-        OC1hMDM2LWZkOTI3MzA0NTE5NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMWYyNDQ2MjEtMGNiYi00YmU4LTk2MjMtM2JkZGMzYjEw
-        ZWIxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJkNjJjZjg0LTRjNTUtNDg5NC05
-        NDRmLTg2MjczNzk3NTZkMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUx
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEy
-        Zi00YzM0LTRhNDItYWFmNi02Mjk3NTQ5YjAzODgvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBh
-        LTQ1ODExZmUzZmQ4MC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3YTI4NWIwZDNiLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83NzAyYmFkNi01
-        ZDc2LTQ0YWQtOTlhZi1iMzIwMzUwNDZlYmUvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1
-        OWIwNjFiNThhNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvYTNlMDNjZDEtM2MzNC00Y2JiLTlmODYtZjkyN2Y2YWMxZjljLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hODNkYWM4Ny03NWI1
-        LTRlN2ItOGIwYi1iZjE5OGRjYjYyMTQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3
-        YTNlZjg3MC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0ZDI4MGY1ZWQzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iNjZmNzBkYS01OWQ4LTQz
-        YjctOGRhMi1jMmIxMTBhMWYxYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2I4ZDRlN2ExLTAzODctNDhiMS1hMGQ2LWNmN2E5OGFm
-        ZGM1NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhl
-        NjRkNGQtMjBlMC00N2MyLTk1OTYtMzNhNDNmMTRiYmI1LyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iYWYyNGMxYS0wZTA3LTQxNmUt
-        ODRhNy1lZTQ1NzIzMmIwNWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2MxZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2Yx
-        Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzM2NGU5
-        MmUtMTY0MS00Y2ViLTgwYjAtOTQ5OTlkMjE5YzQ0LyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9jZTZmMTY5ZS1kOWZkLTRjMjQtODZj
-        Yi1jMjUzYTZmZTU1MDkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzL2QwNmI3OTk2LTQyNWEtNGE4NS04MWJiLWEyNDZjODAwZTliOC8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUt
-        ZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNiNy0y
-        YTM4MjZkMDFkNmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4ZjUwMmMzNDAxMi8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTVjYWUzZjMtYjJk
-        MC00MjJjLTllOTEtOGVkZDlkOWQxMTYyLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2MtYjJjYS1kZWQz
-        ZTI3ZmU2ZGEvIl19
+        cG0vYWR2aXNvcmllcy8yMjUwZjE3YS1iYzE4LTRjZTEtOGM2YS0wN2M0ZjA2
+        ODI1NGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NjZmMzRmMWEtMzcwNC00ODNjLThjNTctMjNiMzllZGE1NWRiLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzc3ZmUyNzVhLTBkZTct
+        NDk5NC1iMGUzLWUzNjE5NmViZjdmZi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvMDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1
+        MjE1OGJiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
+        ZDRmNzdiMy0xNDgxLTRmNTItOWM3NS0xYmJhNzcwYjY3ZGUvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBk
+        Mi1hZjQzLTM4MDMxMzZkMTIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMGY3NTdkMjQtNjc4Mi00NTEwLTliZDctMWY0ZDg5ZjE5
+        OGNiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNWM5
+        MTA0Zi0xMjMzLTQ2YzQtYmY3My03NTE4MThmYzZmMTUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04
+        MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NGU4OTAw
+        ZC03MjIxLTQ0MDgtOTAwNS0xM2E5M2IzOTJhMGQvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5M2E0ZWIyLWQ3MzktNDA5Mi04OTZm
+        LTgzNjMwZmYzYzRmYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZGM4YzA3Ni1k
+        NTFkLTQxZGQtYjQ1NS04MzRjMmY4ZDU4OGMvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzZlYjVkZTgxLWQ2MDUtNDkzMS04ZTY0LTQ2
+        ZTAxZjE1MzAwMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvNmYxYzkwYjAtYTc4Ny00OGNjLTgwY2ItZmNhMzk4MDAwYzc2LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83MzNhNGEwMC04ODRl
+        LTRhMDEtYjI0MC02ZTM4YzNlZTczYjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQzYjMtNGQ0Mi1iYmUxLWZhMGQ4
+        OTAxMzM1MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85MmI2NmFjYi02MGI5LTRl
+        ZjQtYjUxYS05YWI2YTc1MDBmODIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzk5YjZhZmVmLWYyMWItNDlmOS1hMzZiLTg1MTgwMzNm
+        MDM2MC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTBi
+        MmZmY2ItYjM4MC00YWI5LWJiOGItNDI5YzRmOWJmYzdiLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAt
+        YmQyYi05MDMzNmRkMzBjNGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2E1Y2RiZGRlLWJjYTgtNDUyOS05YjQxLWM3YmU4MWY3OTI0
+        OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJh
+        ZjAtNTZmOC00ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYz
+        ZS1lMmMyMzNjOGZmODQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzL2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDUwOTg5MWEt
+        ZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5LTRjNTAtOWNjNy0y
+        YzgyYWU3ODc4OGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2U0OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRhODIyZDYtNGVm
+        NC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdj
+        YTc5ODI2ZGYvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2872,7 +3297,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2890,21 +3315,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8601945a298846378cbd0eceeadc0d00
+      - da21b26720f94564bf12da55ef688c94
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NjZDAxYjRjLWIwNWEtNDgw
-        YS05ODEyLTIyNjMwOTNkYTMwNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFhMDcyOGFhLTZhZTctNGEy
+        OS05MjliLTljYTAzMmVhZWU5Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ccd01b4c-b05a-480a-9812-2263093da307/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1a0728aa-6ae7-4a29-929b-9ca032eaee9f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,53 +3350,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43063158a2da4627a94e596be9d09a0a
+      - 568f522c23aa474f8d3878263990feaf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2NkMDFiNGMtYjA1
-        YS00ODBhLTk4MTItMjI2MzA5M2RhMzA3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTYuMjA3MzU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWEwNzI4YWEtNmFl
+        Ny00YTI5LTkyOWItOWNhMDMyZWFlZTlmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NTQuOTI4OTY2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4NjAxOTQ1YTI5ODg0NjM3OGNi
-        ZDBlY2VlYWRjMGQwMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjE2LjM1Mzc5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MTYuNDk5MDA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkYTIxYjI2NzIwZjk0NTY0YmYx
+        MmRhNTVlZjY4OGM5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjU1LjE4MTMxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        NTUuNDE2Mzc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9jNDJiZjU0Ni1kODNmLTRhM2YtYjUzMC0wYmUxYWIwNWExZDQvdmVyc2lv
+        bS9kZWU4ODc4Yi03ZmZlLTQ4ZWMtODNmYS0wN2VjOTVkNzFiODgvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzQyYmY1NDYtZDgzZi00YTNm
-        LWI1MzAtMGJlMWFiMDVhMWQ0LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGVlODg3OGItN2ZmZS00OGVj
+        LTgzZmEtMDdlYzk1ZDcxYjg4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2979,7 +3404,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2992,95 +3417,95 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2604'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46c812a1d143437fa049b26ebc7643e3
+      - 76902cfc39f24749950a45b184cfcede
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '793'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MjksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U1NzYw
-        OTBmLWVmMGUtNGFlZi1iM2I3LTJhMzgyNmQwMWQ2Yy8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wYjQ2ZTQ5
-        MC1iMzU3LTRiNGYtYjFhZC05ODcwM2I1ZTdkMTIvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzcwMmJhZDYt
-        NWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2ZWJlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2
-        N2EtNDA4NC04NzVhLTc4ZjUwMmMzNDAxMi8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iYWYyNGMxYS0wZTA3
-        LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzM2NGU5MmUtMTY0MS00
-        Y2ViLTgwYjAtOTQ5OTlkMjE5YzQ0LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2VjMjdkMzU5LTkzODgtNDg3
-        Yy1iMmNhLWRlZDNlMjdmZTZkYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iNjZmNzBkYS01OWQ4LTQzYjct
-        OGRhMi1jMmIxMTBhMWYxYmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgz
-        MWEtN2E3YTI4NWIwZDNiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0MTJmLTRjMzQtNGE0Mi1hYWY2
-        LTYyOTc1NDliMDM4OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04
-        YjRkMjgwZjVlZDMvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2Y2ItYzI1
-        M2E2ZmU1NTA5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2I4ZTY0ZDRkLTIwZTAtNDdjMi05NTk2LTMzYTQz
-        ZjE0YmJiNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hODNkYWM4Ny03NWI1LTRlN2ItOGIwYi1iZjE5OGRj
-        YjYyMTQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2VlMTJmOWMtMTc1Zi00NDY3LWJkMjItMzU5YjA2MWI1
-        OGE2LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3
-        MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDUw
+        OTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNjLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZlYjVk
+        ZTgxLWQ2MDUtNDkzMS04ZTY0LTQ2ZTAxZjE1MzAwMy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZDRmNzdi
+        My0xNDgxLTRmNTItOWM3NS0xYmJhNzcwYjY3ZGUvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGFlZjg5YjAt
+        ZDNiMy00ZDQyLWJiZTEtZmEwZDg5MDEzMzUxLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2FlMzViYWYwLTU2
+        ZjgtNGY5YS04NGYzLTFiMzEyNTRjZWRkNy8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMmRmZjEzZS1mODky
+        LTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00
+        MWRkLWI0NTUtODM0YzJmOGQ1ODhjLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZmMWM5MGIwLWE3ODctNDhj
+        Yy04MGNiLWZjYTM5ODAwMGM3Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zMmRhOTUzZC0xOWJhLTQ2Yzct
+        ODM0ZC01N2VjNGVkOWQ3OWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMGUyNjg3M2EtZWIzNy00MGQyLWFm
+        NDMtMzgwMzEzNmQxMjJhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0YTgyMmQ2LTRlZjQtNDZmZS1hMjdj
+        LTIxM2JmOGVhOWRmNC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy83MzNhNGEwMC04ODRlLTRhMDEtYjI0MC02
+        ZTM4YzNlZTczYjkvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDRlODkwMGQtNzIyMS00NDA4LTkwMDUtMTNh
+        OTNiMzkyYTBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzL2U0OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUw
+        NTkxYjIzMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5LTRjNTAtOWNjNy0yYzgyYWU3
+        ODc4OGMvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3
+        YmFmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZk
+        OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9
+        a2FnZXMvMDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzJkNjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7
+        Z2VzLzBmNzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yZDVlNjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJw
+        cy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MTliMzk3MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4
-        ZDRlN2ExLTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MTVjOTEwNGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1
+        NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3088,7 +3513,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3101,7 +3526,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3119,21 +3544,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cdd588087da2432fa067852fa2c495b7
+      - 0261c7a18b7440daae6da7e289dba834
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3141,7 +3566,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3154,37 +3579,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2976'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ba12bd5acc1841ce8eb32822d59c98bd
+      - 460774f9e6db4d49b306f39275e2de4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '707'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3200,8 +3625,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3229,8 +3654,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy84ZmQ2Mjg4Yi1lNjgzLTQ2ZWYtOWI5NC1kMGU5MDRiOWY2OGIvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzI2NDJaIiwi
+        cmllcy83N2ZlMjc1YS0wZGU3LTQ5OTQtYjBlMy1lMzYxOTZlYmY3ZmYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjQ5NDJaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1OCIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDkiLCJkZXNjcmlwdGlvbiI6IkdvcmlsbGFfRXJyYXR1bSIs
         Imlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOSIsImZyb21zdHIi
@@ -3248,10 +3673,10 @@ http_interactions:
         NjIifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3259,7 +3684,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3272,7 +3697,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:16 GMT
+      - Fri, 29 Jul 2022 08:58:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3290,21 +3715,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 913cdb5409e848e0a02dbe35a5faff99
+      - 5d09e88d51084dafa4521b276887ed10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:16 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3312,7 +3737,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3325,7 +3750,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:17 GMT
+      - Fri, 29 Jul 2022 08:58:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3343,21 +3768,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e02696374a6a49e9a1cbd137e4b51484
+      - 7d7c0b3b504f476fbfea497cbf7fed6e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:17 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3365,7 +3790,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3378,7 +3803,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:17 GMT
+      - Fri, 29 Jul 2022 08:58:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3396,16 +3821,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56082def61324a0cbb7a202699f31b21
+      - d756c142890b40cb94805a84becbab08
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:17 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:56 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_errata_inclusion_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_errata_inclusion_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c777f52ec5a41bcb7c0432eeb05043a
+      - ac4eba85bbf2453c8995308fe2ab61f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84NWQwNDgzOS0yZDgyLTQxZmEtYjUwMy0xNmUxZWFmOWRkZWYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyMi42MjMzMzda
+        cnBtL3JwbS9iMmYyNzczZC0xMDNlLTRlMmQtYmI3Yy0wZjJmMGU1MjdkMjIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1NzozMy4wMzY2NzRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84NWQwNDgzOS0yZDgyLTQxZmEtYjUwMy0xNmUxZWFmOWRkZWYv
+        cnBtL3JwbS9iMmYyNzczZC0xMDNlLTRlMmQtYmI3Yy0wZjJmMGU1MjdkMjIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzg1ZDA0
-        ODM5LTJkODItNDFmYS1iNTAzLTE2ZTFlYWY5ZGRlZi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IyZjI3
+        NzNkLTEwM2UtNGUyZC1iYjdjLTBmMmYwZTUyN2QyMi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/85d04839-2d82-41fa-b503-16e1eaf9ddef/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b2f2773d-103e-4e2d-bb7c-0f2f0e527d22/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f975c094a38144d88d67a667cccfdbe3
+      - 92c4ec69b3264f6ea73324ffcf313c60
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiMzdhY2Y5LThjYmEtNGFl
-        MS1hNzNmLTQ5ZjFlOWU4MzUxZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkOGJmNWIyLWI4NzctNGUz
+        Yy05MTk5LTkwMjhiNDNlMzUyMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b26ea97d02d142e19f694f5617594ba0
+      - 4291340c258b4a33bbb920638bb7c2e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4b37acf9-8cba-4ae1-a73f-49f1e9e8351d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2d8bf5b2-b877-4e3c-9199-9028b43e3523/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1f79c72c4a594267815807e3c9f8f9e0
+      - b9c0857142f24edab1762d01894205e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGIzN2FjZjktOGNi
-        YS00YWUxLWE3M2YtNDlmMWU5ZTgzNTFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjkuMTIwMTQwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ4YmY1YjItYjg3
+        Ny00ZTNjLTkxOTktOTAyOGI0M2UzNTIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NDQuMjQxOTM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmOTc1YzA5NGEzODE0NGQ4OGQ2N2E2Njdj
-        Y2NmZGJlMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjI5LjE1
-        MjA0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MjkuMjc1
-        Nzg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5MmM0ZWM2OWIzMjY0ZjZlYTczMzI0ZmZj
+        ZjMxM2M2MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjQ0LjI4
+        MjMwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NDQuNDcx
+        MzQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODVkMDQ4MzktMmQ4Mi00MWZh
-        LWI1MDMtMTZlMWVhZjlkZGVmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjJmMjc3M2QtMTAzZS00ZTJk
+        LWJiN2MtMGYyZjBlNTI3ZDIyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8cdabd4985b2441a8fa9feb5b72c8edc
+      - 65ef89a2a8d44afaa1466f87c79438bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - dc8f3c07ac484ab692030ebfc1342f43
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMDA2MTFkMTYtMTg1My00ZGE3LWIyMmYtNjY5YWQ1MTBiYjll
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NDAuMDI5Mjky
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/00611d16-1853-4da7-b22f-669ad510bb9e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 032b0e80224042558e56cf869cbd87c5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxNTc4MDQwLTE1YWYtNGQ1
+        Ni1hMjVjLTI4ZTAyZDRiYjA2MS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c1578040-15af-4d56-a25c-28e02d4bb061/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6c6bd4c71b0d46228d7b094869f6a544
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzE1NzgwNDAtMTVh
+        Zi00ZDU2LWEyNWMtMjhlMDJkNGJiMDYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NDQuNjU3MTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMzJiMGU4MDIyNDA0MjU1OGU1NmNmODY5
+        Y2JkODdjNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjQ0LjY5
+        NTYyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NDQuNzI5
+        MTQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7e0b849933004c51a5017bbcb5aa4c9c
+      - e066ff467c604fa98a66475b844e1dd2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b9ca6a8913b4df9a2c5af4639ec72c2
+      - fc899de379b14e2782cbfda32ccae323
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33e72170209b46b5996480bf13cfda61
+      - b4fb15fda61146e2967b228b8d9fbb29
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c5e0ffb874794e21b67b12ef7d6e884a
+      - e3049c4e362e45059cfdc928d8a9af63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:29 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e8ed8cb86a1f4f1ebb1b330847b9e3a6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:44 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/282af98e-620b-4918-a7b9-03549edf48cd/"
+      - "/pulp/api/v3/remotes/rpm/rpm/105bf9b7-cde6-41ca-af8c-527afe56a8c6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ec07fe3ae6a4dfc92825f137e993618
+      - 06f3afc1edfa4656886d19ff7c19c17c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzI4
-        MmFmOThlLTYyMGItNDkxOC1hN2I5LTAzNTQ5ZWRmNDhjZC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI5LjcyMTExNFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzEw
+        NWJmOWI3LWNkZTYtNDFjYS1hZjhjLTUyN2FmZTU2YThjNi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU3OjQ1LjAxODg0MloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI5LjcyMTEzNFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU3OjQ1LjAxODg3NFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/"
+      - "/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b9f73de4abb4625937223138915b066
+      - b3a29d7902c14014ace8c48433283cd5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDBkNjQwOGQtMDQ5OS00OGUwLWJjOTYtN2M5YzNhMGRiMzE0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjkuODM1MDYwWiIsInZl
+        cG0vNWMxNmNlNzUtNTZiYS00NWQ1LWJiYWUtMTI2YzZjMzhjNDg0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NDUuMTc0NDQwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDBkNjQwOGQtMDQ5OS00OGUwLWJjOTYtN2M5YzNhMGRiMzE0L3ZlcnNp
+        cG0vNWMxNmNlNzUtNTZiYS00NWQ1LWJiYWUtMTI2YzZjMzhjNDg0L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wMGQ2NDA4ZC0w
-        NDk5LTQ4ZTAtYmM5Ni03YzljM2EwZGIzMTQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81YzE2Y2U3NS01
+        NmJhLTQ1ZDUtYmJhZS0xMjZjNmMzOGM0ODQvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:29 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0eb6942d28824d4ea7b9d4b434c929e4
+      - df6c2553e8234f8abe65aac1dda40f8d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kYzFmNWVkNC1lNzgxLTQ1YTItOTVjNi1kYTEyNmFmYTlmNjkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyMy4zNTgwNTRa
+        cnBtL3JwbS9lNGY5MDc1My03ZDViLTRkNDctYjE2OC05MWI3YzE5ODM3ODIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1NzozNC4zMDA4OTBa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kYzFmNWVkNC1lNzgxLTQ1YTItOTVjNi1kYTEyNmFmYTlmNjkv
+        cnBtL3JwbS9lNGY5MDc1My03ZDViLTRkNDctYjE2OC05MWI3YzE5ODM3ODIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2RjMWY1
-        ZWQ0LWU3ODEtNDVhMi05NWM2LWRhMTI2YWZhOWY2OS92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U0Zjkw
+        NzUzLTdkNWItNGQ0Ny1iMTY4LTkxYjdjMTk4Mzc4Mi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:29 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/dc1f5ed4-e781-45a2-95c6-da126afa9f69/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e4f90753-7d5b-4d47-b168-91b7c1983782/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c8d5e00afd243508b1cd098481611be
+      - 39a9c80518c2470d88cd48f822661bcc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYyNWZjMWZmLTUwYWMtNDgw
-        NC1iNjcxLWNkZDQ0NDhjOWFhNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E4ZjU1N2EyLTg3MzMtNGNm
+        OC04OWQ0LWI5NjlkY2JkNzFkZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 454d64c5bdfc4dc589093b1355958397
+      - c40ceff2dab74910a8ca2b49f42e6428
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMTQ1MWFjN2QtYzgxZS00NGRkLTllYzYtZTFjMjY0NjMwY2YwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjIuNTA3NjMzWiIsIm5h
+        cG0vYjJmOTFiYzgtMWMzMC00YTQzLTgwYzgtODU3OTUzMzE3ZTMzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6MzIuNzY3Nzc0WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyMy42NzU0NDlaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1NzozNC43MjgwMjlaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/1451ac7d-c81e-44dd-9ec6-e1c264630cf0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b2f91bc8-1c30-4a43-80c8-857953317e33/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 508a285de998460f9157e4bde789f53b
+      - cb0006c3f7de4e95b79f6c11b4595b1c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg3ZGViNGY3LTUzODQtNGIx
-        Mi04ZWEyLTEwNmQwYjk4YTNiOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY4OGJiZTAxLWNjYTgtNDEw
+        Zi1iZDk4LTBjYTRlNGFmZjI3OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/625fc1ff-50ac-4804-b671-cdd4448c9aa4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a8f557a2-8733-4cf8-89d4-b969dcbd71dd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 942dc246d9c64477a0819eca610a1c8e
+      - 58b3366a4da94d469328e34f4cdcfff8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjI1ZmMxZmYtNTBh
-        Yy00ODA0LWI2NzEtY2RkNDQ0OGM5YWE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MjkuOTkxNDYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYThmNTU3YTItODcz
+        My00Y2Y4LTg5ZDQtYjk2OWRjYmQ3MWRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NDUuMzg5ODg0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwYzhkNWUwMGFmZDI0MzUwOGIxY2QwOTg0
-        ODE2MTFiZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjMwLjAy
-        NDc3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzAuMDg1
-        MDM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzOWE5YzgwNTE4YzI0NzBkODhjZDQ4Zjgy
+        MjY2MWJjYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjQ1LjQy
+        NTAzOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NDUuNTE3
+        NzA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGMxZjVlZDQtZTc4MS00NWEy
-        LTk1YzYtZGExMjZhZmE5ZjY5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTRmOTA3NTMtN2Q1Yi00ZDQ3
+        LWIxNjgtOTFiN2MxOTgzNzgyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/87deb4f7-5384-4b12-8ea2-106d0b98a3b8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/688bbe01-cca8-410f-bd98-0ca4e4aff279/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9aa85e5fdf354451a4b47702f907fafb
+      - daece772763346c4b47305cf1b4977c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODdkZWI0ZjctNTM4
-        NC00YjEyLThlYTItMTA2ZDBiOThhM2I4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzAuMDk2NzUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjg4YmJlMDEtY2Nh
+        OC00MTBmLWJkOTgtMGNhNGU0YWZmMjc5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NDUuNTE1MTk2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MDhhMjg1ZGU5OTg0NjBmOTE1N2U0YmRl
-        Nzg5ZjUzYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjMwLjEz
-        MDE0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzAuMTc2
-        NTkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjYjAwMDZjM2Y3ZGU0ZTk1Yjc5ZjZjMTFi
+        NDU5NWIxYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjQ1LjU2
+        MjQwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NDUuNjI1
+        OTY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE0NTFhYzdkLWM4MWUtNDRkZC05ZWM2
-        LWUxYzI2NDYzMGNmMC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IyZjkxYmM4LTFjMzAtNGE0My04MGM4
+        LTg1Nzk1MzMxN2UzMy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c6b6f25123344af4a3102d9890c9bdec
+      - 0fa87845419244ab8fcaa1b21586ef92
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 93eba5dc06c24fc8a6acb02dc48bd553
+      - 5ed415b12214449db29238a0541cfdbb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 16afd38a5d544709a8501ccc1cf89491
+      - 5e6bea68591b47d6a633909f0bd85039
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b58258c03c84f2f8969d7384d6fbc54
+      - '0683fd6d5de949bdab034fe3df0a143e'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5df616f6cfd40439ce5e9431e0d36c2
+      - ae40705d99a44e2c83e04391de5fb7e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c713f0d246d34befbe89b53f4869dc9a
+      - f7000aae71fd4a939cc4dedbf1bb4560
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:30 GMT
+      - Fri, 29 Jul 2022 08:57:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/"
+      - "/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a5e17e26427a432287722feb79b6d87b
+      - 13ae04ad944f4e1b9539676cba80964c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYWZlNzA0M2MtMDIwNS00OGM2LWE4MmYtMzE0MTRkMGIzMmQ1LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MzAuNTQ5NDY1WiIsInZl
+        cG0vOGE0MjY2ZGEtZWQ4OS00YTczLTllYjUtY2FlNTkwYWU5YTExLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NDYuMTgyMTIxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYWZlNzA0M2MtMDIwNS00OGM2LWE4MmYtMzE0MTRkMGIzMmQ1L3ZlcnNp
+        cG0vOGE0MjY2ZGEtZWQ4OS00YTczLTllYjUtY2FlNTkwYWU5YTExL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hZmU3MDQzYy0w
-        MjA1LTQ4YzYtYTgyZi0zMTQxNGQwYjMyZDUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84YTQyNjZkYS1l
+        ZDg5LTRhNzMtOWViNS1jYWU1OTBhZTlhMTEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:30 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:46 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/282af98e-620b-4918-a7b9-03549edf48cd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/105bf9b7-cde6-41ca-af8c-527afe56a8c6/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:31 GMT
+      - Fri, 29 Jul 2022 08:57:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d476df2402484502baaa93ce97db6597
+      - fa5902e7ab804d97861d4853488b08f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlNmVhZDc4LTU1MjctNGUx
-        OS05MTk5LTBiNTgxOWE0NDkwOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzY2MwODZjLTdiOGYtNDY4
+        Yi1iOWUwLWEwNDQzMTM5YTBkOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/be6ead78-5527-4e19-9199-0b5819a44908/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/83cc086c-7b8f-468b-b9e0-a0443139a0d8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:31 GMT
+      - Fri, 29 Jul 2022 08:57:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d5952b8127748f9a34dd190d18d5c11
+      - f417225ea6e847e59d5d32506519dd11
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmU2ZWFkNzgtNTUy
-        Ny00ZTE5LTkxOTktMGI1ODE5YTQ0OTA4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzEuMDAxMTM2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODNjYzA4NmMtN2I4
+        Zi00NjhiLWI5ZTAtYTA0NDMxMzlhMGQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NDYuNjgxMDIzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJkNDc2ZGYyNDAyNDg0NTAyYmFhYTkzY2U5
-        N2RiNjU5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjMxLjAz
-        NDA5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzEuMDU2
-        MjUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmYTU5MDJlN2FiODA0ZDk3ODYxZDQ4NTM0
+        ODhiMDhmMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjQ2Ljcy
+        MjU0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NDYuNzUw
+        ODYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzI4MmFmOThlLTYyMGItNDkxOC1hN2I5
-        LTAzNTQ5ZWRmNDhjZC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzEwNWJmOWI3LWNkZTYtNDFjYS1hZjhj
+        LTUyN2FmZTU2YThjNi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzI4MmFm
-        OThlLTYyMGItNDkxOC1hN2I5LTAzNTQ5ZWRmNDhjZC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzEwNWJm
+        OWI3LWNkZTYtNDFjYS1hZjhjLTUyN2FmZTU2YThjNi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:31 GMT
+      - Fri, 29 Jul 2022 08:57:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57453f0ec1ab4032a1782998711a3608
+      - d7a2a847cf784040bb5cce5ede33a09f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyMWVhZmY0LTQzZDEtNGE3
-        Yy05ZWUwLWI5N2NmMDk2YWUxZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkNzY3ODU5LTZmY2MtNGZi
+        ZC05OTRhLWM1YjY1ZTIyNTAwNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:31 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d21eaff4-43d1-4a7c-9ee0-b97cf096ae1f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fd767859-6fcc-4fbd-994a-c5b65e225007/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,82 +1787,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:32 GMT
+      - Fri, 29 Jul 2022 08:57:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6beb3c5aa12f4be8aad71f260dabea00
+      - '063819778f654163b35a4795d613f3ef'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '597'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDIxZWFmZjQtNDNk
-        MS00YTdjLTllZTAtYjk3Y2YwOTZhZTFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzEuMTc5MDU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmQ3Njc4NTktNmZj
+        Yy00ZmJkLTk5NGEtYzViNjVlMjI1MDA3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NDYuOTIzNjkwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI1NzQ1M2YwZWMxYWI0MDMyYTE3
-        ODI5OTg3MTFhMzYwOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjMxLjIyMTY4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        MzIuODQxMzE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkN2EyYTg0N2NmNzg0MDQwYmI1
+        Y2NlNWVkZTMzYTA5ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3
+        OjQ2Ljk2MjQ3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6
+        NTAuOTQwOTQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
-        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
-        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
-        ZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5nLm1l
-        dGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9u
-        ZSI6NSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBB
-        cnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFjdHMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJz
-        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQi
-        LCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxl
-        dGVkIiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9LHsi
-        bWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNp
-        bmcucGFja2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxs
-        LCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQg
-        QWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNvcmllcyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDBkNjQwOGQtMDQ5OS00OGUwLWJjOTYt
-        N2M5YzNhMGRiMzE0L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzAwZDY0MDhkLTA0OTktNDhlMC1iYzk2LTdjOWMzYTBkYjMxNC8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS8yODJhZjk4ZS02MjBi
-        LTQ5MTgtYTdiOS0wMzU0OWVkZjQ4Y2QvIl19
+        IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5hZHZp
+        c29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6
+        NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBNZXRh
+        ZGF0YSBGaWxlcyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5nLm1ldGFkYXRh
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NSwi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFj
+        dHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2Rl
+        IjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
+        ZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFj
+        a2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6
+        MzIsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzVjMTZjZTc1LTU2YmEtNDVkNS1iYmFlLTEy
+        NmM2YzM4YzQ4NC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81
+        YzE2Y2U3NS01NmJhLTQ1ZDUtYmJhZS0xMjZjNmMzOGM0ODQvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMTA1YmY5YjctY2RlNi00
+        MWNhLWFmOGMtNTI3YWZlNTZhOGM2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:32 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDBkNjQwOGQtMDQ5OS00OGUwLWJjOTYtN2M5YzNhMGRi
-        MzE0L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNWMxNmNlNzUtNTZiYS00NWQ1LWJiYWUtMTI2YzZjMzhj
+        NDg0L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:33 GMT
+      - Fri, 29 Jul 2022 08:57:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7ff56304e7a48f2a5bc00884cecd787
+      - efb53e64877641b380015c98817df716
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0Y2VmZTAxLTA4ODYtNGMw
-        Ni1hYzU5LTVhY2NhOTk5MmY1Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5MjVkYzJiLWQ1ZTQtNDM1
+        OS05ZjA1LTdhYmU4YmUwN2Y0Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:33 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/24cefe01-0886-4c06-ac59-5acca9992f5f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7925dc2b-d5e4-4359-9f05-7abe8be07f47/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:33 GMT
+      - Fri, 29 Jul 2022 08:57:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab02bcf2c2cc4d26b7f19a3de30d9ce0
+      - 6a3b73798d794750a38c02a800148267
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjRjZWZlMDEtMDg4
-        Ni00YzA2LWFjNTktNWFjY2E5OTkyZjVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzMuMDQ4OTU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzkyNWRjMmItZDVl
+        NC00MzU5LTlmMDUtN2FiZThiZTA3ZjQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTEuMTc2Njg0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImQ3ZmY1NjMwNGU3YTQ4ZjJhNWJjMDA4ODRj
-        ZWNkNzg3Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzMuMDgy
-        MzQyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMjozMy4yNjY5
-        MzBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImVmYjUzZTY0ODc3NjQxYjM4MDAxNWM5ODgx
+        N2RmNzE2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NTEuMjMw
+        NTgxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1Nzo1MS41NTE3
+        MDVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMGRiOTc5
-        MjUtZjIyNi00YzJjLWEwNjgtNGU2Y2I5M2RiZGM1LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMmY0NzUy
+        YWQtNTkzNS00YWZjLTg0NzgtYjNkNDhlNTA1YWNiLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMDBkNjQwOGQtMDQ5OS00OGUwLWJjOTYtN2M5YzNh
-        MGRiMzE0LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNWMxNmNlNzUtNTZiYS00NWQ1LWJiYWUtMTI2YzZj
+        MzhjNDg0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:33 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:33 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 5adc983d66e641e4adc0c41773c91ae2
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:33 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:33 GMT
+      - Fri, 29 Jul 2022 08:57:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f98eb7bf35e496895febe3e4501cde5
+      - b2bc4d47b6a34964ab33ae1615982dff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:33 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/2f4752ad-5935-4afc-8478-b3d48e505acb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:33 GMT
+      - Fri, 29 Jul 2022 08:57:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3dcafc95e9694654b0793eafd2b2c6cb
+      - b45116294cbf4c2d80b49f772f363d15
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMmY0NzUyYWQtNTkzNS00YWZjLTg0NzgtYjNkNDhlNTA1YWNiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NTEuMjU2NjMzWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS81YzE2Y2U3NS01NmJhLTQ1ZDUtYmJhZS0xMjZjNmMzOGM0ODQv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzVjMTZjZTc1LTU2YmEtNDVkNS1iYmFlLTEyNmM2
+        YzM4YzQ4NC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:51 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8yZjQ3NTJhZC01OTM1LTRhZmMtODQ3OC1iM2Q0OGU1MDVhY2Iv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 80e3f738afd24967a138a92fa48261c3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwNzM2ZTQ3LTQ1NmUtNDk4
+        Mi1hYThjLWZmOTQxNDllNGM3My8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c0736e47-456e-4982-aa8c-ff94149e4c73/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:52 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3bcdaa92b9974b499b56d3b9795ff112
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzA3MzZlNDctNDU2
+        ZS00OTgyLWFhOGMtZmY5NDE0OWU0YzczLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTEuODgzMjczWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4MGUzZjczOGFmZDI0OTY3YTEzOGE5MmZh
+        NDgyNjFjMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3OjUxLjkz
+        MTAzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6NTIuMTQ0
+        NDgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vOTZk
+        NTgyNWEtMWY3Yi00OTcwLTg1YTUtYWM0ZDQ1NDdlNzEzLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:52 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/96d5825a-1f7b-4970-85a5-ac4d4547e713/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:52 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 65096ffd4f2b42fe9679284d66894bb1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzk2ZDU4MjVhLTFmN2ItNDk3MC04NWE1LWFjNGQ0NTQ3ZTcxMy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU3OjUyLjEyNjc2M1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMmY0NzUyYWQtNTkzNS00YWZjLTg0Nzgt
+        YjNkNDhlNTA1YWNiLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:52 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:52 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2438f67454894bd59c72cd6e3a47b485
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:52 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:52 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fb2e930ed8ae4c8bab26a21cce8f7cb6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:57:52 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:57:52 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 25076969e27642cf89a5762dd6bc3c31
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:33 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:33 GMT
+      - Fri, 29 Jul 2022 08:57:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a1c834f91e6149e9aefe1619b5868bc8
+      - 195629b9f11e4f65865b99f25fd71991
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:33 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:33 GMT
+      - Fri, 29 Jul 2022 08:57:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b5456b9bee54369991aebaa33a87e3a
+      - 521a61f82f04433c854eeed36219b516
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:33 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:33 GMT
+      - Fri, 29 Jul 2022 08:57:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c113238c5ca9491580831fa1a2c19b07
+      - 563bee298643405ba4f7ab5dc7f77f46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:33 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab4f0235a50747d683093404450d8a5f
+      - 2ce6f5cd5fce444381805be6573ffd14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed861ac05b284237940e9617032d7edc
+      - 8ea4ebba427b4e59a5d73f9863b9b04d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58afa322efec4c0d8c592fc57c517697
+      - c5c5e7f585744e2c847b041f50b6941d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5c16ce75-56ba-45d5-bbae-126c6c38c484/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 862c2df1ce7a4f06ac71f6740c3395b3
+      - 2ee18de9cd5d445f89ee7c0ef8369057
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,37 +3208,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd04df95e15b4e88966c9af845f33ee5
+      - bac9c83e14c64dc3bdcfa613c638186d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiN2M3MzJjLTllYjItNDg3
-        ZS04YjJiLTRhYWU3ZTk0MDJkYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY4OTZmYjFlLWQ3MGUtNDc2
+        NS1hMTlmLTczYjlhOWNkNzFhNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdk
-        ZWExNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0
-        YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvODNhZTM3ODYtNmZmZS00Njll
-        LWIzOGYtYTU0OGVhZWY1ZmEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1
-        ZmEvIl19
+        cG0vYWR2aXNvcmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRj
+        ZGRlYjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEy
+        MzJjMDU4LWY2ZGQtNDQ2Ny1iOGViLTVjY2MwZDZkYTY4YS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYyOWYzMGEtMTRmNy00NDU1
+        LWEzY2EtMjRiZDhjNmI0ODM5LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5
+        MzMvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2826,7 +3251,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2844,21 +3269,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f162b680b2cf45ba9f5e19da7521fb4e
+      - 9159357509394a7498b8e1a4cbcc84c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmZWRjMGE0LWY4NmQtNDFh
-        YS1iNWUwLTk0NzYxZDUyNDllZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhNDRjMzEyLWY3ZjItNGEy
+        NC05N2E1LWYzMzQ3ZTI4MmVkYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1fedc0a4-f86d-41aa-b5e0-94761d5249ee/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5a44c312-f7f2-4a24-97a5-f3347e282edc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2879,53 +3304,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - be3a05ea99404ec9b7e4b0f84bacd8fa
+      - 5c6f039474664df992b17b60f9dfdd50
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWZlZGMwYTQtZjg2
-        ZC00MWFhLWI1ZTAtOTQ3NjFkNTI0OWVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzQuMjM2MDQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWE0NGMzMTItZjdm
+        Mi00YTI0LTk3YTUtZjMzNDdlMjgyZWRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTc6NTMuNTM4Nzk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmMTYyYjY4MGIyY2Y0NWJhOWY1
-        ZTE5ZGE3NTIxZmI0ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjM0LjM4OTI4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        MzQuNTM0MzM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5MTU5MzU3NTA5Mzk0YTc0OThi
+        OGUxYTRjYmNjODRjMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU3
+        OjUzLjc4MzMxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTc6
+        NTQuMDAyNzA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hZmU3MDQzYy0wMjA1LTQ4YzYtYTgyZi0zMTQxNGQwYjMyZDUvdmVyc2lv
+        bS84YTQyNjZkYS1lZDg5LTRhNzMtOWViNS1jYWU1OTBhZTlhMTEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWZlNzA0M2MtMDIwNS00OGM2
-        LWE4MmYtMzE0MTRkMGIzMmQ1LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGE0MjY2ZGEtZWQ4OS00YTcz
+        LTllYjUtY2FlNTkwYWU5YTExLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2933,7 +3358,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2946,44 +3371,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fc2998a6aa1f4b7d8c02a0f752c2195f
+      - 1c0696418f2641f1b2cfe287c700a930
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '193'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy84M2FlMzc4Ni02ZmZlLTQ2OWUtYjM4Zi1hNTQ4ZWFlZjVmYTIv
+        YWNrYWdlcy83NjI5ZjMwYS0xNGY3LTQ0NTUtYTNjYS0yNGJkOGM2YjQ4Mzkv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3NWZhLyJ9
+        a2FnZXMvMTIzMmMwNTgtZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8ifV19
+        Z2VzL2QwMWMxYmUwLWJmMmEtNDIwOS1iMTgxLThkNTk5ZmQwNzkzMy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2991,7 +3416,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3004,7 +3429,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3022,21 +3447,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - abf0edb8cc674665af35611eed71e389
+      - 466ed009e5e74766b7ce5c3bded0f07b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3044,7 +3469,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3057,37 +3482,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1351'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e117038f2f242a8aa786d733e3bf8bc
+      - 071f8ec878b84a46aafd15ddd811af47
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '527'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzYwMTVkZGM5LTVmZTktNGU4MC04NTkyLTM3Y2Q4N2RlYTE0
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3Njg4
-        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU2IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzL2E3YWZjYTk1LWIzYjYtNGVjZC05YzQ2LTc3MWE0NGNkZGVi
+        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQyNjgy
+        NFoiLCJpZCI6IlJIRUEtMjAxMjowMDU2IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowOCIsImRlc2NyaXB0aW9uIjoiUGFydGhhQmlyZF9F
         cnJhdHVtIiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA4Iiwi
         ZnJvbXN0ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxl
@@ -3115,10 +3540,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3126,7 +3551,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3139,7 +3564,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:34 GMT
+      - Fri, 29 Jul 2022 08:57:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3157,21 +3582,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 61dffbfd26a44eeebca1ee5d3a49d7a9
+      - bdcb545d92c04ba4b14f74846870ae2c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:34 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3179,7 +3604,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3192,7 +3617,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:35 GMT
+      - Fri, 29 Jul 2022 08:57:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3210,21 +3635,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 851155513db8476b91d2b1209a4f262b
+      - 58d32928f24548769228acf88b85986d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8a4266da-ed89-4a73-9eb5-cae590ae9a11/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3232,7 +3657,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3245,7 +3670,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:35 GMT
+      - Fri, 29 Jul 2022 08:57:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3263,16 +3688,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b9c1f7bf2cb645b7aca366cb613a7ebc
+      - e562771214684677aa6852abf9b3b16f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:57:54 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_whitelist_max_version_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_whitelist_max_version_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:42 GMT
+      - Fri, 29 Jul 2022 08:59:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0135c16238334d1081f94245a0e56432
+      - cd6dbdb8386e42328b0be1cc93bc32b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83N2QzNzcxMi04MWI0LTQ1OTMtYWFjZC1jMzU3ZjI2M2M1OTEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjozNi42NDI4NzZa
+        cnBtL3JwbS9lMmQzMTNjYS04YTQyLTQ0MzgtODhiOC1mMWE0MDkwYTlkZjAv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1OTo0My43NDk3NDNa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83N2QzNzcxMi04MWI0LTQ1OTMtYWFjZC1jMzU3ZjI2M2M1OTEv
+        cnBtL3JwbS9lMmQzMTNjYS04YTQyLTQ0MzgtODhiOC1mMWE0MDkwYTlkZjAv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzc3ZDM3
-        NzEyLTgxYjQtNDU5My1hYWNkLWMzNTdmMjYzYzU5MS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UyZDMx
+        M2NhLThhNDItNDQzOC04OGI4LWYxYTQwOTBhOWRmMC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:56 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e2d313ca-8a42-4438-88b8-f1a4090a9df0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:42 GMT
+      - Fri, 29 Jul 2022 08:59:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3296ce1d7d054bdc874493bef2c9453b
+      - '04510846c38640f0bb1cf54e63e545eb'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiZWYzODMxLTcwMWMtNDcw
-        Zi1hMWM2LThlYTE1MTg3YTZjYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiMzBjNjg5LTQ0M2YtNDll
+        My1iOGQ3LTM5N2NjMzIwNGFmNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:42 GMT
+      - Fri, 29 Jul 2022 08:59:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bca227ccfaf546cf85e463689ce492f0
+      - 83e076f2a1044af08f13053e567f1078
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/bbef3831-701c-470f-a1c6-8ea15187a6cb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0b30c689-443f-49e3-b8d7-397cc3204af4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:42 GMT
+      - Fri, 29 Jul 2022 08:59:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7966af4ceffc41fe83205b2d654a250d
+      - 5e23f7386f0f41b59dbec26ded6ec75b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmJlZjM4MzEtNzAx
-        Yy00NzBmLWExYzYtOGVhMTUxODdhNmNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDIuNTc0OTIxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGIzMGM2ODktNDQz
+        Zi00OWUzLWI4ZDctMzk3Y2MzMjA0YWY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTYuMzk2NTAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzMjk2Y2UxZDdkMDU0YmRjODc0NDkzYmVm
-        MmM5NDUzYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjQyLjYw
-        ODE1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NDIuNzI5
-        NDI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNDUxMDg0NmMzODY0MGYwYmIxY2Y1NGU2
+        M2U1NDVlYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjU2LjQ1
+        NDA0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NTYuNjUw
+        MDA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzdkMzc3MTItODFiNC00NTkz
-        LWFhY2QtYzM1N2YyNjNjNTkxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTJkMzEzY2EtOGE0Mi00NDM4
+        LTg4YjgtZjFhNDA5MGE5ZGYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:42 GMT
+      - Fri, 29 Jul 2022 08:59:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7e536dcd99fc4ef6b942624850c1b893
+      - 8cbaf6a556d44c23ab93eb0282aa2205
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:42 GMT
+      - Fri, 29 Jul 2022 08:59:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - be0d44fa0d5841a8b27ef3840c2848d6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNWE2NjVkOGQtYmNiOC00MWEzLWJjMTYtNTIwZDk0ZTM0OGYx
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6NTAuNTIxNzAy
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:56 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/5a665d8d-bcb8-41a3-bc16-520d94e348f1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0e34ef02fdab4edb88c6a4f937262798
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmYjhlZTQ4LTFkMGMtNGFh
+        NS1iMWQ2LWQ1MGFiNmVjZTE4NS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bfb8ee48-1d0c-4aa5-b1d6-d50ab6ece185/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7dbb98b7a11a488487ff265b8f30d106
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmZiOGVlNDgtMWQw
+        Yy00YWE1LWIxZDYtZDUwYWI2ZWNlMTg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTYuODM0ODE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZTM0ZWYwMmZkYWI0ZWRiODhjNmE0Zjkz
+        NzI2Mjc5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjU2Ljg3
+        MzAyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NTYuOTI0
+        MTYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d9d820d972249ce8695d5fb003692cd
+      - 63cf8b71552247afa9e0076db910cc9f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:42 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 61781c43e3c24de6b3064c362377933b
+      - cd95400fe5e745f5bf2fd49da33935a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af2f72d308a24c1688758db792788ab0
+      - 4e129f4e65154280a1f1e2f79dd913d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 34c5bdb544c749be9bf7d195b44d78bf
+      - 02eea459b7f244909951a9e880ba2c20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:43 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0a921921c44143fca549c6a60a0e05e2
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/1dfcd354-b853-4efe-aac9-6bd631d1d368/"
+      - "/pulp/api/v3/remotes/rpm/rpm/fc82639a-84d5-4849-861e-091c3b29152b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8228bb50943245e3907501543e65235e
+      - edcf42b3632b4906a825b7c4615aefab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFk
-        ZmNkMzU0LWI4NTMtNGVmZS1hYWM5LTZiZDYzMWQxZDM2OC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjQzLjI0MTc1MloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Zj
+        ODI2MzlhLTg0ZDUtNDg0OS04NjFlLTA5MWMzYjI5MTUyYi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjU3LjM1NTc2MFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjQzLjI0MTc3MloiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjU3LjM1NTc4MloiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/"
+      - "/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 02460be50ef84908acb05b75e7195efd
+      - 1f88b160a0bf4102b9092900b8d670f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjE3NDQ1ZjAtYTE0Ny00ODkxLWE0OTMtNDExMDI0NTVmMzk3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NDMuMzU0NTMzWiIsInZl
+        cG0vODVlZDAwMDEtYzUyYi00MDg0LTk4NzgtYjkzMzNiZTA2ZmRiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6NTcuNDk5MjQ3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjE3NDQ1ZjAtYTE0Ny00ODkxLWE0OTMtNDExMDI0NTVmMzk3L3ZlcnNp
+        cG0vODVlZDAwMDEtYzUyYi00MDg0LTk4NzgtYjkzMzNiZTA2ZmRiL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yMTc0NDVmMC1h
-        MTQ3LTQ4OTEtYTQ5My00MTEwMjQ1NWYzOTcvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84NWVkMDAwMS1j
+        NTJiLTQwODQtOTg3OC1iOTMzM2JlMDZmZGIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5aadfd6b0eee42dda81c6de3ae924897
+      - 7f0155aa1b8b449899ae99c79258100f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lOTQ1NWNlNi1kNGU4LTQ3MTQtODQ0ZC02ODQ3MTAxMDc3MDgv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjozNy40MDYzNDda
+        cnBtL3JwbS82YTExYTQxNC1jNWUzLTQ1MWYtYjlhZi0zZGE1NGFiZWM1NjQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1OTo0NC43MDA3Mjla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lOTQ1NWNlNi1kNGU4LTQ3MTQtODQ0ZC02ODQ3MTAxMDc3MDgv
+        cnBtL3JwbS82YTExYTQxNC1jNWUzLTQ1MWYtYjlhZi0zZGE1NGFiZWM1NjQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U5NDU1
-        Y2U2LWQ0ZTgtNDcxNC04NDRkLTY4NDcxMDEwNzcwOC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZhMTFh
+        NDE0LWM1ZTMtNDUxZi1iOWFmLTNkYTU0YWJlYzU2NC92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6a11a414-c5e3-451f-b9af-3da54abec564/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c0e7eb83c6f4469ab120ca8f8d7166b
+      - 0f3f4ebb6eef46f29d4f160f5f228e41
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzODMxYzg3LWFiODEtNDMy
-        YS1hZjliLTE0YjMwOWJiMWFkOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjZDg2NTE1LWFhODAtNDg4
+        NC1hOTM2LTI2MmQ4NzU1ZjI3Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 59271a3cb3af43d398138723ee878e90
+      - 4e7adddc956e43409d24b83c3f748124
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZTkzOGRmNTItMTk1Ni00YTJhLWI1YTktZjU5YzllYTdlMDY5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MzYuNDk5OTg5WiIsIm5h
+        cG0vM2JlYTRlMTItOTUwNS00NWI3LWI3MGMtM2ExOGRjOWQ3MzgwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6NDMuNjA0MDI2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjozNy43NDk4NThaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1OTo0NS4xNDQ4MzJaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/e938df52-1956-4a2a-b5a9-f59c9ea7e069/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/3bea4e12-9505-45b7-b70c-3a18dc9d7380/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 551a31e04d464ab290800477a48261c7
+      - ea785bca75e649dd82a86c040010ef19
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwN2NmNjEyLTgzOWItNDQz
-        Yi05NjJiLTY1MjA4MDYxZjM2NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2NmI2OTUzLTFiNjQtNGYy
+        Yy04MWMwLTM5MGFiODdiOTE3MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/63831c87-ab81-432a-af9b-14b309bb1ad8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6cd86515-aa80-4884-a936-262d8755f27c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 80f62a0addf747e387bfe4514948f792
+      - c3ed9f30bfe94ddfbe953d2cd90c106b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjM4MzFjODctYWI4
-        MS00MzJhLWFmOWItMTRiMzA5YmIxYWQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDMuNTA3NDQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmNkODY1MTUtYWE4
+        MC00ODg0LWE5MzYtMjYyZDg3NTVmMjdjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTcuNzEzMTM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5YzBlN2ViODNjNmY0NDY5YWIxMjBjYThm
-        OGQ3MTY2YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjQzLjUz
-        ODM4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NDMuNTk1
-        NzMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZjNmNGViYjZlZWY0NmYyOWQ0ZjE2MGY1
+        ZjIyOGU0MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjU3Ljc0
+        ODY3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NTcuODQy
+        MDMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTk0NTVjZTYtZDRlOC00NzE0
-        LTg0NGQtNjg0NzEwMTA3NzA4LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmExMWE0MTQtYzVlMy00NTFm
+        LWI5YWYtM2RhNTRhYmVjNTY0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/107cf612-839b-443b-962b-65208061f365/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/966b6953-1b64-4f2c-81c0-390ab87b9170/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68454c1e500444f88ba0048c5e671b99
+      - '0068205fc42944cb9eaf187d83670d4c'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTA3Y2Y2MTItODM5
-        Yi00NDNiLTk2MmItNjUyMDgwNjFmMzY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDMuNTkzMDE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTY2YjY5NTMtMWI2
+        NC00ZjJjLTgxYzAtMzkwYWI4N2I5MTcwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTcuODM2OTUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NTFhMzFlMDRkNDY0YWIyOTA4MDA0Nzdh
-        NDgyNjFjNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjQzLjYy
-        ODM0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NDMuNjY4
-        ODc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlYTc4NWJjYTc1ZTY0OWRkODJhODZjMDQw
+        MDEwZWYxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjU3Ljg4
+        MTAxN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NTcuOTMz
+        Mzc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2U5MzhkZjUyLTE5NTYtNGEyYS1iNWE5
-        LWY1OWM5ZWE3ZTA2OS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzNiZWE0ZTEyLTk1MDUtNDViNy1iNzBj
+        LTNhMThkYzlkNzM4MC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd95af31619a40f8933dce16135b9213
+      - 1c09c2cfc17c45db96dd63256460ff2e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 15b0908858504bceb2b82ae5a2654c66
+      - e1655e1935454f3a9ad33de6dc816e77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4a55c8535934d7fa3aa35f585c4f06e
+      - 5a7cf437fa5c43aaaa6f590fcfc83592
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4271a3164123406ca76409022e498f96
+      - 67a9c3ce17ac4c60982f1e04acbeff1b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94c616d7137a46bc81d93157a07c8488
+      - 4f89d814fca542a485578264c4aed71e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:43 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9bc8cf86e440423e84c591482a315fd4
+      - 2bd820708519459aae208592e90ecd77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:43 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:44 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/"
+      - "/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b73cbec6789345ad97cb848336ea5cb2
+      - 96350a61b96345068d9dbee3a4b1a73d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZDliNWY4ZGEtNzkyZS00OGRhLWIxNTYtZDVmOTJjZmFiZjQ2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NDQuMTE4OTU3WiIsInZl
+        cG0vOWI2MWYzOTItZGUyNi00ZGI3LWE5NTYtODcyNjE1Yjk1MmNlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6NTguMzg3MDY3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZDliNWY4ZGEtNzkyZS00OGRhLWIxNTYtZDVmOTJjZmFiZjQ2L3ZlcnNp
+        cG0vOWI2MWYzOTItZGUyNi00ZGI3LWE5NTYtODcyNjE1Yjk1MmNlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kOWI1ZjhkYS03
-        OTJlLTQ4ZGEtYjE1Ni1kNWY5MmNmYWJmNDYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85YjYxZjM5Mi1k
+        ZTI2LTRkYjctYTk1Ni04NzI2MTViOTUyY2UvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:44 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/1dfcd354-b853-4efe-aac9-6bd631d1d368/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/fc82639a-84d5-4849-861e-091c3b29152b/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:44 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 88ba7f18cc6f419f85de44448d3646f3
+      - 9d2bcfec09a0409c9483223553f17972
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjMjFjOGU5LTU1OWQtNGQ4
-        Yi04ZmM1LTBmODIzNGU5ZWY0NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxMTI2ZTYzLTFkYjUtNDhl
+        MC1hNmQ2LTIzNWQxMTkzMzkzYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:44 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4c21c8e9-559d-4d8b-8fc5-0f8234e9ef44/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/71126e63-1db5-48e0-a6d6-235d1193393a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:44 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66d912b766034926b82d5837b0e36d8f
+      - 8fe6ae856d7a4c769a3569002a4ec3fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGMyMWM4ZTktNTU5
-        ZC00ZDhiLThmYzUtMGY4MjM0ZTllZjQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDQuNDIzNzc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzExMjZlNjMtMWRi
+        NS00OGUwLWE2ZDYtMjM1ZDExOTMzOTNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTguNzQwMzI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI4OGJhN2YxOGNjNmY0MTlmODVkZTQ0NDQ4
-        ZDM2NDZmMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjQ0LjQ1
-        NDEwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NDQuNDc2
-        OTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5ZDJiY2ZlYzA5YTA0MDljOTQ4MzIyMzU1
+        M2YxNzk3MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjU4Ljc4
+        NjE4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6NTguODE2
+        MDI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFkZmNkMzU0LWI4NTMtNGVmZS1hYWM5
-        LTZiZDYzMWQxZDM2OC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZjODI2MzlhLTg0ZDUtNDg0OS04NjFl
+        LTA5MWMzYjI5MTUyYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:44 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFkZmNk
-        MzU0LWI4NTMtNGVmZS1hYWM5LTZiZDYzMWQxZDM2OC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZjODI2
+        MzlhLTg0ZDUtNDg0OS04NjFlLTA5MWMzYjI5MTUyYi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:44 GMT
+      - Fri, 29 Jul 2022 08:59:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef2aad7f7b834c718b29d9c85b87ce11
+      - c84dcd502c034fb299635b4cfcbc5846
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhMTA3NTBkLTRkOTItNGJi
-        YS05MGU4LTBmNzIzNzA2NjY1Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU1Mzc3ZWFhLTRhZTEtNGVj
+        MC05NWY4LThjYmMyNDMxY2RiNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:44 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5a10750d-4d92-4bba-90e8-0f723706665f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/55377eaa-4ae1-4ec0-95f8-8cbc2431cdb4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:46 GMT
+      - Fri, 29 Jul 2022 09:00:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e667c02af6254c8a83c2f7e2aa43f0bf
+      - fe0c4ca9892443b4bfa0adb5a7f3506d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '600'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWExMDc1MGQtNGQ5
-        Mi00YmJhLTkwZTgtMGY3MjM3MDY2NjVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDQuNTk4MDUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTUzNzdlYWEtNGFl
+        MS00ZWMwLTk1ZjgtOGNiYzI0MzFjZGI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6NTguOTMwNzMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJlZjJhYWQ3ZjdiODM0YzcxOGIy
-        OWQ5Yzg1Yjg3Y2UxMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjQ0LjYyODA4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        NDYuMjU5NjgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJjODRkY2Q1MDJjMDM0ZmIyOTk2
+        MzViNGNmY2JjNTg0NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjU4Ljk3NjgyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        MDMuOTIxNzcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMjE3NDQ1ZjAtYTE0Ny00ODkxLWE0OTMt
-        NDExMDI0NTVmMzk3L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzIxNzQ0NWYwLWExNDctNDg5MS1hNDkzLTQxMTAyNDU1ZjM5Ny8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS8xZGZjZDM1NC1iODUz
-        LTRlZmUtYWFjOS02YmQ2MzFkMWQzNjgvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzg1ZWQwMDAxLWM1MmItNDA4NC05ODc4LWI5
+        MzMzYmUwNmZkYi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84
+        NWVkMDAwMS1jNTJiLTQwODQtOTg3OC1iOTMzM2JlMDZmZGIvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZmM4MjYzOWEtODRkNS00
+        ODQ5LTg2MWUtMDkxYzNiMjkxNTJiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMjE3NDQ1ZjAtYTE0Ny00ODkxLWE0OTMtNDExMDI0NTVm
-        Mzk3L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vODVlZDAwMDEtYzUyYi00MDg0LTk4NzgtYjkzMzNiZTA2
+        ZmRiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:46 GMT
+      - Fri, 29 Jul 2022 09:00:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d193e49568442c58bd1ca2f03e22446
+      - 4cb3495626b746db9789df8e7b6ceeeb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjMmExYWNkLTIwZGMtNGY4
-        Ni04NGUxLWZiZDlhYTRmMDRiZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5NDEzYTkwLTNhZTktNDQz
+        MS1hYWQ5LWYxYjQ4ZmM4ZDVjNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3c2a1acd-20dc-4f86-84e1-fbd9aa4f04be/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/29413a90-3ae9-4431-aad9-f1b48fc8d5c5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:46 GMT
+      - Fri, 29 Jul 2022 09:00:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '09d0921665414a968be176cfa37fa691'
+      - 209d378891ae40af8fc822dc97d96bec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '473'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2MyYTFhY2QtMjBk
-        Yy00Zjg2LTg0ZTEtZmJkOWFhNGYwNGJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDYuNTI1ODQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjk0MTNhOTAtM2Fl
+        OS00NDMxLWFhZDktZjFiNDhmYzhkNWM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MDQuMTc5Njk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjRkMTkzZTQ5NTY4NDQyYzU4YmQxY2EyZjAz
-        ZTIyNDQ2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NDYuNTU3
-        MTUwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMjo0Ni43NTU1
-        MDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjRjYjM0OTU2MjZiNzQ2ZGI5Nzg5ZGY4ZTdi
+        NmNlZWViIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MDQuMjI4
+        NzU4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMDowNC41NDUz
+        MjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTExMmZi
-        NDEtN2Q3NC00ODk4LTlmM2EtNDYxNzJlYmY5MTFjLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTc3NGY5
+        YzQtYmYwOC00N2ZkLTlhNTAtNmVkODAyY2FjNDM3LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMjE3NDQ1ZjAtYTE0Ny00ODkxLWE0OTMtNDExMDI0
-        NTVmMzk3LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vODVlZDAwMDEtYzUyYi00MDg0LTk4NzgtYjkzMzNi
+        ZTA2ZmRiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 90acb1f42991472e8adc2c1ab7a2fa12
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9079796cadc44aa692cfe2684a5db74b
+      - 68faa64c01804c99a911f80154e35a44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/5774f9c4-bf08-47fd-9a50-6ed802cac437/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c894a4664c6448c8a983ed1e2b8a0c9
+      - 0f17da2d221a40bbb872f0d3c6bc215d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNTc3NGY5YzQtYmYwOC00N2ZkLTlhNTAtNmVkODAyY2FjNDM3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MDQuMjUzMzUyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84NWVkMDAwMS1jNTJiLTQwODQtOTg3OC1iOTMzM2JlMDZmZGIv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzg1ZWQwMDAxLWM1MmItNDA4NC05ODc4LWI5MzMz
+        YmUwNmZkYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:04 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS81Nzc0ZjljNC1iZjA4LTQ3ZmQtOWE1MC02ZWQ4MDJjYWM0Mzcv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f0cd664218654e33bea4af815d519ebb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjMzFjNWJhLWFmZWItNGNk
+        MS1iMzU2LTA0MDAxNTk5ZTkzYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/dc31c5ba-afeb-4cd1-b356-04001599e93b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c9dad601e3b8482a8d471ec4e7ccc582
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGMzMWM1YmEtYWZl
+        Yi00Y2QxLWIzNTYtMDQwMDE1OTllOTNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MDQuODkzNDE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmMGNkNjY0MjE4NjU0ZTMzYmVhNGFmODE1
+        ZDUxOWViYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjA0Ljk0
+        Nzg4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MDUuMjIx
+        MjI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZTA3
+        ZTkzZjktYjI1OC00MDMxLTgzODEtOGRlODE3OWI1MTUwLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/e07e93f9-b258-4031-8381-8de8179b5150/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ab377eeb7cfe4a5b80e7f88861ca916c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2UwN2U5M2Y5LWIyNTgtNDAzMS04MzgxLThkZTgxNzliNTE1MC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjA1LjE5OTc2N1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNTc3NGY5YzQtYmYwOC00N2ZkLTlhNTAt
+        NmVkODAyY2FjNDM3LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c6a0932e834c414b9e286db8ce6544b1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 06f5a93087474ebabd5e52d3cba033a8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 811a705c4a9a4339be75612ee170f1fb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e0912fdde424122badc6f64bbf9d0c1
+      - 16900dd924144755b8efc5d4af8422c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 63905a7efbbb4185b398b545333b8e04
+      - cb53824d70b14f0daac6180853722e6f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53f49f820c334997b90244fbc9e160d9
+      - e381f2bac0114e769495104da54d6eda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e88da9bbab2f4dcdb9ad92b17075a16a
+      - bd805d8adbc443d6ab2909715aad5672
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0472451ad1524ed49e5511fc14ae5d66
+      - 44c6fbab30a64912a9166241e3aaf2a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1ce4776c458484eb75b2ffa1b063439
+      - 18d3e011bbf74bb1b444d65b6fde5662
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 255513af72b64cc4a8b258f9b72c331c
+      - c3017f51215442139a9b2b894b2fc895
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,32 +3208,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4a1f1cfb63ca4210b1ed4c545a6338ed
+      - cc88a74ee67546dab6fc2826c8612d7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3NjZkNGNjLTBhMjQtNDhk
-        MC1iZTFkLWQ0MWE5NTViNjA2Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5ZGEyYTg0LWUwMWEtNDlk
+        My1iZjg4LTQ1MGQ3MjZmOWE3MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvZTVjYWUzZjMtYjJkMC00MjJjLTllOTEtOGVkZDlkOWQx
-        MTYyLyJdfQ==
+        cG0vcGFja2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUx
+        N2NkLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2821,7 +3246,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:47 GMT
+      - Fri, 29 Jul 2022 09:00:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2839,21 +3264,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd8887a994f64ababc02ca714a423182
+      - 219427b1f99846289a161c7caa05c9ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiYWM0Y2IxLTMyNDctNDUw
-        Ni04N2RlLTQwYzU2ODdlOGM5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJmNWM1NmI0LTIxNDEtNDQ1
+        MS05N2VkLTMyYThiZWU5YjhjOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:47 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cbac4cb1-3247-4506-87de-40c5687e8c99/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2f5c56b4-2141-4451-97ed-32a8bee9b8c9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2874,53 +3299,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:48 GMT
+      - Fri, 29 Jul 2022 09:00:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce26ece8dac44a2488ba8ce82ba668cf
+      - 33b3a75996e244759e7f86b5def1039f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2JhYzRjYjEtMzI0
-        Ny00NTA2LTg3ZGUtNDBjNTY4N2U4Yzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDcuNzc1MzE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmY1YzU2YjQtMjE0
+        MS00NDUxLTk3ZWQtMzJhOGJlZTliOGM5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MDYuNzg3OTczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmZDg4ODdhOTk0ZjY0YWJhYmMw
-        MmNhNzE0YTQyMzE4MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjQ3LjkyODk0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        NDguMDU5NDUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMTk0MjdiMWY5OTg0NjI4OWEx
+        NjFjN2NhYTA1YzlhZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjA3LjA3NzU1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        MDcuMzA4Nzk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9kOWI1ZjhkYS03OTJlLTQ4ZGEtYjE1Ni1kNWY5MmNmYWJmNDYvdmVyc2lv
+        bS85YjYxZjM5Mi1kZTI2LTRkYjctYTk1Ni04NzI2MTViOTUyY2UvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDliNWY4ZGEtNzkyZS00OGRh
-        LWIxNTYtZDVmOTJjZmFiZjQ2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWI2MWYzOTItZGUyNi00ZGI3
+        LWE5NTYtODcyNjE1Yjk1MmNlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2928,7 +3353,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2941,41 +3366,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:48 GMT
+      - Fri, 29 Jul 2022 09:00:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e04a5413306a4f6396e49dfa5b6d6a05
+      - f543f864fb524da397919feb088cd01c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDExNjIv
+        YWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3Y2Qv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2983,7 +3408,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2996,7 +3421,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:48 GMT
+      - Fri, 29 Jul 2022 09:00:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3014,21 +3439,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fcac37a78f6c456c81c55ac675a86016
+      - 45f33d3692d6496d9b3ee985108b61a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3036,7 +3461,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3049,7 +3474,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:48 GMT
+      - Fri, 29 Jul 2022 09:00:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3067,21 +3492,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3d182c1b6ec44d4a3b733eec66f3734
+      - dc369caae0c640c398fe33fdcc64923b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3089,7 +3514,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3102,7 +3527,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:48 GMT
+      - Fri, 29 Jul 2022 09:00:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3120,21 +3545,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 88c98143725b4407ae0ee1076ff7d18b
+      - e657c03205284a14b91fe75a402a8ab1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3142,7 +3567,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3155,7 +3580,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:48 GMT
+      - Fri, 29 Jul 2022 09:00:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3173,21 +3598,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4eebc8ba7bab4ed1ab5933d481c8bb17
+      - c227e730f3e04ab1a89dfb7063da7bec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3195,7 +3620,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3208,7 +3633,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:48 GMT
+      - Fri, 29 Jul 2022 09:00:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3226,16 +3651,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 915304455d224cecae9ea137434ba70b
+      - a950e871ff5940af91e0bce4d7f94233
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:08 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_whitelist_min_version_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_whitelist_min_version_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:35 GMT
+      - Fri, 29 Jul 2022 08:58:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0cbc32cb3fd4491eb4a803552851842d
+      - 297d15751e2b4aa68daf2260ffb977de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMGQ2NDA4ZC0wNDk5LTQ4ZTAtYmM5Ni03YzljM2EwZGIzMTQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyOS44MzUwNjBa
+        cnBtL3JwbS81MDdhYTIyMi1lOGY0LTQ5MmItOGVjNS05MDJkZjk4ZDlhNTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1Nzo1Ni45Nzc1OTRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMGQ2NDA4ZC0wNDk5LTQ4ZTAtYmM5Ni03YzljM2EwZGIzMTQv
+        cnBtL3JwbS81MDdhYTIyMi1lOGY0LTQ5MmItOGVjNS05MDJkZjk4ZDlhNTEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAwZDY0
-        MDhkLTA0OTktNDhlMC1iYzk2LTdjOWMzYTBkYjMxNC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzUwN2Fh
+        MjIyLWU4ZjQtNDkyYi04ZWM1LTkwMmRmOThkOWE1MS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:06 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/00d6408d-0499-48e0-bc96-7c9c3a0db314/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/507aa222-e8f4-492b-8ec5-902df98d9a51/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:35 GMT
+      - Fri, 29 Jul 2022 08:58:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a27deca75dd14df78ed0b20bbc4d4c5c
+      - 31804f1d772243bc9c175cb04de9654b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5YzVlYjA2LTMyN2EtNGM3
-        NC05MGJjLTcyNjkwY2RkYWJjOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjMDUxODY1LWNhMWYtNDA3
+        NC1hN2I2LWM1MDRjZDZkYTVhNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:35 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 075af38846bf4791a95b3cdc3c45798b
+      - 119cdddb19d54dbcbcb47515239944ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/29c5eb06-327a-4c74-90bc-72690cddabc8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3c051865-ca1f-4074-a7b6-c504cd6da5a4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '09a5da315c6b4d1f9b0b378f634300e2'
+      - bfc93f50b3114157af3d02da35fb8dfa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjljNWViMDYtMzI3
-        YS00Yzc0LTkwYmMtNzI2OTBjZGRhYmM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzUuOTUyNjg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2MwNTE4NjUtY2Ex
+        Zi00MDc0LWE3YjYtYzUwNGNkNmRhNWE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDYuNjM1MzgwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhMjdkZWNhNzVkZDE0ZGY3OGVkMGIyMGJi
-        YzRkNGM1YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjM1Ljk4
-        MzMzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzYuMTAw
-        MDIzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzMTgwNGYxZDc3MjI0M2JjOWMxNzVjYjA0
+        ZGU5NjU0YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjA2LjY3
+        NjcwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MDYuODU5
+        MzMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDBkNjQwOGQtMDQ5OS00OGUw
-        LWJjOTYtN2M5YzNhMGRiMzE0LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTA3YWEyMjItZThmNC00OTJi
+        LThlYzUtOTAyZGY5OGQ5YTUxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d3369e0329fc4620b01be7111418422d
+      - f3426b47ff354d9483f4b6656f405f18
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 72068b51c3b843698fc3736b5206ad64
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNjU2ZGY2ZjQtYmVlOC00NmI5LWI0MTItYTJkMjkyNzBlZDU5
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MDMuNDY2NjY0
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/656df6f4-bee8-46b9-b412-a2d29270ed59/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 84e8cc87025146dbb18eb69f3dd6b5cb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmNGYxN2E4LTkxMGYtNDMw
+        OC05NDEyLTk1ZDg0ZjE3NzQwNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ef4f17a8-910f-4308-9412-95d84f177405/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2cc4f3a1accf4e179f90807021285406
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWY0ZjE3YTgtOTEw
+        Zi00MzA4LTk0MTItOTVkODRmMTc3NDA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDcuMDUyMjA1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NGU4Y2M4NzAyNTE0NmRiYjE4ZWI2OWYz
+        ZGQ2YjVjYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjA3LjA5
+        MjgwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MDcuMTI4
+        MTY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b2f60bf53674de2b146322586d23a6f
+      - ad79b4e9b6f44783ba33567b6eb3a40d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dfd577c653db4fadb1afac5135c86fa9
+      - 4ecbff32be384a728ec14094b9d83429
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3da2cb1bc7a34600bb4a01127125f784
+      - d1ca778c4ef9473385df6cdf87eb4629
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f021cc433e6a43a28715bc2e526f4e02
+      - 30e3aad67cf14de48f2f2ee1c5b63f61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:36 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - af5a79aa8d98434ca8850f5816914c19
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/e938df52-1956-4a2a-b5a9-f59c9ea7e069/"
+      - "/pulp/api/v3/remotes/rpm/rpm/b11353fd-3937-4489-8093-581476fe8773/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e49e2926ea55433b99514902a6f6e658
+      - 1e4943d56dab4874bc7359db14c955cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2U5
-        MzhkZjUyLTE5NTYtNGEyYS1iNWE5LWY1OWM5ZWE3ZTA2OS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjM2LjQ5OTk4OVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Ix
+        MTM1M2ZkLTM5MzctNDQ4OS04MDkzLTU4MTQ3NmZlODc3My8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjA3LjU2NzcyMloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjM2LjUwMDAxMVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjA3LjU2Nzc0M1oiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/"
+      - "/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2391c014fde042d08ea00e88be84c53d
+      - 35020fc41c8e4b75a85820902ae843c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzdkMzc3MTItODFiNC00NTkzLWFhY2QtYzM1N2YyNjNjNTkxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MzYuNjQyODc2WiIsInZl
+        cG0vODU1MTkxOGEtZDI4Zi00MTlkLWFkM2QtY2ViMTAxYzBkYThlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MDcuNzEzODE4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzdkMzc3MTItODFiNC00NTkzLWFhY2QtYzM1N2YyNjNjNTkxL3ZlcnNp
+        cG0vODU1MTkxOGEtZDI4Zi00MTlkLWFkM2QtY2ViMTAxYzBkYThlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83N2QzNzcxMi04
-        MWI0LTQ1OTMtYWFjZC1jMzU3ZjI2M2M1OTEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84NTUxOTE4YS1k
+        MjhmLTQxOWQtYWQzZC1jZWIxMDFjMGRhOGUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 81330b86172740eaaee0afe7bd7aa467
+      - 15b561b47c6949a0947a1255ba6edfe3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hZmU3MDQzYy0wMjA1LTQ4YzYtYTgyZi0zMTQxNGQwYjMyZDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjozMC41NDk0NjVa
+        cnBtL3JwbS82OTEyMzM4NS01YmViLTQyODQtYjczYy05ZTM1ZDVhYmE4Y2Qv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1Nzo1Ny45MDEzODRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hZmU3MDQzYy0wMjA1LTQ4YzYtYTgyZi0zMTQxNGQwYjMyZDUv
+        cnBtL3JwbS82OTEyMzM4NS01YmViLTQyODQtYjczYy05ZTM1ZDVhYmE4Y2Qv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2FmZTcw
-        NDNjLTAyMDUtNDhjNi1hODJmLTMxNDE0ZDBiMzJkNS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY5MTIz
+        Mzg1LTViZWItNDI4NC1iNzNjLTllMzVkNWFiYThjZC92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/afe7043c-0205-48c6-a82f-31414d0b32d5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/69123385-5beb-4284-b73c-9e35d5aba8cd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 477a3fe708a34211a6c60749eef42623
+      - 0fe03e632e034221a0b07579d420fa79
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0Mzg1YzNjLTkxNWEtNDg1
-        MS1hZWEzLTA3YmQ0MDgyMTllNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2YzZhODhlLWI3NjYtNDRk
+        ZS1hNTc3LWE0NTM5MDFiODc1MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08adadeda7ca408b92148060ea5bec11'
+      - aff1e50fe9da414f9e9ad60e0cb0b148
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMjgyYWY5OGUtNjIwYi00OTE4LWE3YjktMDM1NDllZGY0OGNkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjkuNzIxMTE0WiIsIm5h
+        cG0vZjIyN2UyNmUtNGNhZi00MzY3LWE4ZWMtMzlhMThhNmY2OTMwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTc6NTYuODMwNjA1WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjozMS4wNTEzMjJaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1Nzo1OC4zMTMxOThaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/282af98e-620b-4918-a7b9-03549edf48cd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/f227e26e-4caf-4367-a8ec-39a18a6f6930/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d74f115b15d4410ab830f23062ff4028
+      - 4434f1bb622e4d838022b81ec30a6467
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2Yzk5ZDVjLWE2MjQtNDc4
-        NC1iYTlkLTdlYjBmYWQ1MTAzOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmMjJjYjIxLTNiMmMtNDRm
+        Yy05ZmY0LTk2NTRiZGE1Nzg4ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a4385c3c-915a-4851-aea3-07bd408219e5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/36c6a88e-b766-44de-a577-a453901b8750/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:36 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ef5d64da5ed42f19661d775cca37438
+      - e162d733f39d4d918a9c813446d83c31
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQzODVjM2MtOTE1
-        YS00ODUxLWFlYTMtMDdiZDQwODIxOWU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzYuNzk5NzYzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzZjNmE4OGUtYjc2
+        Ni00NGRlLWE1NzctYTQ1MzkwMWI4NzUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDcuOTMwNzA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0NzdhM2ZlNzA4YTM0MjExYTZjNjA3NDll
-        ZWY0MjYyMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjM2Ljg0
-        MDk1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzYuODk5
-        OTU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZmUwM2U2MzJlMDM0MjIxYTBiMDc1Nzlk
+        NDIwZmE3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjA3Ljk2
+        ODYyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MDguMDU4
+        MzA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWZlNzA0M2MtMDIwNS00OGM2
-        LWE4MmYtMzE0MTRkMGIzMmQ1LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjkxMjMzODUtNWJlYi00Mjg0
+        LWI3M2MtOWUzNWQ1YWJhOGNkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:36 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f6c99d5c-a624-4784-ba9d-7eb0fad51039/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1f22cb21-3b2c-44fc-9ff4-9654bda5788d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 694cf1a5fc5c46ccb94070c400f86129
+      - 6f550ca42cfc462c87c8d47bcd9aa601
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjZjOTlkNWMtYTYy
-        NC00Nzg0LWJhOWQtN2ViMGZhZDUxMDM5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzYuOTA0NjkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWYyMmNiMjEtM2Iy
+        Yy00NGZjLTlmZjQtOTY1NGJkYTU3ODhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDguMDczNDM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkNzRmMTE1YjE1ZDQ0MTBhYjgzMGYyMzA2
-        MmZmNDAyOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjM2Ljkz
-        NzcyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzYuOTg2
-        MDU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0NDM0ZjFiYjYyMmU0ZDgzODAyMmI4MWVj
+        MzBhNjQ2NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjA4LjEx
+        NTIxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MDguMTgx
+        NDM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzI4MmFmOThlLTYyMGItNDkxOC1hN2I5
-        LTAzNTQ5ZWRmNDhjZC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2YyMjdlMjZlLTRjYWYtNDM2Ny1hOGVj
+        LTM5YTE4YTZmNjkzMC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c24705e1d567405bb99f545e7ebb0220
+      - c40e726428b143a0a4d3df7c88ff3465
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b49e0c2cd0054c3ebb12d064385d1e06
+      - b067e256a7354fdbb4e296ce0e14f005
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a61ad5ff1e9f47d0af5e35ab1856f079
+      - 68df1c19a2304f89a3dbd2aff2aad35a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 816b0e5768304d1692b264fd53a377dd
+      - 1bcaa04cae204777af0e4255a853c70c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b86605e8d67e447c9e42d9cd85c22e4c
+      - d04069060980485ead9273283f78875f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 444457b418a04f8c8d0baaf812831ece
+      - 34544d7397af4535a653b790df42aa6d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/"
+      - "/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73c36ffcea664f4ab0b3d8184b744e8b
+      - d3f4e0ac5b954a4281b40aac0cbfc276
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTk0NTVjZTYtZDRlOC00NzE0LTg0NGQtNjg0NzEwMTA3NzA4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MzcuNDA2MzQ3WiIsInZl
+        cG0vMTEwOWM1MGMtMDAyMC00ZjA0LWI3MDMtNzBlZjJmZjU5MDA1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MDguNjQ2MjIzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTk0NTVjZTYtZDRlOC00NzE0LTg0NGQtNjg0NzEwMTA3NzA4L3ZlcnNp
+        cG0vMTEwOWM1MGMtMDAyMC00ZjA0LWI3MDMtNzBlZjJmZjU5MDA1L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lOTQ1NWNlNi1k
-        NGU4LTQ3MTQtODQ0ZC02ODQ3MTAxMDc3MDgvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xMTA5YzUwYy0w
+        MDIwLTRmMDQtYjcwMy03MGVmMmZmNTkwMDUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:08 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/e938df52-1956-4a2a-b5a9-f59c9ea7e069/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b11353fd-3937-4489-8093-581476fe8773/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d5b87a9042b4d8b8ef5ca3ef3e931af
+      - 90727e52c12b4dc6bd008cf52b3e0b0b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0NTAyZGFmLTY5NWEtNDhh
-        Mi04MDgwLTgyY2Q5NmQzZDU2Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkMWIwZDQ5LWFlMzktNDRm
+        OC1hMGJjLWU0Yjg1YmM2Y2JjZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/84502daf-695a-48a2-8080-82cd96d3d56c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6d1b0d49-ae39-44f8-a0bc-e4b85bc6cbce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e077c6de1584fddb0c814db97a39293
+      - c4071a8edd1a4303adeba52ab7236207
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODQ1MDJkYWYtNjk1
-        YS00OGEyLTgwODAtODJjZDk2ZDNkNTZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzcuNjk1MTc3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmQxYjBkNDktYWUz
+        OS00NGY4LWEwYmMtZTRiODViYzZjYmNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDkuMDI5MjQ0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwZDViODdhOTA0MmI0ZDhiOGVmNWNhM2Vm
-        M2U5MzFhZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjM3Ljcz
-        MTc3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzcuNzU0
-        MDk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5MDcyN2U1MmMxMmI0ZGM2YmQwMDhjZjUy
+        YjNlMGIwYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjA5LjA2
+        OTc1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MDkuMTAz
+        NTcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2U5MzhkZjUyLTE5NTYtNGEyYS1iNWE5
-        LWY1OWM5ZWE3ZTA2OS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IxMTM1M2ZkLTM5MzctNDQ4OS04MDkz
+        LTU4MTQ3NmZlODc3My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:09 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2U5Mzhk
-        ZjUyLTE5NTYtNGEyYS1iNWE5LWY1OWM5ZWE3ZTA2OS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IxMTM1
+        M2ZkLTM5MzctNDQ4OS04MDkzLTU4MTQ3NmZlODc3My8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:37 GMT
+      - Fri, 29 Jul 2022 08:58:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 12a44fbc0c764aef9d4d770bf6c736c0
+      - edd6a8db5aaf4bd2baf5b57987212f10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxNmY3NzA3LTgyNjctNDVi
-        NS1hNWI1LWZmMmZkNTkyZjg3My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhOTQ3NjZiLTJiMjItNGRl
+        Mi04OGU3LTQwYjEzYmJmMjEyNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:37 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e16f7707-8267-45b5-a5b5-ff2fd592f873/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fa94766b-2b22-4de2-88e7-40b13bbf2126/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:39 GMT
+      - Fri, 29 Jul 2022 08:58:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 51518dd505864542a5679cd49946a2f5
+      - b1fba537ccef4b0a969fa798729e27e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '599'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTE2Zjc3MDctODI2
-        Ny00NWI1LWE1YjUtZmYyZmQ1OTJmODczLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzcuODgyNjEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmE5NDc2NmItMmIy
+        Mi00ZGUyLTg4ZTctNDBiMTNiYmYyMTI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MDkuMjIyMjkxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxMmE0NGZiYzBjNzY0YWVmOWQ0
-        ZDc3MGJmNmM3MzZjMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjM3LjkxMjYxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        MzkuNDY5ODg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJlZGQ2YThkYjVhYWY0YmQyYmFm
+        NWI1Nzk4NzIxMmYxMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjA5LjI4MjQzOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        MTMuMjg1MDY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vNzdkMzc3MTItODFiNC00NTkzLWFhY2Qt
-        YzM1N2YyNjNjNTkxL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        Lzc3ZDM3NzEyLTgxYjQtNDU5My1hYWNkLWMzNTdmMjYzYzU5MS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9lOTM4ZGY1Mi0xOTU2
-        LTRhMmEtYjVhOS1mNTljOWVhN2UwNjkvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzg1NTE5MThhLWQyOGYtNDE5ZC1hZDNkLWNl
+        YjEwMWMwZGE4ZS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84
+        NTUxOTE4YS1kMjhmLTQxOWQtYWQzZC1jZWIxMDFjMGRhOGUvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYjExMzUzZmQtMzkzNy00
+        NDg5LTgwOTMtNTgxNDc2ZmU4NzczLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:39 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:13 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNzdkMzc3MTItODFiNC00NTkzLWFhY2QtYzM1N2YyNjNj
-        NTkxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vODU1MTkxOGEtZDI4Zi00MTlkLWFkM2QtY2ViMTAxYzBk
+        YThlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:39 GMT
+      - Fri, 29 Jul 2022 08:58:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4ceecdbb9a9469ab5c4689eb68a6ed8
+      - c6eaa9b3a95e407dab93510b04d36e21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiN2Y4NzA3LWYzMDMtNGM3
-        Ny05MGQ3LTE1NTc5MWI3OWI4Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkOWNhNjMwLWE4YzktNGYw
+        YS1iMjgxLWU0MGQ5OThhYjFlYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:39 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cb7f8707-f303-4c77-90d7-155791b79b8c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2d9ca630-a8c9-4f0a-b281-e40d998ab1eb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:39 GMT
+      - Fri, 29 Jul 2022 08:58:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d488661387848e3ba886d7863f9b51a
+      - ac902bd641094148bdd820fd9c9413a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2I3Zjg3MDctZjMw
-        My00Yzc3LTkwZDctMTU1NzkxYjc5YjhjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6MzkuNjQ5MTI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ5Y2E2MzAtYThj
+        OS00ZjBhLWIyODEtZTQwZDk5OGFiMWViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MTMuNTI5NDI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImE0Y2VlY2RiYjlhOTQ2OWFiNWM0Njg5ZWI2
-        OGE2ZWQ4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6MzkuNjgw
-        NjE5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMjozOS44NTIy
-        MjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImM2ZWFhOWIzYTk1ZTQwN2RhYjkzNTEwYjA0
+        ZDM2ZTIxIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MTMuNTcw
+        Njk4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1ODoxMy44MzMw
+        MDdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDNmODUy
-        MzItZGM0ZC00NzBmLThlYzAtMDlmNjlmZDhhYmMzLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTYzZjQy
+        N2MtYWRjZC00ZmVlLTk2ZTQtYWE0ODdmMzhjMmY4LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNzdkMzc3MTItODFiNC00NTkzLWFhY2QtYzM1N2Yy
-        NjNjNTkxLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vODU1MTkxOGEtZDI4Zi00MTlkLWFkM2QtY2ViMTAx
+        YzBkYThlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:39 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d4ece76dd6e340828b7c6f03b10d474f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68f5efff293f4ab981111097a5f91901
+      - 6df14b660ab74fc6bcd524a21c86f740
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/563f427c-adcd-4fee-96e4-aa487f38c2f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b2bce0a49df5405bb8519c28f6cc5c78
+      - c725e1f58f594f34bc11622a9619c9af
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNTYzZjQyN2MtYWRjZC00ZmVlLTk2ZTQtYWE0ODdmMzhjMmY4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6MTMuNTkyNjk1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84NTUxOTE4YS1kMjhmLTQxOWQtYWQzZC1jZWIxMDFjMGRhOGUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzg1NTE5MThhLWQyOGYtNDE5ZC1hZDNkLWNlYjEw
+        MWMwZGE4ZS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:14 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS81NjNmNDI3Yy1hZGNkLTRmZWUtOTZlNC1hYTQ4N2YzOGMyZjgv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9d4fd47f77b04d33a6904684a6c2992d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4YzE5MjI2LTcwZmQtNGY4
+        Ny05YWZjLWMzNWJlYmVmODdmNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/08c19226-70fd-4f87-9afc-c35bebef87f4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 252a0480274b4310932aed737b58fb19
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDhjMTkyMjYtNzBm
+        ZC00Zjg3LTlhZmMtYzM1YmViZWY4N2Y0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MTQuMDU2NzE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5ZDRmZDQ3Zjc3YjA0ZDMzYTY5MDQ2ODRh
+        NmMyOTkyZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjE0LjA5
+        MDcyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6MTQuMjk2
+        NDE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNGM2
+        ZmUxOGItZjVjYy00OTY5LWE4MDUtMWI1OTIwYTA3NDE0LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4c6fe18b-f5cc-4969-a805-1b5920a07414/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1a82b5be47024317b804b0fff5c8c9f4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzRjNmZlMThiLWY1Y2MtNDk2OS1hODA1LTFiNTkyMGEwNzQxNC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjE0LjI3NjE3NVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNTYzZjQyN2MtYWRjZC00ZmVlLTk2ZTQt
+        YWE0ODdmMzhjMmY4LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 32e3d79754d54e2fa49a5f7067a027a5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 660ec0681d12465c95eef5744db8a57d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9165c942ddc9456e82a780e7f327ca84
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c8e3035cb7f42ef879b55a7e37268ba
+      - 111f6a923a074e96b52cb16709526df6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f343df837fba48d6924bccfdfbe97483
+      - 59149914ea3c402d8ca17afcd9e80506
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e3a8f13b26648bd9e91e70b3a384df5
+      - 11c22c9bdbb04a54807146aa55107232
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd35552812464ca48997951e47db76e5
+      - c059a50d3fb5433c8bd2c0425262fa92
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6a935cd8f3294537ac07125470e1d3ba
+      - e5ccd6891ef24321973f852fc9d0912f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2596701c398d4aa58d862371dfb22670
+      - 0e6bd48ee6fd4597afc421136e4e956c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77d37712-81b4-4593-aacd-c357f263c591/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8551918a-d28f-419d-ad3d-ceb101c0da8e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1e1d44c6f034b36a3807a6a0f9c34ad
+      - 94df2a9f230248faa882370c9754f38f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,32 +3208,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c1805c9adc645f2872a3109f7802866
+      - d06304155cfd4347821438328abbda41
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY0N2YxYTJmLWY1OTUtNDE1
-        ZS04NDg4LWE1OWMyMmIzNzY4Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyYTM1MmVkLTI5ZTYtNDQ5
+        MS1iODEzLTYyMmU5MWNhZDNmMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1
-        YzUxLyJdfQ==
+        cG0vcGFja2FnZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3
+        YmIzLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2821,7 +3246,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:40 GMT
+      - Fri, 29 Jul 2022 08:58:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2839,21 +3264,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5a75fcae003b458da00b6d7af73ecd5b
+      - dfb9de06e01a46a8846224eaa61d7031
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkNTkwOTYyLWE3NzctNDk0
-        OC04YzU5LTI4MTAzOWJhN2MzZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwZjczM2Y1LWY2MzEtNDBm
+        Zi1iZTM2LWIwNTNlNzEwN2NhYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:40 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4d590962-a777-4948-8c59-281039ba7c3d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d0f733f5-f631-40ff-be36-b053e7107cab/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2874,53 +3299,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:41 GMT
+      - Fri, 29 Jul 2022 08:58:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7b8204f192c4d0ca786b6079e3e3182
+      - 8eb8347dea9d4e0e9ada206263cb527a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGQ1OTA5NjItYTc3
-        Ny00OTQ4LThjNTktMjgxMDM5YmE3YzNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDAuOTQ5NzkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDBmNzMzZjUtZjYz
+        MS00MGZmLWJlMzYtYjA1M2U3MTA3Y2FiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6MTUuNjc2ODc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1YTc1ZmNhZTAwM2I0NThkYTAw
-        YjZkN2FmNzNlY2Q1YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjQxLjEwMzIzNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        NDEuMjMxNDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkZmI5ZGUwNmUwMWE0NmE4ODQ2
+        MjI0ZWFhNjFkNzAzMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4
+        OjE1LjkyODY2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6
+        MTYuMjQyODk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lOTQ1NWNlNi1kNGU4LTQ3MTQtODQ0ZC02ODQ3MTAxMDc3MDgvdmVyc2lv
+        bS8xMTA5YzUwYy0wMDIwLTRmMDQtYjcwMy03MGVmMmZmNTkwMDUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTk0NTVjZTYtZDRlOC00NzE0
-        LTg0NGQtNjg0NzEwMTA3NzA4LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTEwOWM1MGMtMDAyMC00ZjA0
+        LWI3MDMtNzBlZjJmZjU5MDA1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2928,7 +3353,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2941,41 +3366,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:41 GMT
+      - Fri, 29 Jul 2022 08:58:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 87f08d504fc7492da6860fc1176051ef
+      - 21ff0d0ab541405bb7167c7c6d9f05ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80ZWVhYjY2My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEv
+        YWNrYWdlcy82YTVmNjY4My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2983,7 +3408,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2996,7 +3421,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:41 GMT
+      - Fri, 29 Jul 2022 08:58:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3014,21 +3439,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b4a7d50721364010ab64d592dae9f07d
+      - e5cf8bad1e7f4f50a1705fd454bcaa68
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3036,7 +3461,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3049,7 +3474,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:41 GMT
+      - Fri, 29 Jul 2022 08:58:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3067,21 +3492,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7c58cde47fa40f9b63f62be91b2ced8
+      - a23a6c522c5d455e8620268ef9f7946e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3089,7 +3514,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3102,7 +3527,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:41 GMT
+      - Fri, 29 Jul 2022 08:58:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3120,21 +3545,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b280640d8c24e01a9579257efefa488
+      - eb567a9f11f042c4b1f1fc17d771cf8c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3142,7 +3567,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3155,7 +3580,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:41 GMT
+      - Fri, 29 Jul 2022 08:58:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3173,21 +3598,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9de8f678b63d4701a7a6109eef5a1e50
+      - a94780c41731424fad4ca3e3a794f5b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e9455ce6-d4e8-4714-844d-684710107708/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1109c50c-0020-4f04-b703-70ef2ff59005/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3195,7 +3620,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3208,7 +3633,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:41 GMT
+      - Fri, 29 Jul 2022 08:58:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3226,16 +3651,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3469860fec244bcb99faad0da2d27809
+      - 442cfa6e369944259bed4835d489aacf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:41 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:16 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_whitelist_name_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_whitelist_name_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:17 GMT
+      - Fri, 29 Jul 2022 08:58:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8f87b2f5aed4385938d4882afa8f9ea
+      - ad3bf53e186944be8dcfa49dea1d7b05
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNWM0ZGU2ZC0zNzlkLTQ2M2EtYTk4My1kNmJkM2NiZmU2MDgv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoxMi4wMDY0Mjda
+        cnBtL3JwbS8zNjkxNzk0Zi0wMmU0LTRlMWEtYTQ4My1kMTc4MmZkZGQyMDkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODo0Ni44OTA3NDNa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNWM0ZGU2ZC0zNzlkLTQ2M2EtYTk4My1kNmJkM2NiZmU2MDgv
+        cnBtL3JwbS8zNjkxNzk0Zi0wMmU0LTRlMWEtYTQ4My1kMTc4MmZkZGQyMDkv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM1YzRk
-        ZTZkLTM3OWQtNDYzYS1hOTgzLWQ2YmQzY2JmZTYwOC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM2OTE3
+        OTRmLTAyZTQtNGUxYS1hNDgzLWQxNzgyZmRkZDIwOS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:17 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/35c4de6d-379d-463a-a983-d6bd3cbfe608/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3691794f-02e4-4e1a-a483-d1782fddd209/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:17 GMT
+      - Fri, 29 Jul 2022 08:58:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a715710595934f4ab389651e409419e6
+      - be9cd96e03064f70a5e1ba12d46926c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjMjk5MDFmLTA4MjUtNGE3
-        YS04OTU0LTA5YTMxZDA3NWU1Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwM2NhNmUzLTNhYWQtNDI3
+        OC05OGY0LWExNjFjNDZkMThiNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:17 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:17 GMT
+      - Fri, 29 Jul 2022 08:58:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f4ca73c605214a488abef01a4c89bdc9
+      - f60f0f6890854e5a85be950749d4fc9a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:17 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dc29901f-0825-4a7a-8954-09a31d075e5b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c03ca6e3-3aad-4278-98f4-a161c46d18b6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 20457dc1e519470f8e5d34f8bd6a9a30
+      - e0d86ad8e2b8429a824841bc6c4a9a61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGMyOTkwMWYtMDgy
-        NS00YTdhLTg5NTQtMDlhMzFkMDc1ZTViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTcuODk5MDI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzAzY2E2ZTMtM2Fh
+        ZC00Mjc4LTk4ZjQtYTE2MWM0NmQxOGI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NTcuNTQ1MzgwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhNzE1NzEwNTk1OTM0ZjRhYjM4OTY1MWU0
-        MDk0MTllNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjE3Ljkz
-        NTQ1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTguMDU0
-        NzUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZTljZDk2ZTAzMDY0ZjcwYTVlMWJhMTJk
+        NDY5MjZjNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjU3LjU4
+        MzAxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NTcuNzg1
+        MTczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzVjNGRlNmQtMzc5ZC00NjNh
-        LWE5ODMtZDZiZDNjYmZlNjA4LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzY5MTc5NGYtMDJlNC00ZTFh
+        LWE0ODMtZDE3ODJmZGRkMjA5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2443a79932d47c1a431c5c1b3bf794d
+      - 754c4a3de8cb49d3a109e03ef497cd0d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0675daef5b4b4769ae9f65a9b37e5dfb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNGIyNmUyZTYtNTg4YS00MjA5LThjM2QtMjg4MWVmMWI4NDdm
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NTMuNDUzODAx
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:57 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4b26e2e6-588a-4209-8c3d-2881ef1b847f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9449f0825fb14acc86a93fc509a45022
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkZDZmNTA5LWQ0ZDEtNDRk
+        OS05Mjk5LTM4MjZiMzcxNDkyYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3dd6f509-d4d1-44d9-9299-3826b371492b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - eb101e3e4a724a56882701651f192565
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2RkNmY1MDktZDRk
+        MS00NGQ5LTkyOTktMzgyNmIzNzE0OTJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NTcuOTk4MDEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NDQ5ZjA4MjVmYjE0YWNjODZhOTNmYzUw
+        OWE0NTAyMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjU4LjAz
+        NjE5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NTguMDc4
+        MDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f05d0ba181534f05a207a5679be9e3d7
+      - 161f3f63021e4af6991837688c682793
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a1b8379685ab4890be5bd7acd73770d2
+      - 424d41976a544e81887718f0e3890ea7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 76f0e85cfbc34fd48d716ed9e7573664
+      - d4d219fb49b642c49161adae8b952358
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed6f39a949cc4d0b9c80592eba774fa1
+      - 3562158e5fe14b5d88f25ae5447eb4aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 3e5bb8a9d3fd4d91a1226cf96ce39352
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/87e20636-69d3-4ea6-bbba-4834ad6b01ff/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0c83541e-aaac-4121-85d2-31905f5f475c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d63b10a9b79c4e168aaceb7f618c5dd1
+      - 022af3b8b8724106a035ba06db253916
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3
-        ZTIwNjM2LTY5ZDMtNGVhNi1iYmJhLTQ4MzRhZDZiMDFmZi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjE4LjQ0NDU3NFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBj
+        ODM1NDFlLWFhYWMtNDEyMS04NWQyLTMxOTA1ZjVmNDc1Yy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjU4LjUxNDYzOFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIzOjE4LjQ0NDU5M1oiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU4OjU4LjUxNDY2MFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/"
+      - "/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5bec16674a54224aebc8a5955087b45
+      - 01ef32ea2fb54d9392f0077dee68cecc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTJmYjJhOTktMTc1Zi00Y2FiLTlmZmItNWIxOTRiNTFkYzQyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MTguNjE1ODQ1WiIsInZl
+        cG0vMjYwZjI3YzktOWYyNy00ZGUxLWFjMjEtMDkxZTI2YWMzNzAyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NTguNjY5MDE5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTJmYjJhOTktMTc1Zi00Y2FiLTlmZmItNWIxOTRiNTFkYzQyL3ZlcnNp
+        cG0vMjYwZjI3YzktOWYyNy00ZGUxLWFjMjEtMDkxZTI2YWMzNzAyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMmZiMmE5OS0x
-        NzVmLTRjYWItOWZmYi01YjE5NGI1MWRjNDIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yNjBmMjdjOS05
+        ZjI3LTRkZTEtYWMyMS0wOTFlMjZhYzM3MDIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1e89b6bd92d40449decc37257b58a1c
+      - 1c6899b6243244fb8b90386140525388
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '307'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jNDJiZjU0Ni1kODNmLTRhM2YtYjUzMC0wYmUxYWIwNWExZDQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoxMi43NTA1MDha
+        cnBtL3JwbS9kZWU4ODc4Yi03ZmZlLTQ4ZWMtODNmYS0wN2VjOTVkNzFiODgv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODo0Ny43ODcxMjNa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jNDJiZjU0Ni1kODNmLTRhM2YtYjUzMC0wYmUxYWIwNWExZDQv
+        cnBtL3JwbS9kZWU4ODc4Yi03ZmZlLTQ4ZWMtODNmYS0wN2VjOTVkNzFiODgv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M0MmJm
-        NTQ2LWQ4M2YtNGEzZi1iNTMwLTBiZTFhYjA1YTFkNC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2RlZTg4
+        NzhiLTdmZmUtNDhlYy04M2ZhLTA3ZWM5NWQ3MWI4OC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/c42bf546-d83f-4a3f-b530-0be1ab05a1d4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/dee8878b-7ffe-48ec-83fa-07ec95d71b88/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 734fd9832bbc4528a5866dad3a31f0b3
+      - d803f2266e2a49c1a65fc145e7666b54
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4ZmUyZDQ1LWIwNWMtNDNh
-        MC1iZTg2LTQ5YWZmMjZkZTRhYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3ZjExZWZjLThjZTQtNDYx
+        Yy1iMDU1LTQxMjY3NzIyODY3Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ff8a6989f854a4abd55cad51e20761e
+      - 290221211fb0494f87dc6becf4d3f356
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNGY4Mjg0NWQtMDQzNi00OTQ1LWFjOTgtZTI5NGVjMTRhMmJhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MTEuODk2NTk1WiIsIm5h
+        cG0vMTlhMWFiMmQtNjM3NC00ZmVlLThmMzItYzZlMmIwMjE3Nzg2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NDYuNzQ1NDExWiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzoxMy4xMzY2ODlaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1ODo0OC4yMjM4OTZaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/4f82845d-0436-4945-ac98-e294ec14a2ba/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/19a1ab2d-6374-4fee-8f32-c6e2b0217786/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 13245c61568a426883b82d32932a5eac
+      - 73a1deede722400282618fa7a373e594
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkYTVjMjdlLWE2ZmUtNGNi
-        MS04YmYzLWM1YTI4YTY1MjNkZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiZDQzZGE3LTU2NGItNGU2
+        Mi1iOTFhLTdlMjYxMzMwZWUzNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d8fe2d45-b05c-43a0-be86-49aff26de4ac/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c7f11efc-8ce4-461c-b055-412677228672/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b9a741d88f14d18b1c35192ea015f41
+      - 4a866fa57ef1467fbe6132a7ed8ea899
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDhmZTJkNDUtYjA1
-        Yy00M2EwLWJlODYtNDlhZmYyNmRlNGFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTguNzc3MjIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzdmMTFlZmMtOGNl
+        NC00NjFjLWIwNTUtNDEyNjc3MjI4NjcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NTguOTIwODMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MzRmZDk4MzJiYmM0NTI4YTU4NjZkYWQz
-        YTMxZjBiMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjE4Ljgx
-        Mjc4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTguODc0
-        MDc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkODAzZjIyNjZlMmE0OWMxYTY1ZmMxNDVl
+        NzY2NmI1NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjU4Ljk4
+        MzQ1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NTkuMTA3
+        NzE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzQyYmY1NDYtZDgzZi00YTNm
-        LWI1MzAtMGJlMWFiMDVhMWQ0LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGVlODg3OGItN2ZmZS00OGVj
+        LTgzZmEtMDdlYzk1ZDcxYjg4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cda5c27e-a6fe-4cb1-8bf3-c5a28a6523df/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0bd43da7-564b-4e62-b91a-7e261330ee37/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:18 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 438b0ae4470c4970af02c97709d99ebe
+      - 42534901fde34c43954ed3dfc315cf5f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2RhNWMyN2UtYTZm
-        ZS00Y2IxLThiZjMtYzVhMjhhNjUyM2RmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTguODY3OTA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGJkNDNkYTctNTY0
+        Yi00ZTYyLWI5MWEtN2UyNjEzMzBlZTM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTg6NTkuMDY2NTkxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxMzI0NWM2MTU2OGE0MjY4ODNiODJkMzI5
-        MzJhNWVhYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjE4Ljg5
-        ODMxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTguOTQx
-        ODkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3M2ExZGVlZGU3MjI0MDAyODI2MThmYTdh
+        MzczZTU5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU4OjU5LjEz
+        NjQyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTg6NTkuMjE3
+        MDM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmODI4NDVkLTA0MzYtNDk0NS1hYzk4
-        LWUyOTRlYzE0YTJiYS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE5YTFhYjJkLTYzNzQtNGZlZS04ZjMy
+        LWM2ZTJiMDIxNzc4Ni8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:18 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d19ab73e9394a8f992b29b89c6d5bac
+      - 38054377679d4850bc52fa40702e9851
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aae7563e2541498f8d317b3ac59eae4a
+      - fb1491196b574253954bf5bdee5da325
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2a47187d64b54f4abd9a3c6457c720b1
+      - 8c6dd344d57243faad67d13e3e9564f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 149d2e9bc9054bbb95fcc46651cb0ccf
+      - 1898669f5aa04f3ba464491c35ad52a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 23d19cd99e8f4d96b2f8d4422c027309
+      - d7a6a3c86c8243b5a2eeb85bbf9039ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '09881a6fb7a94ea89fef15bb11ba9a3f'
+      - d14bea76bec54068839f9cd2b67b35b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:58:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/"
+      - "/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9abbcb08dd844cd29f430daadb73e00b
+      - 42bdef84d519481b8f7f6ec6eeb06836
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTM4N2M4YmUtOTYyMi00MWE1LThlNWMtN2MzYWU0ZWFlMzIxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6MTkuMzI0MDExWiIsInZl
+        cG0vY2JkNDVlYWMtOGMyNC00YWEzLTkxMDEtNzhiZjFiNTI2Y2E2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTg6NTkuNjkwODY1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTM4N2M4YmUtOTYyMi00MWE1LThlNWMtN2MzYWU0ZWFlMzIxL3ZlcnNp
+        cG0vY2JkNDVlYWMtOGMyNC00YWEzLTkxMDEtNzhiZjFiNTI2Y2E2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xMzg3YzhiZS05
-        NjIyLTQxYTUtOGU1Yy03YzNhZTRlYWUzMjEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ0NWVhYy04
+        YzI0LTRhYTMtOTEwMS03OGJmMWI1MjZjYTYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:58:59 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/87e20636-69d3-4ea6-bbba-4834ad6b01ff/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/0c83541e-aaac-4121-85d2-31905f5f475c/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:59:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 61556cd8e3bd463fb68b3c09d5db77bb
+      - 195f78734f3741f5b641683c27ce1779
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxZmEyYjQyLTg4OGUtNGFj
-        Ny05NWI4LTI4M2NiMGU4MGVkNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiOTU4ZjYzLWI3Y2ItNDg4
+        My04MDk5LWM3ZDk2MDQ1ODNlMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/91fa2b42-888e-4ac7-95b8-283cb0e80ed4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2b958f63-b7cb-4883-8099-c7d9604583e3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:59:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 87b034336cee4e29a9bf6f6586260da2
+      - ed62a786f0094c97912f6d9ef824bf13
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTFmYTJiNDItODg4
-        ZS00YWM3LTk1YjgtMjgzY2IwZTgwZWQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTkuNjYwOTU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI5NThmNjMtYjdj
+        Yi00ODgzLTgwOTktYzdkOTYwNDU4M2UzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MDAuMDU2NTA2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI2MTU1NmNkOGUzYmQ0NjNmYjY4YjNjMDlk
-        NWRiNzdiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIzOjE5LjY5
-        MzM3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MTkuNzE1
-        ODg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIxOTVmNzg3MzRmMzc0MWY1YjY0MTY4M2My
+        N2NlMTc3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjAwLjEy
+        MDQxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MDAuMTQ5
+        Nzg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3ZTIwNjM2LTY5ZDMtNGVhNi1iYmJh
-        LTQ4MzRhZDZiMDFmZi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBjODM1NDFlLWFhYWMtNDEyMS04NWQy
+        LTMxOTA1ZjVmNDc1Yy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:00 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3ZTIw
-        NjM2LTY5ZDMtNGVhNi1iYmJhLTQ4MzRhZDZiMDFmZi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBjODM1
+        NDFlLWFhYWMtNDEyMS04NWQyLTMxOTA1ZjVmNDc1Yy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:19 GMT
+      - Fri, 29 Jul 2022 08:59:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 964ff15cf37e452686583485a3c7962b
+      - 00d3c03bf30f44fcb8e8c1704ba86657
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlZTAyMzFlLTJmYjktNDBj
-        MS1hZTdkLTlhZjFkYWQ1NTA2Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjOGQ5ZWRhLWZlZTQtNGU5
+        NC1iMzE4LWVkNmUyMjlmNWI0MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:19 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5ee0231e-2fb9-40c1-ae7d-9af1dad5506c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fc8d9eda-fee4-4e94-b318-ed6e229f5b41/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:21 GMT
+      - Fri, 29 Jul 2022 08:59:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9d0e8fc4f6344133876cc480d296a05b
+      - 1b3574aa2b424a00a45fa449ce731082
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '600'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWVlMDIzMWUtMmZi
-        OS00MGMxLWFlN2QtOWFmMWRhZDU1MDZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MTkuODM0NDM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmM4ZDllZGEtZmVl
+        NC00ZTk0LWIzMTgtZWQ2ZTIyOWY1YjQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MDAuMzIxNTIyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI5NjRmZjE1Y2YzN2U0NTI2ODY1
-        ODM0ODVhM2M3OTYyYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjE5Ljg2NTc1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MjEuNDMxMDMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwMGQzYzAzYmYzMGY0NGZjYjhl
+        OGMxNzA0YmE4NjY1NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjAwLjM2NzAxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MDQuMjc2ODMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZTJmYjJhOTktMTc1Zi00Y2FiLTlmZmIt
-        NWIxOTRiNTFkYzQyL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2UyZmIyYTk5LTE3NWYtNGNhYi05ZmZiLTViMTk0YjUxZGM0Mi8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS84N2UyMDYzNi02OWQz
-        LTRlYTYtYmJiYS00ODM0YWQ2YjAxZmYvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzI2MGYyN2M5LTlmMjctNGRlMS1hYzIxLTA5
+        MWUyNmFjMzcwMi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8y
+        NjBmMjdjOS05ZjI3LTRkZTEtYWMyMS0wOTFlMjZhYzM3MDIvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMGM4MzU0MWUtYWFhYy00
+        MTIxLTg1ZDItMzE5MDVmNWY0NzVjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:21 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZTJmYjJhOTktMTc1Zi00Y2FiLTlmZmItNWIxOTRiNTFk
-        YzQyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMjYwZjI3YzktOWYyNy00ZGUxLWFjMjEtMDkxZTI2YWMz
+        NzAyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:21 GMT
+      - Fri, 29 Jul 2022 08:59:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ccea77b991a4adc9725136b30eb7836
+      - 79da17e67b1f4c3d9383af6393aa24a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4MDkwZDRmLTQ1ODgtNGVl
-        ZC1hNDc2LWIyMWIxZWY4MDU4OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmMmFlM2MwLWUyZDUtNDM0
+        Mi04NjlmLTc0N2MxMTQzODhmMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:21 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/88090d4f-4588-4eed-a476-b21b1ef80588/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ef2ae3c0-e2d5-4342-869f-747c114388f0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:21 GMT
+      - Fri, 29 Jul 2022 08:59:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5522ad89c8f349d095f5c8beea707da6
+      - a6a5408dd8854f3db284de14970a8067
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODgwOTBkNGYtNDU4
-        OC00ZWVkLWE0NzYtYjIxYjFlZjgwNTg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjEuNTk0MTI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWYyYWUzYzAtZTJk
+        NS00MzQyLTg2OWYtNzQ3YzExNDM4OGYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MDQuNTMxODY3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjZjY2VhNzdiOTkxYTRhZGM5NzI1MTM2YjMw
-        ZWI3ODM2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6MjEuNjUx
-        MzM4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMzoyMS44MzEx
-        ODVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6Ijc5ZGExN2U2N2IxZjRjM2Q5MzgzYWY2Mzkz
+        YWEyNGExIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MDQuNTgw
+        NzQyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwODo1OTowNC44ODUw
+        ODFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjIyZDE5
-        OGUtZjZmZS00NDJhLWEwNDItMjY5MDYzMzQxZjY1LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMzhjMDlj
+        ZDAtY2E4Mi00ZjdkLWI1M2YtNzZiMWRiYmE0ODc5LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZTJmYjJhOTktMTc1Zi00Y2FiLTlmZmItNWIxOTRi
-        NTFkYzQyLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMjYwZjI3YzktOWYyNy00ZGUxLWFjMjEtMDkxZTI2
+        YWMzNzAyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:21 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2f8768104edd48c59fc42770fc06476d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ab4036ef02c4306bf5b0a4955ad0938
+      - 7ae8cb24ba714cf78276be84bf73f4a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/38c09cd0-ca82-4f7d-b53f-76b1dbba4879/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 958a179fdd124baebf2356b16fc06b6e
+      - 9d275cf39cc449d99f92a2451438a5b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMzhjMDljZDAtY2E4Mi00ZjdkLWI1M2YtNzZiMWRiYmE0ODc5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6MDQuNjAzNjU3WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8yNjBmMjdjOS05ZjI3LTRkZTEtYWMyMS0wOTFlMjZhYzM3MDIv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzI2MGYyN2M5LTlmMjctNGRlMS1hYzIxLTA5MWUy
+        NmFjMzcwMi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8zOGMwOWNkMC1jYTgyLTRmN2QtYjUzZi03NmIxZGJiYTQ4Nzkv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 533a80eff5c84667aede4102d9cec053
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3NzlkNTI4LTcxMTgtNDkz
+        Yy1hYjViLTQyNWQxNjAwNjg5Yy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9779d528-7118-493c-ab5b-425d1600689c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0c4c5456dcb14500b86b01e166e778c2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTc3OWQ1MjgtNzEx
+        OC00OTNjLWFiNWItNDI1ZDE2MDA2ODljLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MDUuMTEzNjQwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1MzNhODBlZmY1Yzg0NjY3YWVkZTQxMDJk
+        OWNlYzA1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5OjA1LjE1
+        ODAzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6MDUuMzcw
+        OTQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYTUy
+        ZDliYzMtNjNlOS00MzhiLWIzYzUtODhkMWUzOTdkZDY2LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/a52d9bc3-63e9-438b-b3c5-88d1e397dd66/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7eab21b025414afda7e6b86064b0419e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2E1MmQ5YmMzLTYzZTktNDM4Yi1iM2M1LTg4ZDFlMzk3ZGQ2Ni8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA4OjU5OjA1LjM0ODY3NloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMzhjMDljZDAtY2E4Mi00ZjdkLWI1M2Yt
+        NzZiMWRiYmE0ODc5LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 80f272a33c484b73997ab687ec947b94
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 570846075efa4844a8bd52a5431f95ec
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 08:59:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a062e2e324094fed8c63ce427b4aa72f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2a14fe8da594a9bbabf926c9daf56f5
+      - 633726e9a4de425da98037060527bd1d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8dbbb912a1714b6fae4afa2a23ac1394
+      - 5e08cc89e53648588fba05e84eec5a9d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c4c25360e2844130a6852ac38048e192
+      - 69987b0ec3b641afa64bd9b9e85e2204
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c57bfc06cd5843f384fa84674b044af8
+      - 21510a62fbca4867a9d4c14e88ec47b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ec279ed44f04a03aa1b538a58ebf45c
+      - 7efcd448dff742448d94fd87ab69bb12
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd229abe0de44fa29834159837e644b9
+      - 0eaa3d8b0a6247118210a06c81964faf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2fb2a99-175f-4cab-9ffb-5b194b51dc42/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/260f27c9-9f27-4de1-ac21-091e26ac3702/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b416f74ef694d93943b51920d2b911e
+      - 4c2d7dc9e509452bae4d8406241504cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,32 +3208,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c76144d23cd643e898c39235d1bae569
+      - bc5fcaf0fea1422aa3483afa6275858d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxZTMzZmJmLTgxOGQtNGVh
-        Zi1iMzJkLWRkNGM5YmE3MmUyYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiMTU2M2IxLWI3NGYtNGI0
+        YS04NDljLTNlZjFlYzFjNDYzNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvZWMyN2QzNTktOTM4OC00ODdjLWIyY2EtZGVkM2UyN2Zl
-        NmRhLyJdfQ==
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2821,7 +3246,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:22 GMT
+      - Fri, 29 Jul 2022 08:59:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2839,21 +3264,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fcaa9f362baa4c49951572e58547ad31
+      - '08b40abc36184900848e5111dd28242b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0MzA4OGUxLTU4NzYtNGI3
-        Yy1hNWQ3LTE0MjJkZTQ0YTAyNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyNjM1MzE5LTNmNmUtNDk3
+        Yi1hNmUxLTNmZjZmZWM3NjBjYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:22 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/043088e1-5876-4b7c-a5d7-1422de44a026/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/22635319-3f6e-497b-a6e1-3ff6fec760cb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2874,53 +3299,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:23 GMT
+      - Fri, 29 Jul 2022 08:59:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - deb528bf9d5d45688b6e29eb47c3012d
+      - d0f220e434194aeeab40b87017a5f066
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQzMDg4ZTEtNTg3
-        Ni00YjdjLWE1ZDctMTQyMmRlNDRhMDI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjM6MjIuNzk5MjY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjI2MzUzMTktM2Y2
+        ZS00OTdiLWE2ZTEtM2ZmNmZlYzc2MGNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDg6NTk6MDYuNjkxNDcwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmY2FhOWYzNjJiYWE0YzQ5OTUx
-        NTcyZTU4NTQ3YWQzMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIz
-        OjIyLjk1ODg1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjM6
-        MjMuMDkxMzEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwOGI0MGFiYzM2MTg0OTAwODQ4
+        ZTUxMTFkZDI4MjQyYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA4OjU5
+        OjA2LjkyNTcxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDg6NTk6
+        MDcuMTQ4MDk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xMzg3YzhiZS05NjIyLTQxYTUtOGU1Yy03YzNhZTRlYWUzMjEvdmVyc2lv
+        bS9jYmQ0NWVhYy04YzI0LTRhYTMtOTEwMS03OGJmMWI1MjZjYTYvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTM4N2M4YmUtOTYyMi00MWE1
-        LThlNWMtN2MzYWU0ZWFlMzIxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2JkNDVlYWMtOGMyNC00YWEz
+        LTkxMDEtNzhiZjFiNTI2Y2E2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2928,7 +3353,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2941,41 +3366,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:23 GMT
+      - Fri, 29 Jul 2022 08:59:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa80700e71e141b7b6db9002584289ec
+      - 59811ce7f7d24fc3a2bdad06cc32e2f8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2MtYjJjYS1kZWQzZTI3ZmU2ZGEv
+        YWNrYWdlcy82ZGM4YzA3Ni1kNTFkLTQxZGQtYjQ1NS04MzRjMmY4ZDU4OGMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2983,7 +3408,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2996,7 +3421,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:23 GMT
+      - Fri, 29 Jul 2022 08:59:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3014,21 +3439,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41fb3a04c5534286ad6d4d99c07c98b0
+      - e8537653d4d94723bbe6da98a1086fb0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3036,7 +3461,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3049,7 +3474,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:23 GMT
+      - Fri, 29 Jul 2022 08:59:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3067,21 +3492,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2dcf604a0e194fe0b621703a92f26625
+      - a3b0439fbd0546598de3ba28cc92275c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3089,7 +3514,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3102,7 +3527,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:23 GMT
+      - Fri, 29 Jul 2022 08:59:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3120,21 +3545,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9aa2c52d40014077bb0457b7d357514d
+      - 5529c9801de4463ab23f942fa5465af7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3142,7 +3567,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3155,7 +3580,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:23 GMT
+      - Fri, 29 Jul 2022 08:59:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3173,21 +3598,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8efa8a9120b44853b8ba48954cfb78ea
+      - f0232a08403b413a87cc955fc9a5e4d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1387c8be-9622-41a5-8e5c-7c3ae4eae321/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/cbd45eac-8c24-4aa3-9101-78bf1b526ca6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3195,7 +3620,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3208,7 +3633,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:23:23 GMT
+      - Fri, 29 Jul 2022 08:59:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3226,16 +3651,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '090c7817e0d94742872a6e3197e43fd0'
+      - 6f9d2f3eb3c24eaf8bc6b8567c1b6f37
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:23:23 GMT
+  recorded_at: Fri, 29 Jul 2022 08:59:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_whitelist_name_original_packages_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_repository/yum_copy_with_whitelist_name_original_packages_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b431abdd058a4b989c69fc383f013423
+      - e45863c3fcf249ac8df942c4d23162e0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yMTc0NDVmMC1hMTQ3LTQ4OTEtYTQ5My00MTEwMjQ1NWYzOTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo0My4zNTQ1MzNa
+        cnBtL3JwbS84NWVkMDAwMS1jNTJiLTQwODQtOTg3OC1iOTMzM2JlMDZmZGIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1OTo1Ny40OTkyNDda
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yMTc0NDVmMC1hMTQ3LTQ4OTEtYTQ5My00MTEwMjQ1NWYzOTcv
+        cnBtL3JwbS84NWVkMDAwMS1jNTJiLTQwODQtOTg3OC1iOTMzM2JlMDZmZGIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzIxNzQ0
-        NWYwLWExNDctNDg5MS1hNDkzLTQxMTAyNDU1ZjM5Ny92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzg1ZWQw
+        MDAxLWM1MmItNDA4NC05ODc4LWI5MzMzYmUwNmZkYi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:09 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/217445f0-a147-4891-a493-41102455f397/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/85ed0001-c52b-4084-9878-b9333be06fdb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4c991af7baeb4376a0691f8dce2e4430
+      - 302b3282c7f44be7ab46a9ce44f70d18
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxYzU0ODcyLTdkYzMtNGQ3
-        My1iZGZhLTVjZmE3NzBlMzlkOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2OGFkZjFhLTRhZjgtNDdm
+        Ny1hNjhlLTk5ODFjNWIzNzg5OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25baf08d03424e42baf7c0778032142c
+      - 598712b8390640029126277b2c81de48
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/71c54872-7dc3-4d73-bdfa-5cfa770e39d9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e68adf1a-4af8-47f7-a68e-9981c5b37898/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 961729107784450eb51359e7dd9720aa
+      - d0a4974c5b3748fba4ca934c3d574c7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzFjNTQ4NzItN2Rj
-        My00ZDczLWJkZmEtNWNmYTc3MGUzOWQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NDkuNDg4Njc3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTY4YWRmMWEtNGFm
+        OC00N2Y3LWE2OGUtOTk4MWM1YjM3ODk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MDkuNTQyMjk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0Yzk5MWFmN2JhZWI0Mzc2YTA2OTFmOGRj
-        ZTJlNDQzMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjQ5LjU0
-        MTE5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NDkuNjU5
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzMDJiMzI4MmM3ZjQ0YmU3YWI0NmE5Y2U0
+        NGY3MGQxOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjA5LjYw
+        MTcyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MDkuODIx
         MTU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjE3NDQ1ZjAtYTE0Ny00ODkx
-        LWE0OTMtNDExMDI0NTVmMzk3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODVlZDAwMDEtYzUyYi00MDg0
+        LTk4NzgtYjkzMzNiZTA2ZmRiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41050b4f01cd4832bfa800148858e173
+      - 40efa4e5c01b470f8ee491d88210c84b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 88ca2840ba7b4b6c940abdbfd279d7ee
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZTA3ZTkzZjktYjI1OC00MDMxLTgzODEtOGRlODE3OWI1MTUw
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MDUuMTk5NzY3
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:09 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/e07e93f9-b258-4031-8381-8de8179b5150/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 014b27ae6afc4fe0bbc604ec7c18646e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4ZTNhNTg1LTllNDYtNDhj
+        Yy04OWE4LTYzZmIyOGYxM2Y3Mi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/98e3a585-9e46-48cc-89a8-63fb28f13f72/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ef005b2588844cd5a4d96a3cb65f649b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOThlM2E1ODUtOWU0
+        Ni00OGNjLTg5YTgtNjNmYjI4ZjEzZjcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MTAuMDA3MjIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMTRiMjdhZTZhZmM0ZmUwYmJjNjA0ZWM3
+        YzE4NjQ2ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjEwLjA0
+        Njg1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MTAuMDk1
+        MzM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb7b43a8cc98465eb3a0b482a51689d8
+      - 8d817e57cd574b96b6ab53ea916fe4e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6fd2e237d14140b68dd88b1efc871c5d
+      - 2207b62f805a45d88fecf2bd02b1c6bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1607beb0b17040619abddaaad75dd894
+      - 360e237039624956bed1128620b0fbc9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:49 GMT
+      - Fri, 29 Jul 2022 09:00:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7b59837482ad4782b440973a6f15498d
+      - bc0c41289bd64a21a4e32489d6ba2018
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:49 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 3d42291e94c14adf9b3aa94bba48cde9
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/7125228e-3cb5-48df-815b-aab14218f8bb/"
+      - "/pulp/api/v3/remotes/rpm/rpm/52fec0c2-ae5f-4473-a363-3f9b2b049e8b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2cc8f069b9bd4e51928c0dd42ba4fcbb
+      - fc084d21b86e41059dd54f684dbcb816
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcx
-        MjUyMjhlLTNjYjUtNDhkZi04MTViLWFhYjE0MjE4ZjhiYi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjUwLjEwMTY2MVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzUy
+        ZmVjMGMyLWFlNWYtNDQ3My1hMzYzLTNmOWIyYjA0OWU4Yi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjEwLjU1OTM2NloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjUwLjEwMTY4MloiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjEwLjU1OTM5MFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/"
+      - "/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3fbce2976c71472988971dcd89c4d1ef
+      - b42e7077ebf640fe991c676c18874e6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTY4MmYzMDgtNjAxZi00M2E0LWFjMDUtYTgwMjU2Y2JiNWMxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NTAuMjEzNjY5WiIsInZl
+        cG0vNGM5ZmUwZjItNjIzNy00ZTkyLWFmNzItNGFhZTYzNjdmN2QxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MTAuNzA3MTc1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTY4MmYzMDgtNjAxZi00M2E0LWFjMDUtYTgwMjU2Y2JiNWMxL3ZlcnNp
+        cG0vNGM5ZmUwZjItNjIzNy00ZTkyLWFmNzItNGFhZTYzNjdmN2QxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85NjgyZjMwOC02
-        MDFmLTQzYTQtYWMwNS1hODAyNTZjYmI1YzEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80YzlmZTBmMi02
+        MjM3LTRlOTItYWY3Mi00YWFlNjM2N2Y3ZDEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d168b7c261294a62b830c2ac1c914b0a
+      - 130dc444cbda4edfb087118efdc15838
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kOWI1ZjhkYS03OTJlLTQ4ZGEtYjE1Ni1kNWY5MmNmYWJmNDYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo0NC4xMTg5NTda
+        cnBtL3JwbS85YjYxZjM5Mi1kZTI2LTRkYjctYTk1Ni04NzI2MTViOTUyY2Uv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwODo1OTo1OC4zODcwNjda
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kOWI1ZjhkYS03OTJlLTQ4ZGEtYjE1Ni1kNWY5MmNmYWJmNDYv
+        cnBtL3JwbS85YjYxZjM5Mi1kZTI2LTRkYjctYTk1Ni04NzI2MTViOTUyY2Uv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q5YjVm
-        OGRhLTc5MmUtNDhkYS1iMTU2LWQ1ZjkyY2ZhYmY0Ni92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzliNjFm
+        MzkyLWRlMjYtNGRiNy1hOTU2LTg3MjYxNWI5NTJjZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/d9b5f8da-792e-48da-b156-d5f92cfabf46/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/9b61f392-de26-4db7-a956-872615b952ce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c01e6a2005044547b83163213475146e
+      - fa3251754fdd459d946e9f1782340a13
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzMTA4YjUyLTU5N2EtNGY0
-        YS04YWMxLWEyZTg3MDVjY2Q5OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg5MGE3MWFiLTU0ZWItNDI5
+        Zi1hZmY3LWMxMjY3NmVmOTI2Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e13777b5b65413c810b13af48b9c049
+      - 7e3d245de58c4684a7ddf0897c8e4415
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMWRmY2QzNTQtYjg1My00ZWZlLWFhYzktNmJkNjMxZDFkMzY4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NDMuMjQxNzUyWiIsIm5h
+        cG0vZmM4MjYzOWEtODRkNS00ODQ5LTg2MWUtMDkxYzNiMjkxNTJiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDg6NTk6NTcuMzU1NzYwWiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjo0NC40NzIzMDBaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwODo1OTo1OC44MDg0MDBaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/1dfcd354-b853-4efe-aac9-6bd631d1d368/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/fc82639a-84d5-4849-861e-091c3b29152b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 62c1682598074ed5b04e0ce8faf08d87
+      - 5122365ca83847cf85de48f89ea4184b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjMjU1YzFkLWY0MDktNDEy
-        My04ZTAyLTk3ZDgyNGU3MjA1Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1OGY1NjkxLTcwYmYtNDFj
+        Yy1iZWVkLTIzMTM0MTgxOGY2My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f3108b52-597a-4f4a-8ac1-a2e8705ccd98/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/890a71ab-54eb-429f-aff7-c12676ef926b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 00bb60932657480f9c64309ce950168e
+      - 25ba5e75083a46d7bd95f9a247e6f0c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjMxMDhiNTItNTk3
-        YS00ZjRhLThhYzEtYTJlODcwNWNjZDk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTAuMzc1NjA5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODkwYTcxYWItNTRl
+        Yi00MjlmLWFmZjctYzEyNjc2ZWY5MjZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MTAuOTYzNzQyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMDFlNmEyMDA1MDQ0NTQ3YjgzMTYzMjEz
-        NDc1MTQ2ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjUwLjQw
-        OTUwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NTAuNDcy
-        NTk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmYTMyNTE3NTRmZGQ0NTlkOTQ2ZTlmMTc4
+        MjM0MGExMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjExLjAx
+        NzU5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MTEuMTIx
+        NDQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDliNWY4ZGEtNzkyZS00OGRh
-        LWIxNTYtZDVmOTJjZmFiZjQ2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWI2MWYzOTItZGUyNi00ZGI3
+        LWE5NTYtODcyNjE1Yjk1MmNlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fc255c1d-f409-4123-8e02-97d824e7205b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/358f5691-70bf-41cc-beed-231341818f63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a7b0fb1c915147f688bcabec3245df45
+      - e7da668fdf7e4ddd84564e415173d9a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmMyNTVjMWQtZjQw
-        OS00MTIzLThlMDItOTdkODI0ZTcyMDViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTAuNDcyNTE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzU4ZjU2OTEtNzBi
+        Zi00MWNjLWJlZWQtMjMxMzQxODE4ZjYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MTEuMTIxMzgyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2MmMxNjgyNTk4MDc0ZWQ1YjA0ZTBjZThm
-        YWYwOGQ4NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjUwLjUw
-        NTA3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NTAuNTUw
-        Mzc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MTIyMzY1Y2E4Mzg0N2NmODVkZTQ4Zjg5
+        ZWE0MTg0YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjExLjE3
+        MzI4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MTEuMjQ1
+        NDYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFkZmNkMzU0LWI4NTMtNGVmZS1hYWM5
-        LTZiZDYzMWQxZDM2OC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZjODI2MzlhLTg0ZDUtNDg0OS04NjFl
+        LTA5MWMzYjI5MTUyYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - adc23603c6a24fe1877bcf972b3ae30d
+      - 01d7f95d72474075aebdbf15b0bcc6c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9eff662563241859388c757b17b2b1d
+      - 4ed221c76e91461c93b811beb17a3bd9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a99f265a1884f6980ea6dbcf78bbd1a
+      - bab4bf1cde3c4d1f8835188021e6820e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 105631c92ee34a3c9310ea28339d436c
+      - b976491654bc44899f9b4ffc4008cfa9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a621ce21f7154496876c6b7df94dd32b
+      - ff41884bbeb34394839a21028c4baad8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e68c947cb574479dbb8777e6b3761eae
+      - cc4181c00dda4598a2b7d281a47bd08d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:50 GMT
+      - Fri, 29 Jul 2022 09:00:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/"
+      - "/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 03bc9c6dbc2941bc9670c2e619e405bb
+      - cde0465badbd442da66d6d5fb84167bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWIwMjFlMDItOGUyOC00NDg1LWI2OWMtMTQzMjcxOGY2ZWUwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6NTAuOTIwMjgzWiIsInZl
+        cG0vOGRiNDVmZDYtMjFkYy00ZjJhLWJiOTYtZDYxMDRkMDBkY2U5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MTEuNzU3Nzk3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWIwMjFlMDItOGUyOC00NDg1LWI2OWMtMTQzMjcxOGY2ZWUwL3ZlcnNp
+        cG0vOGRiNDVmZDYtMjFkYy00ZjJhLWJiOTYtZDYxMDRkMDBkY2U5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xYjAyMWUwMi04
-        ZTI4LTQ0ODUtYjY5Yy0xNDMyNzE4ZjZlZTAvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84ZGI0NWZkNi0y
+        MWRjLTRmMmEtYmI5Ni1kNjEwNGQwMGRjZTkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:50 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:11 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/7125228e-3cb5-48df-815b-aab14218f8bb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/52fec0c2-ae5f-4473-a363-3f9b2b049e8b/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:51 GMT
+      - Fri, 29 Jul 2022 09:00:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e56e388e44de4742903ee0708c34c676
+      - ba2b9049f400453da1e9151542a72f01
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3YWRkNjBhLTI3NmItNDVl
-        NC1iOWNkLTJjNGYyOGY4YWU2OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmM2RiMWM2LWEzNjItNDNk
+        OC05ZWU3LThiNDgwNzAwZWJjYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/47add60a-276b-45e4-b9cd-2c4f28f8ae69/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7f3db1c6-a362-43d8-9ee7-8b480700ebcc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:51 GMT
+      - Fri, 29 Jul 2022 09:00:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea1f924700bb46bcb28bc7855886d5cb
+      - 85864a4ba56546d9b7dc977cc30fdb25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDdhZGQ2MGEtMjc2
-        Yi00NWU0LWI5Y2QtMmM0ZjI4ZjhhZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTEuMTg5Nzc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2YzZGIxYzYtYTM2
+        Mi00M2Q4LTllZTctOGI0ODA3MDBlYmNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MTIuMTUzMjY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJlNTZlMzg4ZTQ0ZGU0NzQyOTAzZWUwNzA4
-        YzM0YzY3NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIyOjUxLjIy
-        Mjk3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NTEuMjQ2
-        NzMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiYTJiOTA0OWY0MDA0NTNkYTFlOTE1MTU0
+        MmE3MmYwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjEyLjIw
+        MDU5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MTIuMjI3
+        NTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcxMjUyMjhlLTNjYjUtNDhkZi04MTVi
-        LWFhYjE0MjE4ZjhiYi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzUyZmVjMGMyLWFlNWYtNDQ3My1hMzYz
+        LTNmOWIyYjA0OWU4Yi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:12 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzcxMjUy
-        MjhlLTNjYjUtNDhkZi04MTViLWFhYjE0MjE4ZjhiYi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzUyZmVj
+        MGMyLWFlNWYtNDQ3My1hMzYzLTNmOWIyYjA0OWU4Yi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:51 GMT
+      - Fri, 29 Jul 2022 09:00:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dd74af4071354730a205a16e1d5a54ec
+      - 71328a83ebf24e4bb6093cb235a92260
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3OTkyZWVkLWY5YTUtNDM1
-        YS1hNmFlLWQ2MGU5ZjAyYjlkMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4MGNmZTkyLTE4NzctNDYz
+        Yi1hYzBiLTQyMTY0Y2EzOTA1NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c7992eed-f9a5-435a-a6ae-d60e9f02b9d1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/380cfe92-1877-463b-ac0b-42164ca39055/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,82 +1787,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:53 GMT
+      - Fri, 29 Jul 2022 09:00:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd98b19878f241d08a8cb94fc94f158d
+      - 8f574e7c06d5402cb49bb22c0d6aeede
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '600'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzc5OTJlZWQtZjlh
-        NS00MzVhLWE2YWUtZDYwZTlmMDJiOWQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTEuMzY0OTQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzgwY2ZlOTItMTg3
+        Ny00NjNiLWFjMGItNDIxNjRjYTM5MDU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MTIuNDAyOTc1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkZDc0YWY0MDcxMzU0NzMwYTIw
-        NWExNmUxZDVhNTRlYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjUxLjQwNTY2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        NTIuOTY5NDYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI3MTMyOGE4M2ViZjI0ZTRiYjYw
+        OTNjYjIzNWE5MjI2MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjEyLjQ0NjUwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        MTYuNzUyODE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
-        IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
-        bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
-        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
-        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vOTY4MmYzMDgtNjAxZi00M2E0LWFjMDUt
-        YTgwMjU2Y2JiNWMxL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        Lzk2ODJmMzA4LTYwMWYtNDNhNC1hYzA1LWE4MDI1NmNiYjVjMS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS83MTI1MjI4ZS0zY2I1
-        LTQ4ZGYtODE1Yi1hYWIxNDIxOGY4YmIvIl19
+        IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2Fn
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6MzIs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgTWV0YWRh
+        dGEgRmlsZXMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5tZXRhZGF0YSIs
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjUsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3Rz
+        IiwiY29kZSI6InN5bmMuZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
+        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjpudWxsLCJkb25lIjozNiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzRjOWZlMGYyLTYyMzctNGU5Mi1hZjcyLTRh
+        YWU2MzY3ZjdkMS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80
+        YzlmZTBmMi02MjM3LTRlOTItYWY3Mi00YWFlNjM2N2Y3ZDEvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNTJmZWMwYzItYWU1Zi00
+        NDczLWEzNjMtM2Y5YjJiMDQ5ZThiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:16 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOTY4MmYzMDgtNjAxZi00M2E0LWFjMDUtYTgwMjU2Y2Ji
-        NWMxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNGM5ZmUwZjItNjIzNy00ZTkyLWFmNzItNGFhZTYzNjdm
+        N2QxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:53 GMT
+      - Fri, 29 Jul 2022 09:00:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ad52c9c2acd468ba47154f452acb884
+      - 91eecbb89d4340569255fe1e5a2514a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NjZmIyZTNlLTdiMDgtNDVl
-        ZS05Nzc4LTZmMDNmNzg2OTM4NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlMTY3ZDU1LWU3ZmUtNGQx
+        Yi04YzMzLWJkNmNlYzBlMmNjYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ccfb2e3e-7b08-45ee-9778-6f03f7869385/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8e167d55-e7fe-4d1b-8c33-bd6cec0e2cca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:53 GMT
+      - Fri, 29 Jul 2022 09:00:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 835f6bf09c8c42ffae80e8c557f5b0e9
+      - 20958e40013846a58f09c52dde9736d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2NmYjJlM2UtN2Iw
-        OC00NWVlLTk3NzgtNmYwM2Y3ODY5Mzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTMuMjMyMTQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGUxNjdkNTUtZTdm
+        ZS00ZDFiLThjMzMtYmQ2Y2VjMGUyY2NhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MTcuMDM5ODgzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjNhZDUyYzljMmFjZDQ2OGJhNDcxNTRmNDUy
-        YWNiODg0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6NTMuMjY1
-        OTUwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyMjo1My40NDY3
-        MTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjkxZWVjYmI4OWQ0MzQwNTY5MjU1ZmUxZTVh
+        MjUxNGE4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MTcuMDg1
+        NTA0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMDoxNy4zODc3
+        MDZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMjA4MjUx
-        YjktMjM2NS00N2FjLTlkNGYtMGU0YzQzZDM2YzUwLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vN2Q4MTVh
+        NTctMTI0NS00NzdlLTk0ZTctNGNiMmE3NjgwMDZkLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOTY4MmYzMDgtNjAxZi00M2E0LWFjMDUtYTgwMjU2
-        Y2JiNWMxLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNGM5ZmUwZjItNjIzNy00ZTkyLWFmNzItNGFhZTYz
+        NjdmN2QxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:53 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - c9a6e75772924a7b8863e41c1440e067
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:22:53 GMT
+      - Fri, 29 Jul 2022 09:00:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7031b47844314bd49663a48b46db4d45
+      - 74c71176275e41b6b4e75866d7e0baa2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/7d815a57-1245-477e-94e7-4cb2a768006d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:53 GMT
+      - Fri, 29 Jul 2022 09:00:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6011e2e4f82e43c4a0e5b08102554b6b
+      - 770d1a98573a4a0d9ffee779bd9e691f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vN2Q4MTVhNTctMTI0NS00NzdlLTk0ZTctNGNiMmE3NjgwMDZkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MTcuMTA1MzA5WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80YzlmZTBmMi02MjM3LTRlOTItYWY3Mi00YWFlNjM2N2Y3ZDEv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzRjOWZlMGYyLTYyMzctNGU5Mi1hZjcyLTRhYWU2
+        MzY3ZjdkMS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:17 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS83ZDgxNWE1Ny0xMjQ1LTQ3N2UtOTRlNy00Y2IyYTc2ODAwNmQv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - aade46d7be2242bcb01c70433b2f551f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFkOGI3OTBlLWQzNGEtNDVk
+        ZS05NWI0LWRlMDc0NjUxYWY5Yy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1d8b790e-d34a-45de-95b4-de074651af9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 534657a01a63465db24be84774a97713
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWQ4Yjc5MGUtZDM0
+        YS00NWRlLTk1YjQtZGUwNzQ2NTFhZjljLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MTcuNjM3MDcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhYWRlNDZkN2JlMjI0MmJjYjAxYzcwNDMz
+        YjJmNTUxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjE3LjY4
+        OTEyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MTcuOTE1
+        MDY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYjQ3
+        NjJjMWItMzA2YS00ODRmLTg5OGEtNTUyZmYyZTdlODViLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/b4762c1b-306a-484f-898a-552ff2e7e85b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a69e913d731048aeba1c2d0e2d822733
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2I0NzYyYzFiLTMwNmEtNDg0Zi04OThhLTU1MmZmMmU3ZTg1Yi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjE3Ljg5MDQyNloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vN2Q4MTVhNTctMTI0NS00NzdlLTk0ZTct
+        NGNiMmE3NjgwMDZkLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ab0e0dee4e604c8e9e9f62da0547e349
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - cd0a642cb9c04dc79aea6ef155c5b185
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a55830018d344123a9bdaa290391f354
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:53 GMT
+      - Fri, 29 Jul 2022 09:00:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a213e461bff04f22874e9202ec15da79
+      - fab5cd85d7c241d59469644a68e29ec2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:53 GMT
+      - Fri, 29 Jul 2022 09:00:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a633d7970a34157907c7c26ca10ae2f
+      - a7bbc007ddb54552ace3483ee01e4835
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:53 GMT
+      - Fri, 29 Jul 2022 09:00:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 60a513b88794425bbcd276fa39320fd9
+      - 999b2ee223424ef1a561943b6f82a01f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:54 GMT
+      - Fri, 29 Jul 2022 09:00:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8206f345599348d3b8e42098987a53c8
+      - d095a4f6a93443528a51ffe2a78a1741
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:54 GMT
+      - Fri, 29 Jul 2022 09:00:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6da7d7d09d43451397a0c5f6f26fa341
+      - 6be3edecf7f54d6193cae715b5383561
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:54 GMT
+      - Fri, 29 Jul 2022 09:00:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 81e8989bf46a45de9dd9dc3d4c12a8ab
+      - 8e24ef8b25f8466c9839d32020a7e245
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9682f308-601f-43a4-ac05-a80256cbb5c1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:54 GMT
+      - Fri, 29 Jul 2022 09:00:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e57ba9084224a3f80a77ccbe0ff4d4a
+      - 8f35c75ded8f4468bf3f4c3fac3b6a23
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:54 GMT
+      - Fri, 29 Jul 2022 09:00:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,69 +3208,69 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e2d6fa3a57844a4b3eea2606609d602
+      - 0a64fbedcbcc4062ae4bbe6ec4e4afcd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5MTljY2JkLTFhMWEtNGQy
-        Ny1hYmM3LTYzYTRjYzA4ZWI5Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxNDAzNTUzLTk4M2UtNGI3
+        NC1iNDYyLTRkZjhjNjZlOWY0MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMTliMzk3MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgx
-        ZmI1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xYTU3
-        NjVlZS03MDc4LTQzMzgtYTAzNi1mZDkyNzMwNDUxOTQvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFmMjQ0NjIxLTBjYmItNGJlOC05
-        NjIzLTNiZGRjM2IxMGViMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMmQ1ZTY2MTgtMGIwZC00YjlmLTlkOGQtMTVjNDgxMTg4Yzk1
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDYyY2Y4
-        NC00YzU1LTQ4OTQtOTQ0Zi04NjI3Mzc5NzU2ZDIvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0MTJmLTRjMzQtNGE0Mi1hYWY2
-        LTYyOTc1NDliMDM4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzAxYmEwMzctNWY4Zi00N2JkLWE5MGEtNDU4MTFmZTNmZDgwLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83NzAyYmFkNi01
-        ZDc2LTQ0YWQtOTlhZi1iMzIwMzUwNDZlYmUvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1
-        OWIwNjFiNThhNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvYTNlMDNjZDEtM2MzNC00Y2JiLTlmODYtZjkyN2Y2YWMxZjljLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hODNkYWM4Ny03NWI1
-        LTRlN2ItOGIwYi1iZjE5OGRjYjYyMTQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3
-        YTNlZjg3MC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0ZDI4MGY1ZWQzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iNjZmNzBkYS01OWQ4LTQz
-        YjctOGRhMi1jMmIxMTBhMWYxYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2I4ZTY0ZDRkLTIwZTAtNDdjMi05NTk2LTMzYTQzZjE0
-        YmJiNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFm
-        MjRjMWEtMGUwNy00MTZlLTg0YTctZWU0NTcyMzJiMDVkLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMWQ2OTMwYi0yNjFjLTRkZjQt
-        OTY5Yi1lMTU2MDVhZjNmMTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0OTk5ZDIxOWM0
-        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2
-        OWUtZDlmZC00YzI0LTg2Y2ItYzI1M2E2ZmU1NTA5LyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDZiNzk5Ni00MjVhLTRhODUtODFi
-        Yi1hMjQ2YzgwMGU5YjgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZmODUwYjkyNmU1Yy8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTU3NjA5MGYt
-        ZWYwZS00YWVmLWIzYjctMmEzODI2ZDAxZDZjLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04
-        ZWRkOWQ5ZDExNjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2VjMjdkMzU5LTkzODgtNDg3Yy1iMmNhLWRlZDNlMjdmZTZkYS8iXX0=
+        cG0vcGFja2FnZXMvMDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1
+        OGJiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZDRm
+        NzdiMy0xNDgxLTRmNTItOWM3NS0xYmJhNzcwYjY3ZGUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1h
+        ZjQzLTM4MDMxMzZkMTIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvMGY3NTdkMjQtNjc4Mi00NTEwLTliZDctMWY0ZDg5ZjE5OGNi
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zMzE5Y2Zh
+        MC1kZGZjLTQzYzAtOGE2ZS1kMWQ5OWQ0MWI2ZDgvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1
+        LTEzYTkzYjM5MmEwZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvNjkzYTRlYjItZDczOS00MDkyLTg5NmYtODM2MzBmZjNjNGZiLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZGM4YzA3Ni1k
+        NTFkLTQxZGQtYjQ1NS04MzRjMmY4ZDU4OGMvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzZmMWM5MGIwLWE3ODctNDhjYy04MGNiLWZj
+        YTM5ODAwMGM3Ni8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUzOGMzZWU3M2I5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84YjgzYTg5Ny01ODRj
+        LTQ2YTItODI3Zi04YjA3ZGFlOTdiYWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzkyYjY2YWNiLTYwYjktNGVmNC1iNTFhLTlhYjZh
+        NzUwMGY4Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OTliNmFmZWYtZjIxYi00OWY5LWEzNmItODUxODAzM2YwMzYwLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRh
+        YjktYmI4Yi00MjljNGY5YmZjN2IvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQz
+        MGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTVj
+        ZGJkZGUtYmNhOC00NTI5LTliNDEtYzdiZTgxZjc5MjQ4LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4LTRmOWEt
+        ODRmMy0xYjMxMjU0Y2VkZDcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2NhZjM4MDc5LWUwNTYtNDRlNy05NjNlLWUyYzIzM2M4ZmY4
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2VhMWQ4
+        OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUxN2NkLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9kNTA5ODkxYS1mMjIyLTQ5MjktYWYy
+        ZC1jOTEwMGE0OGE2Y2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4Yy8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTQ5N2UwZWUt
+        M2JhOS00YTNlLWE3YmEtZGIyNTA1OTFiMjMyLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2YyZGZmMTNlLWY4OTItNGM3Ny1iNGI0LTU4N2NhNzk4MjZkZi8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2858,7 +3283,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:54 GMT
+      - Fri, 29 Jul 2022 09:00:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2876,21 +3301,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11c01d2bc5d5461daf5574f9422e6e67
+      - 32ba4267561d4790a21ee6dd8b3fa2f7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzNzc5NWU3LWU3MzktNDQ4
-        NC1iNjIxLTkzZjMyMjcyYmEwYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzYmViZGI1LWRjZDItNDll
+        Zi1hYzNjLTllYTlmOTIyZGE1OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/837795e7-e739-4484-b621-93f32272ba0a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/13bebdb5-dcd2-49ef-ac3c-9ea9f922da59/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2911,53 +3336,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:54 GMT
+      - Fri, 29 Jul 2022 09:00:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 424d6f8ff1764346a0d2e84780cb07b4
+      - 97559270a1a54262b18746d7d7e33f16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODM3Nzk1ZTctZTcz
-        OS00NDg0LWI2MjEtOTNmMzIyNzJiYTBhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjI6NTQuNDIyNDIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTNiZWJkYjUtZGNk
+        Mi00OWVmLWFjM2MtOWVhOWY5MjJkYTU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MTkuNDA1MTcyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxMWMwMWQyYmM1ZDU0NjFkYWY1
-        NTc0Zjk0MjJlNmU2NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjIy
-        OjU0LjU2MjExNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjI6
-        NTQuNjk2MDYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMmJhNDI2NzU2MWQ0NzkwYTIx
+        ZWU2ZGQ4YjNmYTJmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjE5LjY1NDg2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        MTkuOTAzOTA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xYjAyMWUwMi04ZTI4LTQ0ODUtYjY5Yy0xNDMyNzE4ZjZlZTAvdmVyc2lv
+        bS84ZGI0NWZkNi0yMWRjLTRmMmEtYmI5Ni1kNjEwNGQwMGRjZTkvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMWIwMjFlMDItOGUyOC00NDg1
-        LWI2OWMtMTQzMjcxOGY2ZWUwLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGRiNDVmZDYtMjFkYy00ZjJh
+        LWJiOTYtZDYxMDRkMDBkY2U5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2965,7 +3390,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2978,86 +3403,86 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:54 GMT
+      - Fri, 29 Jul 2022 09:00:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2164'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96031b86ed954a429f57f60b4e06594e
+      - 98e2f9fec82546d78a15af0a8634733f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '678'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MjQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvZTVjYWUzZjMtYjJkMC00MjJjLTllOTEtOGVkZDlkOWQxMTYyLyJ9LHsi
+        ZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUxN2NkLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZmODUwYjkyNmU1Yy8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
-        MWQ2OTMwYi0yNjFjLTRkZjQtOTY5Yi1lMTU2MDVhZjNmMTIvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTU3
-        NjA5MGYtZWYwZS00YWVmLWIzYjctMmEzODI2ZDAxZDZjLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJi
-        YWQ2LTVkNzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iYWYyNGMx
-        YS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzM2NGU5MmUt
-        MTY0MS00Y2ViLTgwYjAtOTQ5OTlkMjE5YzQ0LyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2VjMjdkMzU5LTkz
-        ODgtNDg3Yy1iMmNhLWRlZDNlMjdmZTZkYS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iNjZmNzBkYS01OWQ4
-        LTQzYjctOGRhMi1jMmIxMTBhMWYxYmUvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNmE3NjQxMmYtNGMzNC00
-        YTQyLWFhZjYtNjI5NzU0OWIwMzg4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2FhZTgzMzVkLTg1ZjItNGVl
-        MS04ODljLThiNGQyODBmNWVkMy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jZTZmMTY5ZS1kOWZkLTRjMjQt
-        ODZjYi1jMjUzYTZmZTU1MDkvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2MyLTk1
-        OTYtMzNhNDNmMTRiYmI1LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBi
-        LWJmMTk4ZGNiNjIxNC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0z
-        NTliMDYxYjU4YTYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYThjMzk2MzItZWNlOC00MzZiLWJkMDctYjg0
-        MDdhM2VmODcwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzFmMjQ0NjIxLTBjYmItNGJlOC05NjIzLTNiZGRj
-        M2IxMGViMS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9kMDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2Yzgw
-        MGU5YjgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1NS00ODk0LTk0NGYtODYyNzM3OTc1
-        NmQyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4MTE4OGM5
-        NS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8xOWIzOTcyMy0wYjc1LTRkZmUtYWMzZi03NmZhZWJlODFmYjUv
+        Lzk5YjZhZmVmLWYyMWItNDlmOS1hMzZiLTg1MTgwMzNmMDM2MC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        NTA5ODkxYS1mMjIyLTQ5MjktYWYyZC1jOTEwMGE0OGE2Y2MvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0
+        Zjc3YjMtMTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2FlMzVi
+        YWYwLTU2ZjgtNGY5YS04NGYzLTFiMzEyNTRjZWRkNy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMmRmZjEz
+        ZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNmRjOGMwNzYt
+        ZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1ODhjLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZmMWM5MGIwLWE3
+        ODctNDhjYy04MGNiLWZjYTM5ODAwMGM3Ni8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3
+        LTQwZDItYWY0My0zODAzMTM2ZDEyMmEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRhODIyZDYtNGVmNC00
+        NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEw
+        MS1iMjQwLTZlMzhjM2VlNzNiOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NGU4OTAwZC03MjIxLTQ0MDgt
+        OTAwNS0xM2E5M2IzOTJhMGQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3
+        YmEtZGIyNTA1OTFiMjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3
+        LTJjODJhZTc4Nzg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy84YjgzYTg5Ny01ODRjLTQ2YTItODI3Zi04
+        YjA3ZGFlOTdiYWYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFk
+        OTlkNDFiNmQ4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzL2NhZjM4MDc5LWUwNTYtNDRlNy05NjNlLWUyYzIz
+        M2M4ZmY4NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8wOGM5ZTgxZS0wMjhkLTQ3ZjQtYmM5ZC1hYThmOTUy
+        MTU4YmIvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMGY3NTdkMjQtNjc4Mi00NTEwLTliZDctMWY0ZDg5ZjE5
+        OGNiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2E1Y2RiZGRlLWJjYTgtNDUyOS05YjQxLWM3YmU4MWY3OTI0
+        OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQyYi05MDMzNmRkMzBjNGMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3065,7 +3490,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3078,7 +3503,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:55 GMT
+      - Fri, 29 Jul 2022 09:00:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3096,21 +3521,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a19cc178ef7d44419fbd4b2fa1189ace
+      - c1fc13f0b09749c79435ebb3f788fd52
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3118,7 +3543,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3131,7 +3556,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:55 GMT
+      - Fri, 29 Jul 2022 09:00:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3149,21 +3574,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '068b280681fb41cc936320578f6a9acb'
+      - 44f3119041ad4ef78a817fcb33ab6177
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3171,7 +3596,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3184,7 +3609,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:55 GMT
+      - Fri, 29 Jul 2022 09:00:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3202,21 +3627,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1a1abe41172494e9c9985592f5f89af
+      - aa60d58969eb459eab259dd1c08d55fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3224,7 +3649,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3237,7 +3662,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:55 GMT
+      - Fri, 29 Jul 2022 09:00:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3255,21 +3680,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95a36b2d00df43d397fbafa16a74560c
+      - d29b989d9e464d47b5b672936a53e842
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1b021e02-8e28-4485-b69c-1432718f6ee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3277,7 +3702,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3290,7 +3715,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:22:55 GMT
+      - Fri, 29 Jul 2022 09:00:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3308,16 +3733,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab60f0f58b2441fa9399005896c74ea1
+      - 60a4c1a99dde4673a350e1cada366363
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:22:55 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:20 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_srpms_repository/all_srpms_copied_despite_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_unit_yum_srpms_repository/all_srpms_copied_despite_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:46 GMT
+      - Fri, 29 Jul 2022 09:00:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,27 +35,41 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 78c2fbf8c3074fbda3c7f6b70112e4f5
+      - c3791c5eef464a619580a9998f3f7945
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80YzlmZTBmMi02MjM3LTRlOTItYWY3Mi00YWFlNjM2N2Y3ZDEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDoxMC43MDcxNzVa
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80YzlmZTBmMi02MjM3LTRlOTItYWY3Mi00YWFlNjM2N2Y3ZDEv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzRjOWZl
+        MGYyLTYyMzctNGU5Mi1hZjcyLTRhYWU2MzY3ZjdkMS92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
+        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
+        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
+        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
+        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
+        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
+        ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:46 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
 - request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/4c9fe0f2-6237-4e92-af72-4aae6367f7d1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,1025 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 129ed1464c1447d39797ad9c9e873c9d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:46 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1c9f6652b89948e9a762b4e46c194d42
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:46 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - a9042a5cde1c423a82f4489acc6ad5f5
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:46 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - df9d1d5044374c91a2360affd36b8ef6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:46 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f9bff8021af241bab9a558699f4e1980
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:46 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - bb738d25183447eaa97a74b1cd60cfe9
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:46 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1975aa47fc064d49a7355ba7b997d484
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:46 GMT
-- request:
-    method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2ZpeHR1cmVz
-        LnB1bHBwcm9qZWN0Lm9yZy9zcnBtLXVuc2lnbmVkLyIsImNhX2NlcnQiOm51
-        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0bHNf
-        dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwcm94eV91c2Vy
-        bmFtZSI6bnVsbCwicHJveHlfcGFzc3dvcmQiOm51bGwsInVzZXJuYW1lIjpu
-        dWxsLCJwYXNzd29yZCI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRlIiwidG90
-        YWxfdGltZW91dCI6MzYwMCwiY29ubmVjdF90aW1lb3V0Ijo2MCwic29ja19j
-        b25uZWN0X3RpbWVvdXQiOjYwLCJzb2NrX3JlYWRfdGltZW91dCI6MzYwMCwi
-        cmF0ZV9saW1pdCI6MH0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/cd7d70f2-44de-456e-9ea4-31aacfa8f31c/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '566'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - dc01bde927334c869cde4a009b5591b9
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Nk
-        N2Q3MGYyLTQ0ZGUtNDU2ZS05ZWE0LTMxYWFjZmE4ZjMxYy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjQ3LjA3MTEyMVoiLCJuYW1lIjoi
-        Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2ZpeHR1cmVzLnB1bHBwcm9q
-        ZWN0Lm9yZy9zcnBtLXVuc2lnbmVkLyIsImNhX2NlcnQiOm51bGwsImNsaWVu
-        dF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJs
-        IjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoi
-        MjAyMi0wNS0yM1QyMzoxMzo0Ny4wNzExNTJaIiwiZG93bmxvYWRfY29uY3Vy
-        cmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1l
-        ZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91
-        dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVh
-        ZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQi
-        OjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:47 GMT
-- request:
-    method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9u
-        cyI6MH0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '631'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e9896f4d52224457b48ec52304db08cd
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjkzYjdkN2YtMDBlZC00MjE5LWI5ZjItNTI0MDM5YjIzMTQyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTM6NDcuNTA3NjE1WiIsInZl
-        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjkzYjdkN2YtMDBlZC00MjE5LWI5ZjItNTI0MDM5YjIzMTQyL3ZlcnNp
-        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yOTNiN2Q3Zi0w
-        MGVkLTQyMTktYjlmMi01MjQwMzliMjMxNDIvdmVyc2lvbnMvMC8iLCJuYW1l
-        IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
-        cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
-        OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
-        bl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBl
-        IjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNr
-        IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
-        fQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:47 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f5a36321eab0482199dfe14426cfa9d7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:47 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - ee65358a6b114d01bc237f4ebba3deea
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:47 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 3f025ee3bfb64d49bd34890c1984036a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:47 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 548910518cc444c1b62567d55daa2a22
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:47 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e39e5181cbf145a9b903857bedcd8dfa
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:47 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 6a20082850d241fa9ca88074ab82cb85
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:48 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - b1687d3b0f544d51ab7a7ef35377e170
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:48 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 85c296298178491e8aa54b8142a34283
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:48 GMT
-- request:
-    method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:13:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '621'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f27409e495d74f0e8d1ff6a8648acdab
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmE4NzM4OGQtZTM1Ni00ZDRkLWIyZmItYWNiYmNiZWQ0NzU5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTM6NDguMjM5MDgxWiIsInZl
-        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmE4NzM4OGQtZTM1Ni00ZDRkLWIyZmItYWNiYmNiZWQ0NzU5L3ZlcnNp
-        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82YTg3Mzg4ZC1l
-        MzU2LTRkNGQtYjJmYi1hY2JiY2JlZDQ3NTkvdmVyc2lvbnMvMC8iLCJuYW1l
-        IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
-        cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
-        dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
-        dmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGwsInBh
-        Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
-        Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:48 GMT
-- request:
-    method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/cd7d70f2-44de-456e-9ea4-31aacfa8f31c/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IjIiLCJ1cmwiOiJodHRw
-        czovL2ZpeHR1cmVzLnB1bHBwcm9qZWN0Lm9yZy9zcnBtLXVuc2lnbmVkLyIs
-        InByb3h5X3VybCI6bnVsbCwicHJveHlfdXNlcm5hbWUiOm51bGwsInByb3h5
-        X3Bhc3N3b3JkIjpudWxsLCJ0b3RhbF90aW1lb3V0IjozNjAwLCJjb25uZWN0
-        X3RpbWVvdXQiOjYwLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAsInNvY2tf
-        cmVhZF90aW1lb3V0IjozNjAwLCJyYXRlX2xpbWl0IjowLCJ1c2VybmFtZSI6
-        bnVsbCwicGFzc3dvcmQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGll
-        bnRfa2V5IjpudWxsLCJjYV9jZXJ0IjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
-        dGUifQ==
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1094,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:48 GMT
+      - Fri, 29 Jul 2022 09:00:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1112,21 +108,74 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d496b0e17e424d548526361274349c60
+      - 40a41f470aa346d2b060bf870f6a1f0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VhOTQyNWIyLTc1YWMtNDYx
-        NS1hOGQyLWY5MTYxYmE0ODUzZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5M2FhMTQ1LTMzNjEtNDJj
+        Ny04NGRmLTk4OGM0M2JjNTA1Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:48 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ea9425b2-75ac-4615-a8d2-f9161ba4853f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fbb81407e3ea4bf2bf834379c773352e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/393aa145-3361-42c7-84df-988c43bc505b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1147,63 +196,173 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:49 GMT
+      - Fri, 29 Jul 2022 09:00:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4dcfd64714e34cbb9901b0a0d6ddec41
+      - c4ed6ea8d00f4dca912832a33d38f343
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWE5NDI1YjItNzVh
-        Yy00NjE1LWE4ZDItZjkxNjFiYTQ4NTNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTM6NDguOTgwODY0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJkNDk2YjBlMTdlNDI0ZDU0ODUyNjM2MTI3
-        NDM0OWM2MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjEzOjQ5LjAy
-        Njc1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTM6NDkuMDU4
-        MTQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzkzYWExNDUtMzM2
+        MS00MmM3LTg0ZGYtOTg4YzQzYmM1MDViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MjIuMjA5NDU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0MGE0MWY0NzBhYTM0NmQyYjA2MGJmODcw
+        ZjZhMWYwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjIyLjI1
+        MTYyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MjIuNDQ1
+        MTQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NkN2Q3MGYyLTQ0ZGUtNDU2ZS05ZWE0
-        LTMxYWFjZmE4ZjMxYy8iXX0=
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGM5ZmUwZjItNjIzNy00ZTky
+        LWFmNzItNGFhZTYzNjdmN2QxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
 - request:
-    method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/sync/
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NkN2Q3
-        MGYyLTQ0ZGUtNDU2ZS05ZWE0LTMxYWFjZmE4ZjMxYy8iLCJzeW5jX3BvbGlj
-        eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
-        aW1pemUiOnRydWV9
+      encoding: US-ASCII
+      base64_string: ''
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e31e4ec7ddc044868ec5ee10e4db8ee2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b5fd776bc67b48b89e0225b5dce698e1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vYjQ3NjJjMWItMzA2YS00ODRmLTg5OGEtNTUyZmYyZTdlODVi
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MTcuODkwNDI2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/b4762c1b-306a-484f-898a-552ff2e7e85b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1216,7 +375,1366 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:49 GMT
+      - Fri, 29 Jul 2022 09:00:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 550c8b933f76482794bb0279b6dbf0ed
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2MzVjMGFkLTQ3MzItNDIz
+        YS1iYmE2LWE3OWNhNTZhYmMyNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9635c0ad-4732-423a-bba6-a79ca56abc25/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 256a859cef924a4db591a00a986f9519
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTYzNWMwYWQtNDcz
+        Mi00MjNhLWJiYTYtYTc5Y2E1NmFiYzI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MjIuNjIzODgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NTBjOGI5MzNmNzY0ODI3OTRiYjAyNzli
+        NmRiZjBlZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjIyLjY3
+        MzEyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MjIuNzA3
+        Njc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3f4f8a8517174a75a430822237d5a4f0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - db40942ae9cf4068b69f2607ec7b16b8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f87c74986be949e088c1368c289c6475
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4fca31dd31274d588c5a818f3c2dc975
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2ZpeHR1cmVz
+        LnB1bHBwcm9qZWN0Lm9yZy9zcnBtLXVuc2lnbmVkLyIsImNhX2NlcnQiOm51
+        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0bHNf
+        dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwcm94eV91c2Vy
+        bmFtZSI6bnVsbCwicHJveHlfcGFzc3dvcmQiOm51bGwsInVzZXJuYW1lIjpu
+        dWxsLCJwYXNzd29yZCI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRlIiwidG90
+        YWxfdGltZW91dCI6MzYwMCwiY29ubmVjdF90aW1lb3V0Ijo2MCwic29ja19j
+        b25uZWN0X3RpbWVvdXQiOjYwLCJzb2NrX3JlYWRfdGltZW91dCI6MzYwMCwi
+        cmF0ZV9saW1pdCI6MH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/59c8a1d1-738f-4eac-889d-72c1c945bbd0/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '566'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3210c561dfe24423a14d43edc399b2c9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU5
+        YzhhMWQxLTczOGYtNGVhYy04ODlkLTcyYzFjOTQ1YmJkMC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjIzLjE2NDEwNloiLCJuYW1lIjoi
+        Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2ZpeHR1cmVzLnB1bHBwcm9q
+        ZWN0Lm9yZy9zcnBtLXVuc2lnbmVkLyIsImNhX2NlcnQiOm51bGwsImNsaWVu
+        dF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJs
+        IjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoi
+        MjAyMi0wNy0yOVQwOTowMDoyMy4xNjQxMjlaIiwiZG93bmxvYWRfY29uY3Vy
+        cmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1l
+        ZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91
+        dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVh
+        ZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQi
+        OjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9u
+        cyI6MH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '631'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bebb0d396006402aae41d08a28343d4e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNTU3ZTU5NzEtOWIyNy00YzU1LTliNTEtM2Y2NGJmOGIwYzFkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MjMuMzAyNDk4WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNTU3ZTU5NzEtOWIyNy00YzU1LTliNTEtM2Y2NGJmOGIwYzFkL3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81NTdlNTk3MS05
+        YjI3LTRjNTUtOWI1MS0zZjY0YmY4YjBjMWQvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
+        cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
+        OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
+        bl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBl
+        IjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNr
+        IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
+        fQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '673'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7cf54aaf26f34d278a7666cb9a28132f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84ZGI0NWZkNi0yMWRjLTRmMmEtYmI5Ni1kNjEwNGQwMGRjZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDoxMS43NTc3OTda
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84ZGI0NWZkNi0yMWRjLTRmMmEtYmI5Ni1kNjEwNGQwMGRjZTkv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzhkYjQ1
+        ZmQ2LTIxZGMtNGYyYS1iYjk2LWQ2MTA0ZDAwZGNlOS92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
+        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
+        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
+        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
+        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
+        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8db45fd6-21dc-4f2a-bb96-d6104d00dce9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 29dd9804a1124c27865b1bbbafade16e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NjNWY5MDc4LTA0OTItNGM4
+        YS05ZjE3LTFlYzMyZjQyNGFiZC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '622'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a404fe49ea0a4905914e6b61a5704698
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
+        cG0vNTJmZWMwYzItYWU1Zi00NDczLWEzNjMtM2Y5YjJiMDQ5ZThiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MTAuNTU5MzY2WiIsIm5h
+        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
+        ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
+        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
+        cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQwOTowMDoxMi4yMjI1MzlaIiwiZG93bmxv
+        YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
+        Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
+        Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
+        InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
+        dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/52fec0c2-ae5f-4473-a363-3f9b2b049e8b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 29bf45f1c8f244f38510292b26b046ff
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5NDYyMWZkLTBiNDQtNDc4
+        Yi1hOGRjLTI4MjdkMmEzNWM2Mi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/cc5f9078-0492-4c8a-9f17-1ec32f424abd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '607'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2d9a01d11c3648028baaaa2659c3c902
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2M1ZjkwNzgtMDQ5
+        Mi00YzhhLTlmMTctMWVjMzJmNDI0YWJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MjMuNTI0Mzc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyOWRkOTgwNGExMTI0YzI3ODY1YjFiYmJh
+        ZmFkZTE2ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjIzLjU2
+        NTU3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MjMuNjQ4
+        MjE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGRiNDVmZDYtMjFkYy00ZjJh
+        LWJiOTYtZDYxMDRkMDBkY2U5LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c94621fd-0b44-478b-a8dc-2827d2a35c62/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a90cb2a9e98a46a083b5c9ca40feea3d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzk0NjIxZmQtMGI0
+        NC00NzhiLWE4ZGMtMjgyN2QyYTM1YzYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MjMuNjQ0NDc4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyOWJmNDVmMWM4ZjI0NGYzODUxMDI5MmIy
+        NmIwNDZmZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjIzLjY5
+        NTYzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MjMuNzUx
+        NDIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzUyZmVjMGMyLWFlNWYtNDQ3My1hMzYz
+        LTNmOWIyYjA0OWU4Yi8iXX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2338f873c88643d1bcfe5e45f26c8dc6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2192be9521a44eaeab6288ff54084bd8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a9fc6a75fb5e43ecaa1138388e39efba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f6cfc667046d43f5af575a07280ead4c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e74fadb0001947209e3f1644c4e1f012
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:24 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e3e346262420482a92a3afc66d8199e7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:24 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '621'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a1c0d0d16e5d441b8934dac22dd1ca0f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNjg2YTFiNDktODY5ZC00N2JhLWI0MGYtYmE1NmM3NGY2M2FjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MjQuMjAzODgyWiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNjg2YTFiNDktODY5ZC00N2JhLWI0MGYtYmE1NmM3NGY2M2FjL3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82ODZhMWI0OS04
+        NjlkLTQ3YmEtYjQwZi1iYTU2Yzc0ZjYzYWMvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
+        cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
+        dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
+        dmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGwsInBh
+        Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
+        Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:24 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/59c8a1d1-738f-4eac-889d-72c1c945bbd0/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IjIiLCJ1cmwiOiJodHRw
+        czovL2ZpeHR1cmVzLnB1bHBwcm9qZWN0Lm9yZy9zcnBtLXVuc2lnbmVkLyIs
+        InByb3h5X3VybCI6bnVsbCwicHJveHlfdXNlcm5hbWUiOm51bGwsInByb3h5
+        X3Bhc3N3b3JkIjpudWxsLCJ0b3RhbF90aW1lb3V0IjozNjAwLCJjb25uZWN0
+        X3RpbWVvdXQiOjYwLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAsInNvY2tf
+        cmVhZF90aW1lb3V0IjozNjAwLCJyYXRlX2xpbWl0IjowLCJ1c2VybmFtZSI6
+        bnVsbCwicGFzc3dvcmQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGll
+        bnRfa2V5IjpudWxsLCJjYV9jZXJ0IjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8fab056abe924f94a9e8fe60d3f8a5f8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdkYTY3NmQ1LWY4MzktNDk1
+        Yy05OThjLTZiZjY0MGExODEwNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:24 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7da676d5-f839-495c-998c-6bf640a18104/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 99d35ac6b53842f1a2d5cde154bc668b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2RhNjc2ZDUtZjgz
+        OS00OTVjLTk5OGMtNmJmNjQwYTE4MTA0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MjQuNTU5MzU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4ZmFiMDU2YWJlOTI0Zjk0YTllOGZlNjBk
+        M2Y4YTVmOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjI0LjYw
+        NTk2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MjQuNjQ0
+        NjAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU5YzhhMWQxLTczOGYtNGVhYy04ODlk
+        LTcyYzFjOTQ1YmJkMC8iXX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:24 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU5Yzhh
+        MWQxLTczOGYtNGVhYy04ODlkLTcyYzFjOTQ1YmJkMC8iLCJzeW5jX3BvbGlj
+        eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
+        aW1pemUiOnRydWV9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1234,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d38890849e724292b2eab98ff6d240a7
+      - 9e61a09257da499ea6b278ef384d88ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdkZGQzOTQxLTE4YTktNDI5
-        YS04OTIxLWVkNTY4YWI5MzBmOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzMjIxYzVkLWFkNGMtNDNk
+        Ni1iZmVjLWFkMzBjZTg0MTk1OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:49 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7ddd3941-18a9-429a-8921-ed568ab930f8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b3221c5d-ad4c-43d6-bfec-ad30ce841958/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1269,84 +1787,84 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:51 GMT
+      - Fri, 29 Jul 2022 09:00:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1615'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a52a6b4002e04da385a768b0e6e291cc
+      - ec4a1b63d9e6459c9c99223fd9ced505
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '610'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2RkZDM5NDEtMThh
-        OS00MjlhLTg5MjEtZWQ1NjhhYjkzMGY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTM6NDkuMTc0OTA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjMyMjFjNWQtYWQ0
+        Yy00M2Q2LWJmZWMtYWQzMGNlODQxOTU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MjQuODExMzkzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkMzg4OTA4NDllNzI0MjkyYjJl
-        YWI5OGZmNmQyNDBhNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjEz
-        OjQ5LjIwNjk0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTM6
-        NTEuNzY3NDQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI5ZTYxYTA5MjU3ZGE0OTllYTZi
+        Mjc4ZWYzODRkODhhZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjI0Ljg1Njc3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        MjguOTg2OTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
-        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
-        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6OSwic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
-        c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
-        OiJQYXJzZWQgQ29tcHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmNvbXBzIiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUi
-        OiJzeW5jLnBhcnNpbmcuYWR2aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVk
-        IiwidG90YWwiOjIsImRvbmUiOjIsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0
-        aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxs
-        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI5M2I3ZDdm
-        LTAwZWQtNDIxOS1iOWYyLTUyNDAzOWIyMzE0Mi92ZXJzaW9ucy8xLyJdLCJy
-        ZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8yOTNiN2Q3Zi0wMGVkLTQyMTktYjlmMi01MjQw
-        MzliMjMxNDIvIiwic2hhcmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vY2Q3ZDcwZjItNDRkZS00NTZlLTllYTQtMzFhYWNmYThmMzFjLyJdfQ==
+        IjpudWxsLCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBDb21wcyIsImNvZGUiOiJz
+        eW5jLnBhcnNpbmcuY29tcHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNl
+        ZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5hZHZpc29yaWVz
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MiwiZG9uZSI6Miwic3Vm
+        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMi
+        LCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2Rl
+        IjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6ImFzc29jaWF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
+        b25lIjo5LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU1N2U1OTcxLTli
+        MjctNGM1NS05YjUxLTNmNjRiZjhiMGMxZC92ZXJzaW9ucy8xLyJdLCJyZXNl
+        cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS81NTdlNTk3MS05YjI3LTRjNTUtOWI1MS0zZjY0YmY4
+        YjBjMWQvIiwic2hhcmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0v
+        NTljOGExZDEtNzM4Zi00ZWFjLTg4OWQtNzJjMWM5NDViYmQwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:29 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMjkzYjdkN2YtMDBlZC00MjE5LWI5ZjItNTI0MDM5YjIz
-        MTQyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNTU3ZTU5NzEtOWIyNy00YzU1LTliNTEtM2Y2NGJmOGIw
+        YzFkL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1359,7 +1877,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:51 GMT
+      - Fri, 29 Jul 2022 09:00:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1377,21 +1895,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b6fa40ef65cc48a792b8a2fec02fedcc
+      - a955945b07c542bd92064f6b1c209929
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FhNTE0Yzg4LTI3ZTctNDhi
-        Mi05N2I1LWQzMzMwMzY2ZDAxOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkMzA4NmM1LTQ1NWQtNDFj
+        Yi05Njk4LTExOWUyZmE4N2RiZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:51 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/aa514c88-27e7-48b2-97b5-d3330366d019/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ed3086c5-455d-41cb-9698-119e2fa87dbe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1412,56 +1930,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:52 GMT
+      - Fri, 29 Jul 2022 09:00:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4905f27af82141fc89b1f34f0b753634
+      - bf2584157c8441f3b0e7d257d54d93ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWE1MTRjODgtMjdl
-        Ny00OGIyLTk3YjUtZDMzMzAzNjZkMDE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTM6NTEuOTg3NDEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWQzMDg2YzUtNDU1
+        ZC00MWNiLTk2OTgtMTE5ZTJmYTg3ZGJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MjkuNDQ0MDUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImI2ZmE0MGVmNjVjYzQ4YTc5MmI4YTJmZWMw
-        MmZlZGNjIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTM6NTIuMDE2
-        ODc4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxMzo1Mi4xODcx
-        MjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImE5NTU5NDViMDdjNTQyYmQ5MjA2NGY2YjFj
+        MjA5OTI5Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MjkuNDg0
+        ODkwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQwOTowMDoyOS43NzE3
+        NDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZTZmYjlj
-        ZjEtNzAyMC00ZWM0LWE5MTItNTY5MzQ4MjA2NjZjLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDRhZDM3
+        NmYtMzRiOS00ZDc5LThjNTMtZTI4MjM2NzlkZjYzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMjkzYjdkN2YtMDBlZC00MjE5LWI5ZjItNTI0MDM5
-        YjIzMTQyLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNTU3ZTU5NzEtOWIyNy00YzU1LTliNTEtM2Y2NGJm
+        OGIwYzFkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1469,7 +1987,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1482,7 +2000,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:52 GMT
+      - Fri, 29 Jul 2022 09:00:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1500,21 +2018,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43d3b92f1cfa457cba34202908319c25
+      - ea643945727a4f15868a1447d221b146
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/44ad376f-34b9-4d79-8c53-e2823679df63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1522,7 +2040,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1535,7 +2053,254 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:52 GMT
+      - Fri, 29 Jul 2022 09:00:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5d585b4a565b43649c5b4310fdd8b57f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNDRhZDM3NmYtMzRiOS00ZDc5LThjNTMtZTI4MjM2NzlkZjYzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDA6MjkuNTE2OTQ4WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS81NTdlNTk3MS05YjI3LTRjNTUtOWI1MS0zZjY0YmY4YjBjMWQv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzU1N2U1OTcxLTliMjctNGM1NS05YjUxLTNmNjRi
+        ZjhiMGMxZC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS80NGFkMzc2Zi0zNGI5LTRkNzktOGM1My1lMjgyMzY3OWRmNjMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0a221e8d17914987b9b0625719b21e83
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxOTY5OGRhLTZlMjEtNDE1
+        OC1hYTkzLWQyOWM4ZmM4N2Q2YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d19698da-6e21-4158-aa93-d29c8fc87d6a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bca0b0b78ba2442a9cf7d55f49c8e56e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDE5Njk4ZGEtNmUy
+        MS00MTU4LWFhOTMtZDI5YzhmYzg3ZDZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzAuMDQ5ODA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwYTIyMWU4ZDE3OTE0OTg3YjliMDYyNTcx
+        OWIyMWU4MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAwOjMwLjA5
+        MDc2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6MzAuMzE1
+        Mjc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYTA2
+        NzlhOTgtN2I3NC00MTNkLTg1OWMtMTU5OTFiNTVjMDVhLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/a0679a98-7b74-413d-859c-15991b55c05a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4a2fc83b5b484008985e26b2670302e5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2EwNjc5YTk4LTdiNzQtNDEzZC04NTljLTE1OTkxYjU1YzA1YS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAwOjMwLjI5Njc0NloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNDRhZDM3NmYtMzRiOS00ZDc5LThjNTMt
+        ZTI4MjM2NzlkZjYzLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1553,21 +2318,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6d6df5b9b67c421ca62201cd2b088b16
+      - 15a4643d723a4ccf8d87c864c8bf6f93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1575,7 +2340,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1588,37 +2353,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:52 GMT
+      - Fri, 29 Jul 2022 09:00:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e7d3258e83c40dca739db3ec5fd7cdf
+      - aa27838255a84325ab9baf4faa67dd62
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '578'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:00:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1920'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a982a0e7eb2e4052964f7fb2bdb0cdeb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzE0Mzg5NzRlLTM1N2UtNDIyYS1iOTRjLTE3NThhNWJjZjk2
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMzI5
-        MloiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzL2I5MjNhZDU2LTNlZjctNDAzZS05ZjdmLTQyNGRkOWMyNmRj
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5NjQy
+        NFoiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
         Ni0wMS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVt
         XzEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDYiLCJmcm9t
         c3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -1634,8 +2452,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzYxYzg2MDg1LTM5N2MtNDA4My05ZjA5LTA0YzVkY2UwYTljMy8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMDQyNloi
+        c29yaWVzL2FmOGVhMzhjLTUzMzEtNDI4ZS1iNzQxLTNhNTg1NTA2Y2M4MS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5MTk4Nloi
         LCJpZCI6IlJIRUEtMjAxMjowMDIzIiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         Mi0yNyAxNzowMDowMCIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVtXzIi
         LCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDgiLCJmcm9tc3Ry
@@ -1658,10 +2476,10 @@ http_interactions:
         dW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6
         W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1669,7 +2487,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1682,37 +2500,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:52 GMT
+      - Fri, 29 Jul 2022 09:00:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1031'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9e9b1ea490645f59c022158ef689f15
+      - eb8baacd393c4d2aaa2c6fe071e20e95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '442'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzVjZGNmMzFjLTBjYWMtNGM0Yi05MjdhLWE0NWMyNjNk
-        YTJiZi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYx
-        NDY1NFoiLCJpZCI6InRlc3QtMDEiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zp
+        YWNrYWdlZ3JvdXBzLzg3MmYxYjU3LTUyMjktNGNjNi1hMzhlLTJlOThjOWE5
+        ZmQwNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5
+        ODU1M1oiLCJpZCI6InRlc3QtMDEiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zp
         c2libGUiOnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJ0ZXN0
         LTAxIiwiZGVzY3JpcHRpb24iOiIiLCJwYWNrYWdlcyI6W3sibmFtZSI6InRl
         c3Qtc3JwbTAxIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNo
@@ -1720,9 +2538,9 @@ http_interactions:
         ZyI6e30sIm5hbWVfYnlfbGFuZyI6e30sImRpZ2VzdCI6IjhiYzlhYjcyNTZm
         M2Q0OWI1MjQyYjg3MjVlNTY5NDRmMjE2ODdhYzgwNTkwYmIwNGU5YmY0YmZm
         M2UwMGRmMDcifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlZ3JvdXBzLzA2YmM0ZTM4LTMzOWYtNDc4YS04YWQ3LTVi
-        Nzc5M2M5NzAzYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEz
-        OjUxLjYwODA3OFoiLCJpZCI6InRlc3QtMDIiLCJkZWZhdWx0Ijp0cnVlLCJ1
+        L3JwbS9wYWNrYWdlZ3JvdXBzL2Q5OGMyMGI1LTJlOTAtNGYyYS1hMjhjLTQx
+        YmY0MTgxZDcxMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1
+        OjA3LjA4NjYzOVoiLCJpZCI6InRlc3QtMDIiLCJkZWZhdWx0Ijp0cnVlLCJ1
         c2VyX3Zpc2libGUiOnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUi
         OiJ0ZXN0LTAyIiwiZGVzY3JpcHRpb24iOiIiLCJwYWNrYWdlcyI6W3sibmFt
         ZSI6InRlc3Qtc3JwbTAyIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJh
@@ -1732,10 +2550,10 @@ http_interactions:
         YW5nIjp7fSwiZGlnZXN0IjoiMjVmMjBiOTQ0Njc2NTIzMjI0MWQxYWViM2U1
         ODljMjgwMGQzZDhjOWM3MTc2MTk4NTBmNGI1ZjgyZDkzMzQzZiJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1743,7 +2561,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1756,60 +2574,60 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:52 GMT
+      - Fri, 29 Jul 2022 09:00:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1035'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 32f73ad51ac443908369bc0ffd87cca8
+      - 4a9c601ef86d496983f409d15aebb060
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '438'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zZDAzODhjZi1iYmM2LTQ3M2QtYmIyNi1jZmE4NTVkMzkxMDUv
+        YWNrYWdlcy9kZDk2OTJkYi01MjE0LTQ4YjAtODgzOS1jMWEwMTVlMGQ3MTkv
         IiwibmFtZSI6InRlc3Qtc3JwbTAzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNzZk
         YjY2MDk5YzA0MzVmMjQ1YjZkY2JhNTQ1Y2M4ZGI2Mjc2NWY2ZTgwMjc2ZTBk
         NjZkYjY1YzE2ZDhjN2JhYyIsInN1bW1hcnkiOiJEdW1teSBQYWNrYWdlIHRv
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         My0xLjAtMS5zcmMucnBtIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvZWUwZjQwZmItNzQ2ZC00NTAxLWJkMjIt
-        MTY1MDJjYzU0ZjZjLyIsIm5hbWUiOiJ0ZXN0LXNycG0wMiIsImVwb2NoIjoi
+        Y29udGVudC9ycG0vcGFja2FnZXMvYWRlOTE2MjctNWFhYS00YWYxLTk2ZTct
+        ZjExOWFiOTRmOWVlLyIsIm5hbWUiOiJ0ZXN0LXNycG0wMiIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJzcmMi
         LCJwa2dJZCI6ImY4ZDY3NWI0ZWRkOTkzM2I4YzQzODg0YzgxZjNkOWYxMzVj
         ZGJlNzQxYTkwMTMzNDM1ZGUwZjA2MzIwNzVlNGMiLCJzdW1tYXJ5IjoiRHVt
         bXkgUGFja2FnZSB0byBwcm92aWRlIHRvbWNhdDUiLCJsb2NhdGlvbl9ocmVm
         IjoidGVzdC1zcnBtMDItMS4wLTEuc3JjLnJwbSJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkNjBkYTJmLTBh
-        YTctNDZhZi1iZjZmLWE5YTNkODZlZTE0OS8iLCJuYW1lIjoidGVzdC1zcnBt
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E3MjQwZDI2LTkw
+        ZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIwZS8iLCJuYW1lIjoidGVzdC1zcnBt
         MDEiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6IjEi
         LCJhcmNoIjoic3JjIiwicGtnSWQiOiI1NGNjNDcxM2ZlNzA0ZGZjN2E0ZmQ1
         YjM5OGY4MzRjZWI2YTY5MmY1M2IwYzZhZWZhZjg5ZDg4NDE3YjRjNTFkIiwi
         c3VtbWFyeSI6IkR1bW15IFBhY2thZ2UgdG8gcHJvdmlkZSB0b21jYXQ1Iiwi
         bG9jYXRpb25faHJlZiI6InRlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1817,7 +2635,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1830,7 +2648,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:52 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1848,21 +2666,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c950521746e4447889aa3957b248201b
+      - 6a44b34a9d1245e6821f3f6f22b7278c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:52 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/5cdcf31c-0cac-4c4b-927a-a45c263da2bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/872f1b57-5229-4cc6-a38e-2e98c9a9fd07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1870,7 +2688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1883,35 +2701,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '455'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e373d296799449e29b66a81e4550f9a5
+      - '0665780149ad4cfca6b19de88e8632a9'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy81Y2RjZjMxYy0wY2FjLTRjNGItOTI3YS1hNDVjMjYzZGEyYmYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxMzo1MS42MTQ2NTRa
+        ZWdyb3Vwcy84NzJmMWI1Ny01MjI5LTRjYzYtYTM4ZS0yZTk4YzlhOWZkMDcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowNy4wOTg1NTNa
         IiwiaWQiOiJ0ZXN0LTAxIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxl
         Ijp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoidGVzdC0wMSIs
         ImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJ0ZXN0LXNy
@@ -1921,10 +2739,10 @@ http_interactions:
         NTI0MmI4NzI1ZTU2OTQ0ZjIxNjg3YWM4MDU5MGJiMDRlOWJmNGJmZjNlMDBk
         ZjA3In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/5cdcf31c-0cac-4c4b-927a-a45c263da2bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/872f1b57-5229-4cc6-a38e-2e98c9a9fd07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1932,7 +2750,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1945,35 +2763,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '455'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1da4bd898352435d87f95f786d15d26d
+      - f07f871379f744b8a91b66e7d4e5b64c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy81Y2RjZjMxYy0wY2FjLTRjNGItOTI3YS1hNDVjMjYzZGEyYmYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxMzo1MS42MTQ2NTRa
+        ZWdyb3Vwcy84NzJmMWI1Ny01MjI5LTRjYzYtYTM4ZS0yZTk4YzlhOWZkMDcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowNy4wOTg1NTNa
         IiwiaWQiOiJ0ZXN0LTAxIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxl
         Ijp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoidGVzdC0wMSIs
         ImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJ0ZXN0LXNy
@@ -1983,10 +2801,10 @@ http_interactions:
         NTI0MmI4NzI1ZTU2OTQ0ZjIxNjg3YWM4MDU5MGJiMDRlOWJmNGJmZjNlMDBk
         ZjA3In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/06bc4e38-339f-478a-8ad7-5b7793c9703c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/d98c20b5-2e90-4f2a-a28c-41bf4181d711/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1994,7 +2812,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2007,35 +2825,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '523'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 36f1971619824cea808f75db5c731d61
+      - '09c6eb339a4b4e60b38b4fe6b55395d0'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wNmJjNGUzOC0zMzlmLTQ3OGEtOGFkNy01Yjc3OTNjOTcwM2Mv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxMzo1MS42MDgwNzha
+        ZWdyb3Vwcy9kOThjMjBiNS0yZTkwLTRmMmEtYTI4Yy00MWJmNDE4MWQ3MTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowNy4wODY2Mzla
         IiwiaWQiOiJ0ZXN0LTAyIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxl
         Ijp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoidGVzdC0wMiIs
         ImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJ0ZXN0LXNy
@@ -2046,10 +2864,10 @@ http_interactions:
         Z2VzdCI6IjI1ZjIwYjk0NDY3NjUyMzIyNDFkMWFlYjNlNTg5YzI4MDBkM2Q4
         YzljNzE3NjE5ODUwZjRiNWY4MmQ5MzM0M2YifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/06bc4e38-339f-478a-8ad7-5b7793c9703c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/d98c20b5-2e90-4f2a-a28c-41bf4181d711/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2057,7 +2875,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2070,35 +2888,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '523'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1127e86e051545cda8de4ea74e62ed76
+      - 79cd9ce95977443bbd70c0f2b110f346
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wNmJjNGUzOC0zMzlmLTQ3OGEtOGFkNy01Yjc3OTNjOTcwM2Mv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxMzo1MS42MDgwNzha
+        ZWdyb3Vwcy9kOThjMjBiNS0yZTkwLTRmMmEtYTI4Yy00MWJmNDE4MWQ3MTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowNy4wODY2Mzla
         IiwiaWQiOiJ0ZXN0LTAyIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxl
         Ijp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoidGVzdC0wMiIs
         ImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJ0ZXN0LXNy
@@ -2109,10 +2927,10 @@ http_interactions:
         Z2VzdCI6IjI1ZjIwYjk0NDY3NjUyMzIyNDFkMWFlYjNlNTg5YzI4MDBkM2Q4
         YzljNzE3NjE5ODUwZjRiNWY4MmQ5MzM0M2YifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2120,7 +2938,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2133,7 +2951,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2151,21 +2969,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 52f55705ebe34ebc8c221df9a3f2851f
+      - '09bad17d122144478b67422d8d2ee31a'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2173,7 +2991,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2186,7 +3004,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2204,21 +3022,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 137403fd54f64c398d7a999d52b7f8c5
+      - ea456330e9cb4c31a48b660005947166
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2226,7 +3044,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2239,7 +3057,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2257,21 +3075,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1c5b626313fb42818d7cfbf02444cb72
+      - 9c920756645c478a91c2449a323818f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/293b7d7f-00ed-4219-b9f2-524039b23142/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/557e5971-9b27-4c55-9b51-3f64bf8b0c1d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2279,7 +3097,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2292,7 +3110,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2310,21 +3128,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa15a3cc1fe14ffcaba0255eb1fbcd24
+      - 16d3beff04ac458daa3108d2edc7ce93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2334,7 +3152,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2347,7 +3165,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2365,38 +3183,38 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5b4584efec9b48e8bd4179f57f01497f
+      - 6f005fc23bed4ae283cb045918ae271f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlMzE4YWI3LWFmNTktNDJk
-        My04YmQ4LWFkMWZiMGM1NzgxNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkNTFhM2E1LTMzY2UtNDgy
+        My04ZDA3LTdkY2YxZjVhODA5YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:31 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8xNDM4OTc0ZS0zNTdlLTQyMmEtYjk0Yy0xNzU4YTVi
-        Y2Y5NmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NjFjODYwODUtMzk3Yy00MDgzLTlmMDktMDRjNWRjZTBhOWMzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZDAzODhjZi1iYmM2LTQ3
-        M2QtYmIyNi1jZmE4NTVkMzkxMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzZkNjBkYTJmLTBhYTctNDZhZi1iZjZmLWE5YTNkODZl
-        ZTE0OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZWUw
-        ZjQwZmItNzQ2ZC00NTAxLWJkMjItMTY1MDJjYzU0ZjZjLyJdfQ==
+        cG0vYWR2aXNvcmllcy9hZjhlYTM4Yy01MzMxLTQyOGUtYjc0MS0zYTU4NTUw
+        NmNjODEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        YjkyM2FkNTYtM2VmNy00MDNlLTlmN2YtNDI0ZGQ5YzI2ZGMwLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRh
+        YzItYTk5YS0yMmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzL2FkZTkxNjI3LTVhYWEtNGFmMS05NmU3LWYxMTlhYjk0
+        ZjllZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZGQ5
+        NjkyZGItNTIxNC00OGIwLTg4MzktYzFhMDE1ZTBkNzE5LyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2409,7 +3227,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2427,21 +3245,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 23f8cafbec994251ba9676969f914e98
+      - 990c03df07e64dd5acaf1ccf68007ddd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzMWJhM2Q3LTRiOGMtNDgx
-        NC1iOTE0LWFiZGVkN2I1ODIzNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmYjY3NWE5LTRjZGUtNDM4
+        ZS1iN2U4LWVmNzliM2U3ZjQ4ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/831ba3d7-4b8c-4814-b914-abded7b58234/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5fb675a9-4cde-438e-b7e8-ef79b3e7f48e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2462,53 +3280,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:53 GMT
+      - Fri, 29 Jul 2022 09:00:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 15319247b7f141e9bbd399e68b4b708d
+      - e8a524138cb04209b9ee6d69ba5ef643
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODMxYmEzZDctNGI4
-        Yy00ODE0LWI5MTQtYWJkZWQ3YjU4MjM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTM6NTMuNDQ0ODE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWZiNjc1YTktNGNk
+        ZS00MzhlLWI3ZTgtZWY3OWIzZTdmNDhlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDA6MzIuMDI1NTE3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyM2Y4Y2FmYmVjOTk0MjUxYmE5
-        Njc2OTY5ZjkxNGU5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjEz
-        OjUzLjYwMzM4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTM6
-        NTMuNzQxNjgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5OTBjMDNkZjA3ZTY0ZGQ1YWNh
+        ZjFjY2Y2ODAwN2RkZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAw
+        OjMyLjI4MTI4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDA6
+        MzIuNTEyNDA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82YTg3Mzg4ZC1lMzU2LTRkNGQtYjJmYi1hY2JiY2JlZDQ3NTkvdmVyc2lv
+        bS82ODZhMWI0OS04NjlkLTQ3YmEtYjQwZi1iYTU2Yzc0ZjYzYWMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmE4NzM4OGQtZTM1Ni00ZDRk
-        LWIyZmItYWNiYmNiZWQ0NzU5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjg2YTFiNDktODY5ZC00N2Jh
+        LWI0MGYtYmE1NmM3NGY2M2FjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:53 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2516,7 +3334,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2529,7 +3347,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:54 GMT
+      - Fri, 29 Jul 2022 09:00:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2547,21 +3365,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d9ada0bf6c74648b638f43c0925e747
+      - 75620cb4c19344fcab1b6cefeb79a883
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2569,7 +3387,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2582,7 +3400,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:54 GMT
+      - Fri, 29 Jul 2022 09:00:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2600,21 +3418,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb36e78d2066465d94c5ab34bcaf4e18
+      - 42b345d637a64c5ca177ec4143e70888
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2622,7 +3440,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2635,37 +3453,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:54 GMT
+      - Fri, 29 Jul 2022 09:00:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1920'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 72c8377e14a64ae2999ee6e00d533602
+      - dd45025bf7084cd0b183ea3f260d7f17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '578'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzE0Mzg5NzRlLTM1N2UtNDIyYS1iOTRjLTE3NThhNWJjZjk2
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMzI5
-        MloiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzL2I5MjNhZDU2LTNlZjctNDAzZS05ZjdmLTQyNGRkOWMyNmRj
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5NjQy
+        NFoiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
         Ni0wMS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVt
         XzEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDYiLCJmcm9t
         c3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2681,8 +3499,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzYxYzg2MDg1LTM5N2MtNDA4My05ZjA5LTA0YzVkY2UwYTljMy8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMDQyNloi
+        c29yaWVzL2FmOGVhMzhjLTUzMzEtNDI4ZS1iNzQxLTNhNTg1NTA2Y2M4MS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5MTk4Nloi
         LCJpZCI6IlJIRUEtMjAxMjowMDIzIiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         Mi0yNyAxNzowMDowMCIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVtXzIi
         LCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDgiLCJmcm9tc3Ry
@@ -2705,10 +3523,10 @@ http_interactions:
         dW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6
         W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2716,7 +3534,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2729,7 +3547,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:54 GMT
+      - Fri, 29 Jul 2022 09:00:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2747,21 +3565,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53f4d3c5648641659c3426fcf5a9864c
+      - 821415a370e94539b01d193e5e0adc0b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2769,7 +3587,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2782,44 +3600,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:54 GMT
+      - Fri, 29 Jul 2022 09:00:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 36fdfe7f562f40feb19fc96623a2427c
+      - 5f562e56087e49159adde0b2a243c8dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '195'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zZDAzODhjZi1iYmM2LTQ3M2QtYmIyNi1jZmE4NTVkMzkxMDUv
+        YWNrYWdlcy9kZDk2OTJkYi01MjE0LTQ4YjAtODgzOS1jMWEwMTVlMGQ3MTkv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZWUwZjQwZmItNzQ2ZC00NTAxLWJkMjItMTY1MDJjYzU0ZjZjLyJ9
+        a2FnZXMvYWRlOTE2MjctNWFhYS00YWYxLTk2ZTctZjExOWFiOTRmOWVlLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzZkNjBkYTJmLTBhYTctNDZhZi1iZjZmLWE5YTNkODZlZTE0OS8ifV19
+        Z2VzL2E3MjQwZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIwZS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/686a1b49-869d-47ba-b40f-ba56c74f63ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2827,7 +3645,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2840,7 +3658,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:13:54 GMT
+      - Fri, 29 Jul 2022 09:00:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2858,16 +3676,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9b677ae1b054f36a954bca4985e5a5b
+      - d6679ae027a341909abbdf93b6862cda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:13:54 GMT
+  recorded_at: Fri, 29 Jul 2022 09:00:33 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_units_docker_repository/exclusion_docker_filters.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_units_docker_repository/exclusion_docker_filters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:10 GMT
+      - Fri, 29 Jul 2022 09:03:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,27 +35,91 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '555'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b22785fad88342a09255084f9b1d6b94
+      - fdb6049f1d4f4ae89c6459aaa6d3a1af
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9lZDYwZDEzNi1hMTljLTQ4YWQtYjU5Zi1k
+        OWYxNzRkMmMwZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1
+        NDo0OS41MjUwNDhaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9lZDYwZDEzNi1hMTlj
+        LTQ4YWQtYjU5Zi1kOWYxNzRkMmMwZmIvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2VkNjBkMTM2LWExOWMt
+        NDhhZC1iNTlmLWQ5ZjE3NGQyYzBmYi92ZXJzaW9ucy8xLyIsIm5hbWUiOiJE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsImRl
+        c2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwi
+        cmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:10 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:09 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/ed60d136-a19c-48ad-b59f-d9f174d2c0fb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.10.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1e4d9665f7144339a73b757cf860c779
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NhOTZjM2Q3LThiOWUtNGQ2
+        NC05ZTNiLTE2ZjcxZDU2ZDJkYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +140,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:10 GMT
+      - Fri, 29 Jul 2022 09:03:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +158,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 91e30e6276624497b596528b9c1d4476
+      - 9ce8811bba224a8da1c73868e9e0821e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:10 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ca96c3d7-8b9e-4d64-9e3b-16f71d56d2da/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +180,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +193,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:10 GMT
+      - Fri, 29 Jul 2022 09:03:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -137,31 +201,43 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '619'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb58464a91f74ec0835fd19b2ea396f4
+      - 5aa420f8ac754c13b492225fe20e12ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2E5NmMzZDctOGI5
+        ZS00ZDY0LTllM2ItMTZmNzFkNTZkMmRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MDkuODQyNzkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxZTRkOTY2NWY3MTQ0MzM5YTczYjc1N2Nm
+        ODYwYzc3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjA5Ljg4
+        NzMyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MDkuOTg5
+        MDk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZWQ2MGQx
+        MzYtYTE5Yy00OGFkLWI1OWYtZDlmMTc0ZDJjMGZiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:10 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +245,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +258,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:10 GMT
+      - Fri, 29 Jul 2022 09:03:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +276,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 830b7b66f7374755a153b54b8aee4ce1
+      - 4fb22f3d818842dd9d02827a0ca9869d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:10 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -222,7 +298,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -235,7 +311,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:10 GMT
+      - Fri, 29 Jul 2022 09:03:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -247,27 +323,94 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '691'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dabd6225b5694806baea73ffe175c3b8
+      - 9cc9313e1e7240fab8ba6e16834c7341
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6ImVtcHR5X29yZ2FuaXphdGlvbi1wdXBwZXRf
+        cHJvZHVjdC1idXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rp
+        c3RyaWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8wMmQ3M2M1Ni0xMTYz
+        LTQxZDItYWUxYy03NzIyNjkzMDA1ZDkvIiwicmVwb3NpdG9yeSI6bnVsbCwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDo1NS44NDc2NThaIiwi
+        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1kZXYi
+        LCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y29udGFpbmVyL2NvbnRlbnRfcmVkaXJlY3QvODY3MDMzYmYtOTIyNi00ODg4
+        LWI5YjMtZTYwMGZlYjhhMmJjLyIsInB1bHBfbGFiZWxzIjp7fSwicmVwb3Np
+        dG9yeV92ZXJzaW9uIjpudWxsLCJyZWdpc3RyeV9wYXRoIjoiY2VudG9zOC1r
+        YXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL2VtcHR5X29yZ2FuaXphdGlvbi1w
+        dXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZXNwYWNlIjoiL3B1bHAvYXBp
+        L3YzL3B1bHBfY29udGFpbmVyL25hbWVzcGFjZXMvODAwZDllMDUtZDIzNC00
+        M2U4LWI0YzUtZmIyOTgzNDc5ZDVkLyIsInByaXZhdGUiOmZhbHNlLCJkZXNj
+        cmlwdGlvbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:10 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/02d73c56-1163-41d2-ae1c-7722693005d9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.10.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 24fce4c485214806b3ea6f304519d63f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhMWUyZDczLWI0NGQtNDg5
+        NC04OWVjLTIyYWQ3ZTI3NTcyNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fa1e2d73-b44d-4894-89ec-22ad7e275724/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -275,7 +418,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -288,7 +431,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -296,31 +439,43 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '626'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1679e8ad85594549bb536d95b25aff88
+      - 24c2c88cf34d475f8ed0ae6bff6d2416
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmExZTJkNzMtYjQ0
+        ZC00ODk0LTg5ZWMtMjJhZDdlMjc1NzI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTAuMzQ0MTgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfbXVs
+        dGlfZGVsZXRlIiwibG9nZ2luZ19jaWQiOiIyNGZjZTRjNDg1MjE0ODA2YjNl
+        YTZmMzA0NTE5ZDYzZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAz
+        OjEwLjM4NTY0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6
+        MTAuNDQwNTYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9jb250YWluZXIvY29udGFpbmVy
+        LzAyZDczYzU2LTExNjMtNDFkMi1hZTFjLTc3MjI2OTMwMDVkOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -328,7 +483,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -341,7 +496,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -359,21 +514,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49f0e39546e64b578f20b61ce3785373
+      - 8cfc215090f44791ab52654bb964d65d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -381,7 +536,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +549,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -412,21 +567,127 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f86fbb66a72e41a6aa842325777e5af7
+      - cd3c5ebaea2440e1b01a214294705652
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.10.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e44430b785224c18821e24d5947e7391
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.10.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8d5d478dde02455c8a431797d50ae7b4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -444,7 +705,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -457,13 +718,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/2e3b0e78-ecb6-4e7f-b5d6-fedb51b3a67f/"
+      - "/pulp/api/v3/remotes/container/container/c2c02cc7-6f3d-4a27-928f-4b220c32207d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -477,22 +738,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2bfe22e272d4920929e3c87bd3b273b
+      - b7a324888d354af2bd0ff4ee3d5b3480
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzJlM2IwZTc4LWVjYjYtNGU3Zi1iNWQ2LWZlZGI1MWIzYTY3
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjExLjE4ODY5
-        NVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyL2MyYzAyY2M3LTZmM2QtNGEyNy05MjhmLTRiMjIwYzMyMjA3
+        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAzOjEwLjg4MDE1
+        M1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3F1YXkuaW8iLCJjYV9jZXJ0Ijpu
         dWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUs
         InByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3Rf
-        dXBkYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTEuMTg4NzE0WiIsImRvd25s
+        dXBkYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MTAuODgwMTc4WiIsImRvd25s
         b2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9s
         aWN5IjoiaW1tZWRpYXRlIiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25u
         ZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4w
@@ -501,10 +762,10 @@ http_interactions:
         LCJpbmNsdWRlX3RhZ3MiOlsibGF0ZXN0IiwiZ2xpYmMiLCJtdXNsIl0sImV4
         Y2x1ZGVfdGFncyI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -514,7 +775,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -527,13 +788,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/f25282ff-52be-4cd4-b602-644627c884b6/"
+      - "/pulp/api/v3/repositories/container/container/c68a5d87-d93b-42e8-8a83-a9411be5cc50/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -547,31 +808,31 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e44ba4167f1d4e98857521e0b274be98
+      - 28497acf5a384c5094b4667920bf2cc7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZjI1MjgyZmYtNTJiZS00Y2Q0LWI2MDItNjQ0NjI3
-        Yzg4NGI2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTEu
-        MzkwNjc3WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZjI1MjgyZmYtNTJiZS00Y2Q0
-        LWI2MDItNjQ0NjI3Yzg4NGI2L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
+        aW5lci9jb250YWluZXIvYzY4YTVkODctZDkzYi00MmU4LThhODMtYTk0MTFi
+        ZTVjYzUwLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MTEu
+        MDY1ODI4WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYzY4YTVkODctZDkzYi00MmU4
+        LThhODMtYTk0MTFiZTVjYzUwL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
         fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mMjUyODJmZi01MmJlLTRjZDQt
-        YjYwMi02NDQ2MjdjODg0YjYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
+        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9jNjhhNWQ4Ny1kOTNiLTQyZTgt
+        OGE4My1hOTQxMWJlNWNjNTAvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
         dF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlw
         dGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90
         ZSI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -579,7 +840,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -592,7 +853,374 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '551'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9e64917c1efe4f28bd0a4004483b325a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9iNWI5NGI5NS0wMDFiLTQzNzgtODI4My03
+        MTA5MjcxYTVjYWEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1
+        NDo1MC41ODA4NDlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iNWI5NGI5NS0wMDFi
+        LTQzNzgtODI4My03MTA5MjcxYTVjYWEvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2I1Yjk0Yjk1LTAwMWIt
+        NDM3OC04MjgzLTcxMDkyNzFhNWNhYS92ZXJzaW9ucy8xLyIsIm5hbWUiOiJE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
+        cHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1v
+        dGUiOm51bGx9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/b5b94b95-001b-4378-8283-7109271a5caa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.10.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 37a0e9c02af343fe8ebe911db9f38ee0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViMWNkNjkwLTE2ODItNGQz
+        Yi1hNzM3LThiYmMyZDY1OTZmZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.10.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '695'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - aacfb723531c40a2bedebdb68514c428
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
+        aW5lci9jb250YWluZXIvMjM0Njg4NmYtMDBhMy00MGY1LWI2M2MtNmQ1MmM3
+        MjM5OTdkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6NDku
+        MzQxNTk4WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        c3lib3gtZGV2IiwidXJsIjoiaHR0cHM6Ly9xdWF5LmlvIiwiY2FfY2VydCI6
+        bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVl
+        LCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjUxLjA2OTUzNFoiLCJkb3du
+        bG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBv
+        bGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29u
+        bmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAu
+        MCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwi
+        cmF0ZV9saW1pdCI6MCwidXBzdHJlYW1fbmFtZSI6ImxpYnBvZC9idXN5Ym94
+        IiwiaW5jbHVkZV90YWdzIjpbImxhdGVzdCIsImdsaWJjIiwibXVzbCJdLCJl
+        eGNsdWRlX3RhZ3MiOm51bGx9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/2346886f-00a3-40f5-b63c-6d52c723997d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.10.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6a1a7330c3e241e197c938fa19d33bec
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0NWRmNzNjLWZmNDMtNGM0
+        YS1hYmQzLTQ1NzU0ODgyMjY1OC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5b1cd690-1682-4d3b-a737-8bbc2d6596fe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '619'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bb8a039412fb46929969677103e3ac54
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWIxY2Q2OTAtMTY4
+        Mi00ZDNiLWE3MzctOGJiYzJkNjU5NmZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTEuMzY1NjUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzN2EwZTljMDJhZjM0M2ZlOGViZTkxMWRi
+        OWYzOGVlMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjExLjQy
+        MzAxN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MTEuNTM4
+        ODA2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjViOTRi
+        OTUtMDAxYi00Mzc4LTgyODMtNzEwOTI3MWE1Y2FhLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/845df73c-ff43-4c4a-abd3-457548822658/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '614'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c1d0d4541c47441ca5359b87d4b87cd7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODQ1ZGY3M2MtZmY0
+        My00YzRhLWFiZDMtNDU3NTQ4ODIyNjU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTEuNTAzNzgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2YTFhNzMzMGMzZTI0MWUxOTdjOTM4ZmEx
+        OWQzM2JlYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjExLjU3
+        MDcwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MTEuNjM3
+        Nzc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzIzNDY4ODZmLTAw
+        YTMtNDBmNS1iNjNjLTZkNTJjNzIzOTk3ZC8iXX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.10.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 09:03:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -610,21 +1238,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ffa079ec0c3d4e21aa8efdda2fb0d6bd
+      - b2ac1ed86ac14fe1972c6bf4ddf0369e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -632,7 +1260,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -645,7 +1273,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -663,21 +1291,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b7dcb060185746d98faa59565b290587
+      - b34a66e16a4540ed9b6eea279509de22
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -685,7 +1313,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -698,7 +1326,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -716,21 +1344,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 205f70e91bca4dce87e710e8a226bd36
+      - 3cb5ab9870e34b77ac58a78b3e594b01
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -738,7 +1366,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -751,7 +1379,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -769,21 +1397,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 78209640f4f84cd2b49185fd3a451f7b
+      - de1cd96c32f043c5a39a8c70c1f444a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -791,7 +1419,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -804,7 +1432,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -822,21 +1450,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 55b88a24aeaf4cd9850fbaeb22067a03
+      - f6e6ae059b274fe49b87000f6ce54dc6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -844,7 +1472,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -857,7 +1485,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -875,127 +1503,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 830cf4b2cfe04654ba77bf80086bb889
+      - 265eaefcc6ce485f9225157e94e0e44a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:18:11 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 4eb7243d12ef47ddbab53b3ff5aa3e28
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:18:11 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0fe1fbda7e7243858dab9220fe2fdcfb
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1005,7 +1527,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1018,13 +1540,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:11 GMT
+      - Fri, 29 Jul 2022 09:03:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/d046bbbe-9295-4c64-8b79-9df2296e00dc/"
+      - "/pulp/api/v3/repositories/container/container/b05b9638-0d49-4592-8028-d41654e2abe9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1038,31 +1560,31 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 502df5f212d448a590904a90f97b1344
+      - 23f7eccae38940dd8beaaa03ebf11d2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZDA0NmJiYmUtOTI5NS00YzY0LThiNzktOWRmMjI5
-        NmUwMGRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTEu
-        OTMxMzQ4WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZDA0NmJiYmUtOTI5NS00YzY0
-        LThiNzktOWRmMjI5NmUwMGRjL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
+        aW5lci9jb250YWluZXIvYjA1Yjk2MzgtMGQ0OS00NTkyLTgwMjgtZDQxNjU0
+        ZTJhYmU5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MTIu
+        MDk5ODQ2WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjA1Yjk2MzgtMGQ0OS00NTky
+        LTgwMjgtZDQxNjU0ZTJhYmU5L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
         fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kMDQ2YmJiZS05Mjk1LTRjNjQt
-        OGI3OS05ZGYyMjk2ZTAwZGMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
+        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iMDViOTYzOC0wZDQ5LTQ1OTIt
+        ODAyOC1kNDE2NTRlMmFiZTkvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
         dF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWRldiIsImRlc2NyaXB0aW9u
         IjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpu
         dWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:11 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:12 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/2e3b0e78-ecb6-4e7f-b5d6-fedb51b3a67f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/c2c02cc7-6f3d-4a27-928f-4b220c32207d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1081,7 +1603,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1094,7 +1616,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:12 GMT
+      - Fri, 29 Jul 2022 09:03:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1112,21 +1634,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 42a1dc568ec34f70a9d40072c2d51222
+      - 385429e69d044a509175e84975f28fc0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5NzM3MDJhLTFlODMtNGM0
-        YS1hMzc3LTg0Zjc0OTFlNmZkZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlZjMxYmQ3LTdiOWEtNGM5
+        Mi1iMjAwLTI1OTQ2YWNiNjEyMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e973702a-1e83-4c4a-a377-84f7491e6fde/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8ef31bd7-7b9a-4c92-b200-25946acb6122/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1147,62 +1669,62 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:12 GMT
+      - Fri, 29 Jul 2022 09:03:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '614'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 32f1d853ae8d49bd8a31ac37a9a36aa7
+      - a18cd4402eae4818b842277c7c58e29f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTk3MzcwMmEtMWU4
-        My00YzRhLWEzNzctODRmNzQ5MWU2ZmRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTIuMjQxODA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGVmMzFiZDctN2I5
+        YS00YzkyLWIyMDAtMjU5NDZhY2I2MTIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTIuNjQ2NjEyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI0MmExZGM1NjhlYzM0ZjcwYTlkNDAwNzJj
-        MmQ1MTIyMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE4OjEyLjI3
-        MTM3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTg6MTIuMjk4
-        MDcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzODU0MjllNjlkMDQ0YTUwOTE3NWU4NDk3
+        NWYyOGZjMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjEyLjY5
+        NzQ4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MTIuNzI4
+        MjEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzJlM2IwZTc4LWVj
-        YjYtNGU3Zi1iNWQ2LWZlZGI1MWIzYTY3Zi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyL2MyYzAyY2M3LTZm
+        M2QtNGEyNy05MjhmLTRiMjIwYzMyMjA3ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:12 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/f25282ff-52be-4cd4-b602-644627c884b6/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/c68a5d87-d93b-42e8-8a83-a9411be5cc50/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyLzJlM2IwZTc4LWVjYjYtNGU3Zi1iNWQ2LWZlZGI1MWIzYTY3Zi8i
+        dGFpbmVyL2MyYzAyY2M3LTZmM2QtNGEyNy05MjhmLTRiMjIwYzMyMjA3ZC8i
         LCJtaXJyb3IiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1215,7 +1737,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:12 GMT
+      - Fri, 29 Jul 2022 09:03:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1233,21 +1755,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb1f97dd155d433e87fd45f7b4d9a445
+      - 6ccebfd3e69f488a99b7a60f11b04661
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdjMDg1YjZmLWQzN2QtNDIw
-        MC1hNzcyLTg3NzZkZThiYTdjZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI3MmI3Y2ZjLTkzODctNDdj
+        OC04NzQzLThkNTUwYzczM2NjMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:12 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7c085b6f-d37d-4200-a772-8776de8ba7cf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/272b7cfc-9387-47c8-8743-8d550c733cc2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1268,69 +1790,69 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:16 GMT
+      - Fri, 29 Jul 2022 09:03:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1420'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ed323c9168247e09778ea06f1c235d9
+      - f4bd565b7ebd47bea6511ee747fa04af
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '589'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2MwODViNmYtZDM3
-        ZC00MjAwLWE3NzItODc3NmRlOGJhN2NmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTIuNDI4OTEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjcyYjdjZmMtOTM4
+        Ny00N2M4LTg3NDMtOGQ1NTBjNzMzY2MyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTIuOTAxMjI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsImxvZ2dpbmdfY2lkIjoiYmIxZjk3ZGQxNTVkNDMz
-        ZTg3ZmQ0NWY3YjRkOWE0NDUiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1Qy
-        MzoxODoxMi40NTg5MzlaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIz
-        OjE4OjE2LjQ5OTEzM1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvM2ZhNmQwODItOTY4My00ZWZmLWFhNmQtMWVkMzQ1
-        MTA3MmU1LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
+        ZS5zeW5jaHJvbml6ZSIsImxvZ2dpbmdfY2lkIjoiNmNjZWJmZDNlNjlmNDg4
+        YTk5YjdhNjBmMTFiMDQ2NjEiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQw
+        OTowMzoxMi45NDgwNzZaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDA5
+        OjAzOjE2Ljg2NjMxMFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNh
+        NGJmMjA4LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
         InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3Nh
         Z2UiOiJEb3dubG9hZGluZyB0YWcgbGlzdCIsImNvZGUiOiJzeW5jLmRvd25s
         b2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
         MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9h
         ZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRp
         ZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
-        Ijo2OCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBD
+        IjoyNCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBD
         b250ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo3NCwic3VmZml4Ijpu
+        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo3Miwic3VmZml4Ijpu
         dWxsfSx7Im1lc3NhZ2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoic3lu
         Yy5wcm9jZXNzaW5nLnRhZyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNz
         b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRl
         bnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjow
         LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2YyNTI4
-        MmZmLTUyYmUtNGNkNC1iNjAyLTY0NDYyN2M4ODRiNi92ZXJzaW9ucy8xLyJd
+        YXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2M2OGE1
+        ZDg3LWQ5M2ItNDJlOC04YTgzLWE5NDExYmU1Y2M1MC92ZXJzaW9ucy8xLyJd
         LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mMjUyODJmZi01MmJl
-        LTRjZDQtYjYwMi02NDQ2MjdjODg0YjYvIiwic2hhcmVkOi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2NvbnRhaW5lci9jb250YWluZXIvMmUzYjBlNzgtZWNiNi00
-        ZTdmLWI1ZDYtZmVkYjUxYjNhNjdmLyJdfQ==
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9jNjhhNWQ4Ny1kOTNi
+        LTQyZTgtOGE4My1hOTQxMWJlNWNjNTAvIiwic2hhcmVkOi9wdWxwL2FwaS92
+        My9yZW1vdGVzL2NvbnRhaW5lci9jb250YWluZXIvYzJjMDJjYzctNmYzZC00
+        YTI3LTkyOGYtNGIyMjBjMzIyMDdkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:16 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1338,7 +1860,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1351,7 +1873,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:17 GMT
+      - Fri, 29 Jul 2022 09:03:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1369,34 +1891,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2bb27b05808349fe9f3c2d7eb6f29ebf
+      - 50ea66928062493199d79e188589f9c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:17 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:17 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWRl
         diIsImJhc2VfcGF0aCI6ImVtcHR5X29yZ2FuaXphdGlvbi1wdXBwZXRfcHJv
         ZHVjdC1idXN5Ym94IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2YyNTI4MmZm
-        LTUyYmUtNGNkNC1iNjAyLTY0NDYyN2M4ODRiNi92ZXJzaW9ucy8xLyJ9
+        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2M2OGE1ZDg3
+        LWQ5M2ItNDJlOC04YTgzLWE5NDExYmU1Y2M1MC92ZXJzaW9ucy8xLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1409,7 +1931,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:17 GMT
+      - Fri, 29 Jul 2022 09:03:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1427,21 +1949,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - be301a91c7a24f5baab18d49713c33dc
+      - a17e2c76660b4d6a95df0f05acaa127a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4NzUyMTE1LTdlNGEtNDlh
-        OC1iMjgwLTg0M2ExOTU3OGIwMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5ZGJkNWM5LWIwMWMtNDRk
+        Zi05ZThkLTgzYmM5ZGM3ZmU4NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:17 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/58752115-7e4a-49a8-b280-843a19578b03/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c9dbd5c9-b01c-44df-9e8d-83bc9dc7fe85/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1462,52 +1984,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:17 GMT
+      - Fri, 29 Jul 2022 09:03:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '644'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6941564bd40148cd966332021ce50f2c
+      - 74ba226948f249fb992c96a64ec164bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '383'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTg3NTIxMTUtN2U0
-        YS00OWE4LWIyODAtODQzYTE5NTc4YjAzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTcuMjg1MjYzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzlkYmQ1YzktYjAx
+        Yy00NGRmLTllOGQtODNiYzlkYzdmZTg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTcuNDQwMTk4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwibG9nZ2luZ19jaWQiOiJiZTMwMWE5MWM3YTI0ZjViYWFiMThkNDk3
-        MTNjMzNkYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE4OjE3LjMx
-        NDQ1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTg6MTcuNTUw
-        Njg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhMTdlMmM3NjY2MGI0ZDZhOTVkZjBmMDVh
+        Y2FhMTI3YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjE3LjQ4
+        MjM0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MTguMDI0
+        Mjc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2NvbnRhaW5lci9j
-        b250YWluZXIvYWIxZDZjNDItMzRkYS00YjljLThmNDMtYjFjMGY3ZGE2NDA1
+        b250YWluZXIvZWMyZTI0MTctYjNjMi00ZWE2LWJmYmUtYTEwYWYwOGFiZTUz
         LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:17 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/ab1d6c42-34da-4b9c-8f43-b1c0f7da6405/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/ec2e2417-b3c2-4ea6-bfbe-a10af08abe53/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1515,7 +2037,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1528,54 +2050,54 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:17 GMT
+      - Fri, 29 Jul 2022 09:03:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '731'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc1ad10df0614b80a7c068cba4dc9a1f
+      - 62644b3ec16846f7857b1874e5bfd6c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '420'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9jb250
-        YWluZXIvY29udGFpbmVyL2FiMWQ2YzQyLTM0ZGEtNGI5Yy04ZjQzLWIxYzBm
-        N2RhNjQwNS8iLCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnRndWFyZHMvY29udGFpbmVyL2NvbnRlbnRfcmVkaXJlY3QvYzE5OGM1ZDUt
-        ZWFiYi00MzEzLWIxNzEtMzQzYzYzODdjOGQ2LyIsIm5hbWUiOiJEZWZhdWx0
-        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwicHVscF9jcmVhdGVk
-        IjoiMjAyMi0wNS0yM1QyMzoxODoxNy40NTcwNjFaIiwicmVwb3NpdG9yeSI6
-        bnVsbCwiYmFzZV9wYXRoIjoiZW1wdHlfb3JnYW5pemF0aW9uLXB1cHBldF9w
-        cm9kdWN0LWJ1c3lib3giLCJwdWxwX2xhYmVscyI6e30sInJlcG9zaXRvcnlf
+        eyJiYXNlX3BhdGgiOiJlbXB0eV9vcmdhbml6YXRpb24tcHVwcGV0X3Byb2R1
+        Y3QtYnVzeWJveCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmli
+        dXRpb25zL2NvbnRhaW5lci9jb250YWluZXIvZWMyZTI0MTctYjNjMi00ZWE2
+        LWJmYmUtYTEwYWYwOGFiZTUzLyIsInJlcG9zaXRvcnkiOm51bGwsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MTcuODE3MTYzWiIsIm5hbWUi
+        OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiY29u
+        dGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRzL2NvbnRh
+        aW5lci9jb250ZW50X3JlZGlyZWN0Lzg2NzAzM2JmLTkyMjYtNDg4OC1iOWIz
+        LWU2MDBmZWI4YTJiYy8iLCJwdWxwX2xhYmVscyI6e30sInJlcG9zaXRvcnlf
         dmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVy
-        L2NvbnRhaW5lci9mMjUyODJmZi01MmJlLTRjZDQtYjYwMi02NDQ2MjdjODg0
-        YjYvdmVyc2lvbnMvMS8iLCJyZWdpc3RyeV9wYXRoIjoiY2VudG9zOC1rYXRl
-        bGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9lbXB0eV9vcmdhbml6
-        YXRpb24tcHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsIm5hbWVzcGFjZSI6Ii9w
-        dWxwL2FwaS92My9wdWxwX2NvbnRhaW5lci9uYW1lc3BhY2VzL2U2NzI4YWEw
-        LTFmMzctNDk2ZS04YzgwLThhYTkyNGViMjI4YS8iLCJwcml2YXRlIjpmYWxz
-        ZSwiZGVzY3JpcHRpb24iOm51bGx9
+        L2NvbnRhaW5lci9jNjhhNWQ4Ny1kOTNiLTQyZTgtOGE4My1hOTQxMWJlNWNj
+        NTAvdmVyc2lvbnMvMS8iLCJyZWdpc3RyeV9wYXRoIjoiY2VudG9zOC1rYXRl
+        bGxvLWRldmVsLmV4YW1wbGUuY29tL2VtcHR5X29yZ2FuaXphdGlvbi1wdXBw
+        ZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZXNwYWNlIjoiL3B1bHAvYXBpL3Yz
+        L3B1bHBfY29udGFpbmVyL25hbWVzcGFjZXMvODAwZDllMDUtZDIzNC00M2U4
+        LWI0YzUtZmIyOTgzNDc5ZDVkLyIsInByaXZhdGUiOmZhbHNlLCJkZXNjcmlw
+        dGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:17 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/f25282ff-52be-4cd4-b602-644627c884b6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/c68a5d87-d93b-42e8-8a83-a9411be5cc50/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1583,7 +2105,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1596,324 +2118,324 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:17 GMT
+      - Fri, 29 Jul 2022 09:03:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '12900'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1eb829a4b73a45d7a439a8289b81884d
+      - 13e0a2bbe5594bc08d4b774d65bcde69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3446'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MjIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvbWFuaWZlc3RzL2M4MmIwNmIyLWZjYmMtNGFjNy1hNDQ4LTQ1ZGFm
-        MzU3ZmZkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEz
-        LjY2NzEzNFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        NWIxMDE5NGEtMzE3Zi00MDY3LWIzZWMtMjcwYmI4MjJlYzhhLyIsImRpZ2Vz
+        YWluZXIvbWFuaWZlc3RzL2YzYjQ0ZTY4LTcwZGUtNDAwNi04ZmQ5LTY5NWQ5
+        OWIxMWQ4NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMz
+        LjU5MDM3MloiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        N2U5YjhiMDMtM2Q3YS00OThkLWFjMGMtNjQwNDNkMTYwZDBkLyIsImRpZ2Vz
         dCI6InNoYTI1Njo2ZTZkMTMwNTVlZDgxYjcxNDRhZmFhZDE1MTUwZmMxMzdk
         NGY2Mzk0ODJiZWIzMTFhYWEwOTdiYzU3ZTNjYjgwIiwic2NoZW1hX3ZlcnNp
         b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
         c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
         cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL2Jsb2JzL2E0Mzk2NWYzLTdiYjAtNGVhYi05OWZiLTIyNWUwYWIz
-        MjNlOC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvZjg2ZjA5ZDktOTJhYi00NWU4LTk5M2UtYmQzNWIxNTM0ZGI1
+        dGFpbmVyL2Jsb2JzLzQ3MTEyZjk5LTMzZTgtNDdhMC1hMWExLTQ2NGQzODQz
+        ZDhmZS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvM2I5ODg5MjYtM2RkOS00M2I3LWI1ZDMtNGEyZWY3YjY0YmJi
         LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvYzlkOWRjZmEtMmFkNi00Y2QyLWI0YzctOGEwZjQ5
-        Y2YyMjEzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMu
-        NjY0ODQ0WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
-        MmU2OTE3MS1jNzczLTRlZmMtYjU5Ny01ZjE3ODQ2MjA4MDEvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvNDMwNjFhYTQtNTg5ZC00OGMzLThkNGMtNTkzN2Fk
+        ZWM4YzkzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMu
+        NTg0ODg3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        ZjMzMjJkYS0wNjExLTQxZTYtODhmOS03MzA4OTY0N2RiNGMvIiwiZGlnZXN0
         Ijoic2hhMjU2OjIwZThkNmZlNGJiMTEzMTVlMDhmYjY5MmNkNzE2OTYxNjdi
         MDFkYTYxMDUwODIxNTFlZmM0NTRlMDY1OTA4ZjkiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvNGRlMWI1MWUtNTFlOC00OGJhLThkNGYtNDQ1MzIyMmQ5
-        ZmZlLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9kYTYxYjI0Zi05MTM3LTQxYTEtODIzZi1hYzBjYmQ0MWVmNmIv
+        YWluZXIvYmxvYnMvODRlMzFmNTMtNTMwNC00YTljLWI1NjktN2Y0ODQzM2Yx
+        YjAzLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy84YzNiNTNhYi0zM2I3LTQ0OGQtYThkZi1hM2I3NTYzOTFmZWIv
         Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy81YTBhOGUzYy0yMDU4LTRlOWQtYWIyMS1jZjc1ODk5
-        ZGIyMjYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41
-        ODA3ODhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzgw
-        ODhkNDQzLTkwNDYtNDVmYS1hOTI0LTE0OWQzZTE5NGViNy8iLCJkaWdlc3Qi
-        OiJzaGEyNTY6YmE2NWU4ZDM5ZTg5YjVjMTZmMDM2Yzg4Yzg1OTUyNzU2Nzc3
-        YmY1Mzg1YmNlMTQ4YmM0NGJlNDhmYWMzN2Q5NCIsInNjaGVtYV92ZXJzaW9u
+        bmVyL21hbmlmZXN0cy8xMDQxMTA5NC0zMWQxLTQyMzgtODU0MC00YjFmM2Fh
+        MWVlY2EvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4x
+        MzM3NDZaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M1
+        MWZhYzAzLWQxOTctNGZkMi04YThhLWY3ZTA1ODRiNTQ3ZC8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6ZDdlODMzMTZkNzRlMTUwODY2ZDgyYzQ1ZGUzNDJlNzhmNjYy
+        ZmUwYWVmYmRiODIyZDdkMTBjOGI4ZTM5Y2M0YiIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
         OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy9mNTU0ODYzYS0xODcxLTRhNDktOGY2Zi1iZmNiNDhiOTVh
-        NWQvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzA0YWJjNmU4LWQwYzctNDRjNy1iODVjLWZlZmM5N2MwNTdhZC8i
+        aW5lci9ibG9icy82ZDA2YWRmNS1kNzQ4LTQ3ZDAtODFmYi1jYzE3Y2Y2YWNi
+        MTkvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzL2JlZjlkMTg3LTQ3Y2MtNGQ2YS04ZjUyLTVhZDY5ZjJkMjc2Ny8i
         XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzQ2YWZjMmJhLTMwNjAtNDRjYi05ODUyLTNjZTU3MTFj
-        YTRjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjU3
-        OTI3M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGMx
-        ZjI4NjAtZWQyMi00MzViLWI0YjEtZDIwZWY5ZmRlNTA2LyIsImRpZ2VzdCI6
-        InNoYTI1NjozMjk2OGU3MTdlMjlmNzllNWI4ODk3MjE5MDhiM2JlNmQxNTcz
-        OTkyZTFmM2JhNGM5YTQxNzE4ZTI3Mjg0NThjIiwic2NoZW1hX3ZlcnNpb24i
+        ZXIvbWFuaWZlc3RzL2FiMjM4NzM4LWRlZmItNGIwMi1iOTlkLTVjY2ViNGJi
+        N2YwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjEz
+        MTU2MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmQ4
+        MjIwN2QtY2Y2NS00NDljLThlMjUtM2NhMDM5NjNlMTg3LyIsImRpZ2VzdCI6
+        InNoYTI1Njo2Y2E5YTU2YjJiOTNiZTE2YTYyZTZkNDRhZDQ3ZTZkMzIwMTI2
+        MzMyZDFlMjc1MDllMTNmYTJjYzQ5YjEwZTllIiwic2NoZW1hX3ZlcnNpb24i
         OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
         aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
         W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL2Jsb2JzLzI4MWI1YmNmLTVmMDgtNGEwOS1iNzBiLTAxMTM5OThhMWRl
-        Yi8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvYzZmYzA2YjUtMGYxNC00YTViLWE3YmItZDFkNjI4MWZjNWQzLyJd
+        bmVyL2Jsb2JzLzc4MWQ1YmRkLWRiNjAtNGNlZi1iODUwLTYyNmU4ZTYxZmRi
+        ZC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
+        YmxvYnMvZTNlOTM0MjEtZmJiZC00MzU0LTgxMmYtNjQ1YzY1MGY3ZTYwLyJd
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNjNjZGIyMzgtNmE5Zi00ZTBjLThkYTktZTNiNzgwMjVk
-        ZWJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNTQ0
-        MDMyWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iODEw
-        ODRjZC0yMmE4LTQ4ZmMtYTFiMi0zMGY2YjJkNWRhYTAvIiwiZGlnZXN0Ijoi
-        c2hhMjU2OmI4OTQ2MTg0Y2UzYWQ2YjRhMDllYmFkMmQ4NWU4MWNmY2FhZGM2
-        ODk3YmZhZTJlOWM2ZTJhNGZlNmFmYTZlZTAiLCJzY2hlbWFfdmVyc2lvbiI6
+        ci9tYW5pZmVzdHMvOTJiNjJhZjktZDViMi00ZmM2LTgyZmEtNDMzNjAyZDky
+        NmJiLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMTI3
+        MzY1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8yZjVk
+        YTlmYS1jYzkyLTRjMGMtODY0ZS0xYzAxOGE1YTI0ODYvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OjMyOTY4ZTcxN2UyOWY3OWU1Yjg4OTcyMTkwOGIzYmU2ZDE1NzM5
+        OTJlMWYzYmE0YzlhNDE3MThlMjcyODQ1OGMiLCJzY2hlbWFfdmVyc2lvbiI6
         MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
         YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
         XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvYzEwZDQ2OTAtOWIxZi00NDI4LTgxYjEtZWM3OGQyYTMyNDgz
+        ZXIvYmxvYnMvY2FjM2E5NTYtNmI5NC00YTZjLWE0MjItNjI2Yzk0M2EzNDE3
         LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9jM2RlYzJjZi0wZjYwLTQ0ZjktOTkxMS1jNTc0ODM1ZDMyMGEvIl19
+        bG9icy8zMzVmZTUxYy0zZDk5LTRiNmItOGRhMi02ZGYxMmU4MTA4MDkvIl19
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L21hbmlmZXN0cy81Y2NjODkwNy0wNDQ3LTQwMGEtYjUxOS01YWRmNzUzOTU0
-        Y2YvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41NDI4
-        MzNaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U1ZjVj
-        NmJmLTRjOWUtNDU1NS1hNWM2LTJmOTUxMzI2MGY3ZC8iLCJkaWdlc3QiOiJz
-        aGEyNTY6NmNhOWE1NmIyYjkzYmUxNmE2MmU2ZDQ0YWQ0N2U2ZDMyMDEyNjMz
-        MmQxZTI3NTA5ZTEzZmEyY2M0OWIxMGU5ZSIsInNjaGVtYV92ZXJzaW9uIjoy
+        L21hbmlmZXN0cy8xMGJmZWQwMi1iYWM2LTQyNWItYTIwZS1kOTY3ZmE5ZTdk
+        OGMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4xMjQw
+        ODFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzZjZmZh
+        ZGRlLTI3ZDMtNDg4MS1iNTc0LTAyYTFkZDE5ZmE2OS8iLCJkaWdlc3QiOiJz
+        aGEyNTY6MWZhYWY3YTc1MzE5NDE3MjYxMjY3YjNkY2VmNmEyYjE0YzhjNTEy
+        MmQ3ZmNjN2FiZWIwN2EzMmJjMTk3MjhmZCIsInNjaGVtYV92ZXJzaW9uIjoy
         LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
         dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
         LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy8yOWM3MWNiNS02OWExLTQwNjgtOTA0My1jZjEzY2NhZGNjZDIv
+        ci9ibG9icy9iYjgyYmQwMC04ZjdiLTQ5ZjgtYWEwYi1kZmVkZTc0Y2E0YTgv
         IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzFiODc2MTRkLTMzMmMtNGMwYy1iNmY4LTE4ZWVhYmE5MTA0OC8iXX0s
+        b2JzLzZhNTgwMWM4LThiM2ItNDU1ZS04ZDJiLTk2NTI4YjM3OWJlYS8iXX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        bWFuaWZlc3RzL2RlOTU5M2Q3LWQxMDUtNDhhNS1hYjM5LTk0OTUyMDA5MTg4
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjU0MTYx
-        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZGM0Yjk4
-        YmYtYmQ1Ny00Mzk1LWExNzUtZWE5ZDNhMGUzYmZhLyIsImRpZ2VzdCI6InNo
-        YTI1Njo0MjZjODU1Nzc1ZjAyNmQzZmU3Njk4OGI3MTkzOGY0YzlkYzY4NDBm
-        MDljMGYyOWQ4ZDRjNzVjYzQyMzg1MDNiIiwic2NoZW1hX3ZlcnNpb24iOjIs
+        bWFuaWZlc3RzL2Q3NzE2M2JmLTIxOTEtNGEzOC04MTY2LTdmOWFlNDk0MmNj
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjEyMDk3
+        NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODQwYTU5
+        ODYtNWE4ZC00Yjk2LTg3YjctNjExMzlmMWVjNTJlLyIsImRpZ2VzdCI6InNo
+        YTI1NjowYTExYTk1NTY4YjY4MGRjZTY5MDZhMDE1YmVkODgzODFlMjhhZDE3
+        YjMxYTYzZjdmZWMwNTdiMzU1NzMyMzVhIiwic2NoZW1hX3ZlcnNpb24iOjIs
         Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
         dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
         ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzMwMmQ0YjYyLWYxYWQtNDgyOS1iYWNkLTUyZjUwNDM3MGM0Zi8i
+        L2Jsb2JzLzViNDU2M2JhLWE5MzctNGQ5NS1iMzdhLWUxMDViMjI0ODc1My8i
         LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvYTExYTQ5N2MtZDAxZS00YmYwLWIzYjMtYWEyYTllYzFhYTEzLyJdfSx7
+        YnMvZmIzNGYwNTktZDE4Mi00NjJhLWFkMGEtMDRkNjRiZDZlOGYzLyJdfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
-        YW5pZmVzdHMvZDEwMGZhNWEtZWYxZC00NTZkLWJlNmMtN2FmMmJhNjFlNjg2
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNTQwMzcw
-        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mYWI4MjMy
-        Yi01YmJkLTQxMTQtYWIyYi1kY2M5YmFkYzhhMjgvIiwiZGlnZXN0Ijoic2hh
-        MjU2OjFmYWFmN2E3NTMxOTQxNzI2MTI2N2IzZGNlZjZhMmIxNGM4YzUxMjJk
-        N2ZjYzdhYmViMDdhMzJiYzE5NzI4ZmQiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        YW5pZmVzdHMvOTljZDJiYzQtYTVjZS00OGIwLTkxZWQtZjdkZDliOWZhMmJj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMTE4NTcx
+        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9lNTlkMjhm
+        MS04YTdkLTQ5MWUtODUxNS1lOTEwNDhkOGE5YjQvIiwiZGlnZXN0Ijoic2hh
+        MjU2OjA2NWE2NzE0Njk3YjRhNmQyN2ZiMTNhMTI4MzBmMGE5ZmY4MWE0MDQ5
+        OGJlYjlkYTQ5YWRiN2NmZDg3YjA1NGQiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
         bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
         aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
         Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvMWNlNWNjM2ItODRjMy00MmM5LWI2NGItYzYxMjI4YTNjZjg2LyIs
+        YmxvYnMvOWFkNzIxOWYtOTY4Ni00ZjgxLWE4ZmQtZmExOWZmNjkxMjVkLyIs
         ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy84MjY0Mzk4Ny02YjA0LTQxNWItOGFiMC04ZTcwZGNjNGE3YWUvIl19LHsi
+        cy9kMWMyZGYwZS1hMjY2LTQ4ZDEtOTc4OC01MTMwOTMyMDgyNjQvIl19LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
-        bmlmZXN0cy8yNDU2MjE3MS0wMzA5LTQxYWEtOTg4MS04NjAxZWMzMTk3YmUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41MzkwNDNa
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2VlNWNhYzRk
-        LWYwZmEtNDAwNy1hN2RiLTk5YjMyMjBmY2RlYi8iLCJkaWdlc3QiOiJzaGEy
-        NTY6MGExMWE5NTU2OGI2ODBkY2U2OTA2YTAxNWJlZDg4MzgxZTI4YWQxN2Iz
-        MWE2M2Y3ZmVjMDU3YjM1NTczMjM1YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
+        bmlmZXN0cy80NGUxZjM1Ny1mN2QyLTQ2YzMtODA4ZS04OWQ5ODA3MDkyYzIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4wNzUyNTBa
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2I2Y2YxYzhm
+        LTkwNDQtNDk3Zi1hYWI2LWM4ODk4MDAzNTMzZi8iLCJkaWdlc3QiOiJzaGEy
+        NTY6YmE2NWU4ZDM5ZTg5YjVjMTZmMDM2Yzg4Yzg1OTUyNzU2Nzc3YmY1Mzg1
+        YmNlMTQ4YmM0NGJlNDhmYWMzN2Q5NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
         ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
         b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
         b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy8yM2RjMjc3Zi02OWUwLTRjNGYtYTM5OS0zYzIxODEzOGVmZWQvIiwi
+        bG9icy8zYTY1N2Y5MC05OTEyLTRhMDgtYjk0OC01YzU4MDZlMjI3N2MvIiwi
         YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzQ5MWM2OGRkLTViODQtNDM0Ni1hMDA1LWQxYjI3NDZkMjkzMy8iXX0seyJw
+        Lzk1Y2RlYTEzLTQ5ODYtNDE1YS1hYzc2LTZkYjZiNzU0NjY2ZC8iXX0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFu
-        aWZlc3RzLzU5YzNkM2Q1LTJlYjEtNDUxOC04Y2ZhLWUyZDE0OGY5Zjg1OS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjUzNzY0MFoi
-        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODQyNDFiMjct
-        YjI2NC00MmQ1LTkyODEtYmJkNjY2MzY1YjcyLyIsImRpZ2VzdCI6InNoYTI1
-        NjowNjVhNjcxNDY5N2I0YTZkMjdmYjEzYTEyODMwZjBhOWZmODFhNDA0OThi
-        ZWI5ZGE0OWFkYjdjZmQ4N2IwNTRkIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        aWZlc3RzL2UzNzQxYzgwLWU0NTktNGU0OC05MGVhLWQzMGYzMDBmMzRkNS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjA3Mjc5MFoi
+        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjcyYTQ1MWUt
+        NTg4NC00MDQ3LWIwODYtZWE3ZWIxMzBiNGU1LyIsImRpZ2VzdCI6InNoYTI1
+        Njo0MjZjODU1Nzc1ZjAyNmQzZmU3Njk4OGI3MTkzOGY0YzlkYzY4NDBmMDlj
+        MGYyOWQ4ZDRjNzVjYzQyMzg1MDNiIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
         ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
         bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
         bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzAxMmNmYTRlLWE1Y2EtNDBmNy1hMzljLWJkYjg3MTEwMjk5MC8iLCJi
+        b2JzL2NjZmJlNjhjLTAwMWYtNDc5Ni1iOGQzLTRkNTNiYmU2YTQzOC8iLCJi
         bG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MDEzMDQ3ZDEtNDYyYi00ODBhLTk1MzAtMjIxOTA5MDJkMWFiLyJdfSx7InB1
+        NWRjOTJjMWUtM2UxMi00ZjhlLWEwMWEtMzk4OTM3YTIxNTgyLyJdfSx7InB1
         bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5p
-        ZmVzdHMvNzYxODc3MTAtYWJhMy00ZDgwLWEyZDEtYjQwYWIwYzkxNzc0LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNDk3NDUxWiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82NmM3NzU2OS03
-        NTE2LTQ2MWUtYWJhNS1jYzQ3MTcwZDRiZTIvIiwiZGlnZXN0Ijoic2hhMjU2
-        OmQ3ZTgzMzE2ZDc0ZTE1MDg2NmQ4MmM0NWRlMzQyZTc4ZjY2MmZlMGFlZmJk
-        YjgyMmQ3ZDEwYzhiOGUzOWNjNGIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        ZmVzdHMvYjJkYzQyNGMtOWY3MC00ODhlLTg2ZTItNTBlMmU1ZTY4MjVlLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMDI2NjUyWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9hN2ViZDM5Ni1l
+        MmVlLTQzN2UtYjAyNS0yMjMyYzgzNGY2MzUvIiwiZGlnZXN0Ijoic2hhMjU2
+        OmI4OTQ2MTg0Y2UzYWQ2YjRhMDllYmFkMmQ4NWU4MWNmY2FhZGM2ODk3YmZh
+        ZTJlOWM2ZTJhNGZlNmFmYTZlZTAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
         aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
         Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
         ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvZjQ2MmFkNmItNDRmYi00Njg1LWEwMTktNzA5Mjc5NThiMzA2LyIsImJs
-        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9m
-        ZWI2YTYzMi0xMDVhLTQzMzQtYTgyZS04OTM1OTQ0Zjk5MzQvIl19LHsicHVs
+        YnMvOWU5OTJjNDYtZWEwYS00ZDAwLThlOWYtYTE3YjkzM2E1ODhmLyIsImJs
+        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9j
+        MjgyZmRkMi0yMTUwLTQ3MjctOGZiNi0zZmFjYmM3NDBiN2EvIl19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9mZDE2MjUwNC1hMGUyLTQ1MTctYWExNS1hYjhiYjgwOTQ5OTkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy40OTYxNTBaIiwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzdjZDhhMDk0LWY2
-        YTgtNDQwNS05YTYxLTQxODQ5YjY0NDZhNS8iLCJkaWdlc3QiOiJzaGEyNTY6
+        ZXN0cy9mOWJhZjA0OC1iZGExLTQ0NmYtOGRjOS1lNzBhZjc1YWM5ODgvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi44ODgzNjBaIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Q5MDBhYTViLWM2
+        N2EtNDM1NC1hNDQ0LWIzZTM3Y2ZmZGJhMy8iLCJkaWdlc3QiOiJzaGEyNTY6
         NjY1NWRmMDRhM2RmODUzYjAyOWE1ZmFjODgzNjAzNWFjNGZhYjExNzgwMGM5
         YTZjNGI2OTM0MWJiNTMwNmMzZCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
         YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
         bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
         aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy84ZDU2ZGFlYS03YmYyLTQzMjUtYTk4Yy04ZjJlYzhhMTlhODYvIiwiYmxv
-        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Y5
-        NzQ2YjVmLTRkNTQtNGM0OC04YTEyLThhYTJiMzQ4MzBjZi8iXX0seyJwdWxw
+        cy82YTEyMTJkNS1jZTZmLTRjNDYtOWMzZC0yZTAxYjU2MDQwNTYvIiwiYmxv
+        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Zl
+        ZjBmYmZlLTMxNTQtNDM4Ni05OGY3LTZiNTg3MzI5OGM0OC8iXX0seyJwdWxw
         X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2RlYWE2NWVhLTIxYjktNGNlYy05Mzc1LTE5Njk1Y2VlOTFlZC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjM5ODkwMVoiLCJh
-        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMmM5YTFjM2UtNzIx
-        Ni00MTg2LTk4YzAtYmY4MmQ5MWFjNjkyLyIsImRpZ2VzdCI6InNoYTI1Njpk
-        NjM5MzMwYTQyNTQ5YzAyNjI5NGIxNmY0MDM5YTcwZWYyOTRiYmIzNzdjYWVm
-        ZDkyM2UzMGRkMDExMzVjN2Q2Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
+        c3RzLzc0YjM5YzM2LTc4NzQtNDZmNC04YmE3LTg1NzhiOWY4MWNjZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjc1NTUzM1oiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMTlmNzVmMDUtYzI5
+        Mi00ZTdhLTgxY2ItODZkYjMzNDk0MzY0LyIsImRpZ2VzdCI6InNoYTI1Njpj
+        ZTgwMDg3MjA5MmMzN2M1ZjIwZWYxMTFhNWE2OWM1YzhlOTRkMGM1ZTA1NWY3
+        NmY1MzBjYjVlNzhhMjZlYzAzIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
         X3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5t
         YW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZp
         Z19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        L2ExMGM1NTFjLTk1NTktNDFjNC05ZDc4LWE3NDgwNTBiNjY4Mi8iLCJibG9i
-        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvMWQ4
-        MmQ0NDMtZmRlZS00NWZhLTg0ZmItNzgxMTM0NjdkZGMyLyJdfSx7InB1bHBf
+        Lzc2MzExNDA0LWE4NDktNGM5NC04YzQ0LTc0NTYyM2ViNWQyOC8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvYWVi
+        NTMwNzMtZjMwOC00NDE2LWJhNTgtMDkwYWZkNzkyOTkxLyJdfSx7InB1bHBf
         aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvNjZiMzUxN2UtMjY0MS00MmVkLWI5ZGYtYjM5MjhmMjk5NTBiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMzk2NzQ0WiIsImFy
-        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wNWY0MWFjNS1mN2Iw
-        LTQxZGUtOGMwYS0wMzM3ZDNkZTU4OWEvIiwiZGlnZXN0Ijoic2hhMjU2OmNl
-        ODAwODcyMDkyYzM3YzVmMjBlZjExMWE1YTY5YzVjOGU5NGQwYzVlMDU1Zjc2
-        ZjUzMGNiNWU3OGEyNmVjMDMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHMvYmU2NTMxNmEtZjc3Zi00OWNhLTgwM2UtZjgwNTZhZmNiYjU1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNzUyMjYxWiIsImFy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wNGU3Yjc4NC0xMmYz
+        LTQ1ZDgtYmQ0My0xNTI5N2FjNDdhODcvIiwiZGlnZXN0Ijoic2hhMjU2OmM5
+        MjQ5ZmRmNTYxMzhmMGQ5MjllMjA4MGFlOThlZTljYjI5NDZmNzE0OThmYzE0
+        ODQyODhlNmE5MzViNWU1YmMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
         dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
         bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
         X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MmQyODE2MmQtZDZiZC00YjRkLWE5NDktNjcyYzcwNDgyMzg3LyIsImJsb2Jz
-        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy80ODgw
-        MWI0ZS01MzYwLTRmZDMtYTJiOS1iMjNlNGNhM2I4YzIvIl19LHsicHVscF9o
+        OTc0ZGRhMjAtYjk1Ny00OGU4LWJhMWItOTAyY2UxYTU3YWE2LyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9hNzQ2
+        ZjFlNy1kOTBjLTRmZWItYWE1Ni04NzQ5NTA5MTk4ZTMvIl19LHsicHVscF9o
         cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0
-        cy9jNjQ1YjllOC1mZGY3LTRkZGEtOWVmOS1kNDA1Njc1NjAxNDAvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4zOTQ4MjJaIiwiYXJ0
-        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M4NTU3ZmE5LTE5NTMt
-        NDU2ZS05OTNmLTNmNDg5YTlhYWQ5NS8iLCJkaWdlc3QiOiJzaGEyNTY6Yzky
-        NDlmZGY1NjEzOGYwZDkyOWUyMDgwYWU5OGVlOWNiMjk0NmY3MTQ5OGZjMTQ4
-        NDI4OGU2YTkzNWI1ZTViYyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
+        cy8wMWJkNTUxMC0zMTgwLTQ1NDYtODVhYi02ODE3YTE4NmNhYjYvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi43MjQyNDlaIiwiYXJ0
+        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzBlNGIxMTRhLTE1ZTAt
+        NDkyNi04YWYwLTkwYTZlN2M5NTY3Zi8iLCJkaWdlc3QiOiJzaGEyNTY6ZDYz
+        OTMzMGE0MjU0OWMwMjYyOTRiMTZmNDAzOWE3MGVmMjk0YmJiMzc3Y2FlZmQ5
+        MjNlMzBkZDAxMTM1YzdkNiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
         eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFu
         aWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdf
-        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy8w
-        OTg5MmYzOC1mNDM5LTRhMzAtOWVhNS00NGE5Zjc1MDY3YjMvIiwiYmxvYnMi
-        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzJjYTI1
-        NzE3LTVhZWMtNGI1Ny04MTA3LTJmOTg1NzMxYjgzYi8iXX0seyJwdWxwX2hy
+        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9m
+        M2U4Mjk2Mi1mOWYxLTQ3YmEtODhlOC02MDA1YzE3ODNlNzgvIiwiYmxvYnMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzkwNjkz
+        NDNhLThhYTUtNDJhMC04ZWQ1LWQ3NzA0YmMzMDJlMC8iXX0seyJwdWxwX2hy
         ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3Rz
-        LzZiYzA4YjYzLTQ1MTEtNDY2Zi1iYTk2LWM5YTQyMDQxNzgwOS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjM5Mjc5MFoiLCJhcnRp
-        ZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZGY3ZjIzYjMtMmQyOS00
-        YzZjLWFmNDctNjcxYTBjMjkyYTJiLyIsImRpZ2VzdCI6InNoYTI1NjphN2M1
+        L2U5MzA4ZjU5LTQ1NmYtNDNmZi05Zjc5LWIyMzEyZmFiY2VmOC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjcyMTcyNVoiLCJhcnRp
+        ZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTJhYmE0ZmMtNmE5OC00
+        NWUzLWI3YWMtN2IwOTQ4ZTBkYjlkLyIsImRpZ2VzdCI6InNoYTI1NjphN2M1
         NzJjMjZjYTQ3MGIzMTQ4ZDZjMWU0OGFkM2RiOTA3MDhhMjc2OWZkZjgzNmFh
         NDRkNzRiODMxOTA0OTZkIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5
         cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5p
         ZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19i
-        bG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzNl
-        ZTE0NjhiLTJmZWYtNGRlYi04ZWVlLTdhMTU2NzUyODZiMC8iLCJibG9icyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvOGMwZjU0
-        M2ItZDhjMS00OWI2LWI3NDctMzg3NWRhYzgxZGY1LyJdfSx7InB1bHBfaHJl
+        bG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzEz
+        ZmE4OTlhLWYxOWItNDJmNS05ZTE0LTRiMzFkNjIzZGMxNy8iLCJibG9icyI6
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvOWM4ZGY5
+        NDctOWYxNS00YWU2LWIyZGUtZGFhNTkyMzlmYmJkLyJdfSx7InB1bHBfaHJl
         ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMv
-        NjVmOTNmZmYtMjhhOC00NTQ2LTlmYjctNDFkNjUwNmIyM2FkLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMzkwODE0WiIsImFydGlm
-        YWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iODhkYTUxYi02OGQ5LTQ0
-        NGYtODBiNy0zYjA1MmEyOTUwZmMvIiwiZGlnZXN0Ijoic2hhMjU2OmExOWEw
-        MmRlMzA1ZTgzZDE0ZDdjYTRkNDE0ZDhkMjM2MDBiNzk1M2EwYTY5M2QyZDFj
-        ODVkM2NlMjZmYjcyZWIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlw
+        Nzk1YmJhNGEtOThlNS00MTI4LTg1NjctMGJjNmYzNDM5OGYyLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNjUyODQ0WiIsImFydGlm
+        YWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85ZDA5YTM0OC01OTc4LTQ3
+        NTUtOWEwNi1kMWZiMDM2NGM3NWEvIiwiZGlnZXN0Ijoic2hhMjU2OmQyY2Qw
+        Mjg1ZWNlYTgwOWE5OTkwNjlhOTYwNzVlNTBkZmY3MmVhMGExZjZlMTc0YTZm
+        YmQyNjMwMDI1MDYyOWUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlw
         ZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlm
         ZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Js
-        b2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvYmRj
-        MDY4MTMtMjNmOC00ZjBiLWE2M2EtMmJlYTI3Yzc3YjQ5LyIsImJsb2JzIjpb
-        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy83ZjBjYzU1
-        Ny00ODQ3LTQxYTItOTNlYy03MDAwZWRiMjdmOTcvIl19LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83
-        NTVhYjdiMS05NGI0LTQ1NmEtOGVhOC0yZDgxZjgzZTAyY2IvIiwicHVscF9j
-        cmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4zMTQ3NTBaIiwiYXJ0aWZh
-        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2I5MWFkYWQ1LTY5YTQtNDY2
-        NS04MTFiLWEyNzBhYmY0NGI1ZC8iLCJkaWdlc3QiOiJzaGEyNTY6ZDJjZDAy
-        ODVlY2VhODA5YTk5OTA2OWE5NjA3NWU1MGRmZjcyZWEwYTFmNmUxNzRhNmZi
-        ZDI2MzAwMjUwNjI5ZSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBl
+        b2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvYmRk
+        M2VjZTQtMzkxNS00MTJlLTkxYjctOGEzYWY0MjJhYTM2LyIsImJsb2JzIjpb
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9iOTlmNzk0
+        ZC03MjU2LTQ4ZTgtYmI3Ny1hNWRlN2RmZWQzZGMvIl19LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9h
+        YTliYjZiYi05NDQzLTRhZTUtODZiZC02MjMxMzMyOWUyNGEvIiwicHVscF9j
+        cmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi42NTA3MDlaIiwiYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzczNmNjNDhjLTM4ZmMtNDM1
+        YS1hMTExLTk0NjI1ZTY0ZGRhMS8iLCJkaWdlc3QiOiJzaGEyNTY6YjQ5Yjk1
+        Y2MxMWZjZDFiYjc5NDM0MjE0YWViZTFjYzExY2RhNDI2YTFjODc2N2E1ODg5
+        YzBiNzY4NzQyN2JmMiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBl
         IjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZl
         c3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxv
-        YiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy80ZDU2
-        NWIxMC1hMGFjLTQwNzMtYmE1Ny1lNDNlYmU5NTc4MzUvIiwiYmxvYnMiOlsi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2E4YmViNzlj
-        LWYzYjUtNDU3Ni1iMjJiLTEwNWIyZmVlZjYyNy8iXX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk1
-        YWQyYTYyLTc4ZDEtNDlhOC1iNjhkLTRlODk3MThmNGM3OC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjMxMjkzN1oiLCJhcnRpZmFj
-        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTdjNGVhMDQtZTY3OS00MDg2
-        LWE5NDItNzFkOGY3ZWJkMDBjLyIsImRpZ2VzdCI6InNoYTI1Njo4ZThkNjcy
-        NTI2YzdjYTgxOGYxODkyMjVhZTU5ZWU5YWQzNTNjYjFlMmZlYzdkMDExYjc4
-        ZWY3MGVjZDgwNWFlIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        YiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy82MWE4
+        NGUyZC04MDEzLTRlMzUtODhiOC0wZDY3ZDU3N2Y5MTcvIiwiYmxvYnMiOlsi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2VhMzJiMjQy
+        LWU3MjQtNDZlNC1hMTU5LTQ0ZjcyZjA5Zjc1MS8iXX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzNj
+        NjczOWEzLWJiOGYtNDViOS1iY2EzLTI3NDViMzNjNmM0YS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjY0ODM3NVoiLCJhcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTNkZmIyNzYtY2I4Yi00MDY4
+        LTllNGEtYmE3Y2YyOThkZDk0LyIsImRpZ2VzdCI6InNoYTI1NjphMTlhMDJk
+        ZTMwNWU4M2QxNGQ3Y2E0ZDQxNGQ4ZDIzNjAwYjc5NTNhMGE2OTNkMmQxYzg1
+        ZDNjZTI2ZmI3MmViIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
         OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
         dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzRmNjVi
-        OTk3LTgxMmQtNDkxOC1iYmYxLWVmY2I2MGJjZDgxOC8iLCJibG9icyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvODAyODQwMTIt
-        OTQ5Mi00MzlmLTljMDQtMDIwNGI0YzQyY2ZlLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvMDBl
-        NzlhMTktYjhmNS00NjUxLWJmNDUtNTRiY2M1MjZlY2UyLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMjc4Mzg0WiIsImFydGlmYWN0
-        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9lMDZhMWE0ZS0xZGVhLTRmYzIt
-        OWM1My1mMTVjYzM3OTgxZmIvIiwiZGlnZXN0Ijoic2hhMjU2OmI0OWI5NWNj
-        MTFmY2QxYmI3OTQzNDIxNGFlYmUxY2MxMWNkYTQyNmExYzg3NjdhNTg4OWMw
-        Yjc2ODc0MjdiZjIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Y0Y2Fm
+        OWRmLTk5MjgtNDkzNy05NGE3LTk4YmRlMjkwNmUwYy8iLCJibG9icyI6WyIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvN2JkNzYzMjAt
+        ZWFiMC00MmQ5LTg1N2QtZThjMDY5YWNkMWRiLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYWEz
+        N2Y5MzktNDdlNy00NDliLTk5MGMtMWMzODI4YjA2ZGNlLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNjQ2MDc5WiIsImFydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8yMjMwOThlMS0yMTI4LTRjZjAt
+        OTFjZi0wYTk3NDM1YTA0NzgvIiwiZGlnZXN0Ijoic2hhMjU2OjhlOGQ2NzI1
+        MjZjN2NhODE4ZjE4OTIyNWFlNTllZTlhZDM1M2NiMWUyZmVjN2QwMTFiNzhl
+        ZjcwZWNkODA1YWUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
         ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0
         LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2Ii
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvOWVkZmFi
-        MjEtNzQ2Mi00ZmM3LWE0MDEtMDkzODIzYzJmZGY0LyIsImJsb2JzIjpbIi9w
-        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy8wZGE0YTMzYy01
-        ZmJlLTQ3OWEtOTM3My05NzU2ZWFlYzIzNGIvIl19LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kOWM2
-        MGNkNS1hYTk5LTQ5NGYtODY4My01NzkyNWIwYzM1NmQvIiwicHVscF9jcmVh
-        dGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4yNzcxMzdaIiwiYXJ0aWZhY3Qi
-        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2MyNzZjZDRmLTg3YzEtNGQ1Ni1i
-        N2MwLTE2MjVjNmE5ZGIwNS8iLCJkaWdlc3QiOiJzaGEyNTY6MWNlZTg3Mjdm
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvNDJhZWQ1
+        ZTMtZDg4NS00ZjhmLWFmMTItZmNhM2IxODc4OGVjLyIsImJsb2JzIjpbIi9w
+        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9lYzM3MjVhZC03
+        OGVkLTQ2ZDQtYmY3OC02YjA2MDViODg2YzkvIl19LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kZjRk
+        YmNlNC0xMGU3LTQwNmUtYTAwNi0wMDUyNTRmMjBlYjYvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi42Mzg2ODlaIiwiYXJ0aWZhY3Qi
+        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzRhNDMzMjQ4LTFhMjktNDNmZS04
+        YWI4LTQxMzYxNzk5MzkwNS8iLCJkaWdlc3QiOiJzaGEyNTY6MWNlZTg3Mjdm
         YjE1YTNjM2UzODllYjBiZTk1NzQwZjY2Zjc5YjNlZGRjNTdkMmIzZDk2OGZi
         OGEwNDZmYzc2YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoi
         YXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3Qu
         djIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9jOGZhOTY0
-        NS01ZDIzLTQ2MDMtOTllMC03ZWU1YzJlNjUxZDQvIiwiYmxvYnMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzEyOTE0Y2NjLTJh
-        OTAtNGIxMC05ZmZmLWY5NjU0MjlhMjVkMS8iXX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2NmZDJj
-        YTA4LWVhMjktNGM5Ny1hYzJmLTRkMThiYzkxY2E0OC8iLCJwdWxwX2NyZWF0
-        ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjE5Njk4MFoiLCJhcnRpZmFjdCI6
-        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDc3YWE4ZjYtNTYwZS00MzcwLTgy
-        NzItMDkzMWZlZTUzNzAyLyIsImRpZ2VzdCI6InNoYTI1Njo5NThlNDMzYmNm
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9hNWEzMjRm
+        OC1mNDI0LTRiZjktODJiNy05YWQwZjdhZDgyMDkvIiwiYmxvYnMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2NjMDZjMjY3LTk2
+        YjYtNDdmZC1iMzhhLWFhMTMyODI1Nzg4NS8iXX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2ExYjQ0
+        MWFlLWViMDAtNDA1ZS1iNzM3LTZlMDgyNWUwMjI1NS8iLCJwdWxwX2NyZWF0
+        ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjQxMzIzOFoiLCJhcnRpZmFjdCI6
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYmMzYTBkMjYtZjNmNi00NjdlLWEz
+        MGItYWE3YmJhNzU3ODU4LyIsImRpZ2VzdCI6InNoYTI1Njo5NThlNDMzYmNm
         YTZjM2ZhYWNkY2JiZTIwNTg2MGM4YWU0NDc0ZDljODY1ZjkzMmM5MTgyN2Yy
         ZTI5MmI5MmRjIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJh
         cHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52
         Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzk3NGYxMTk4
-        LTZkMTEtNGY5Ny1iNDkwLTlkOTI4YzkzMzUyNS8iLCJibG9icyI6WyIvcHVs
-        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvODQ1YzRlZjItMWEx
-        OC00YTU1LTk2MjYtZWY2NGU3Yzk2YjgwLyJdfV19
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzdkMDdjNzM4
+        LTBmNTEtNGM4ZC05ZjI1LTEwMGY1YTBlZWI0Mi8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvOWM1NmViMWYtYmRh
+        NS00ZTEwLWFkN2UtNzZhY2I5MjVhMTM2LyJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:17 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/f25282ff-52be-4cd4-b602-644627c884b6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/c68a5d87-d93b-42e8-8a83-a9411be5cc50/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1921,7 +2443,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1934,111 +2456,111 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:18 GMT
+      - Fri, 29 Jul 2022 09:03:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '3315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a7c94ff6eb9f498aa0da3cc18ef2478d
+      - dfc3ca6b50f346438daf1382d3c1a942
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1089'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvOTliYTZlNzctNGE2OC00YzM2LTkxOGEtMTk0ZWM0
-        NzlmZWE0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMu
-        MTk4NDAyWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        MmRmMTBiNS0xZjc2LTQ3ZTYtOThhOC0zOGFmNGM4NjI1NjMvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvMjBkN2M4MjMtZDhlZC00Zjc5LWE2NmItM2FlNDY2
+        YTk4YzU2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIu
+        NDE2MjQ3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9h
+        ZTRhM2ViNC0xZTY5LTRkNmYtYjdmMy1jOWQ2NmQ4YWU2ZGUvIiwiZGlnZXN0
         Ijoic2hhMjU2OmE5Mjg2ZGVmYWJhN2IzYTUxOWQ1ODViYTBlMzdkMGIyY2Jl
         ZTc0ZWJmZTU5MDk2MGIwYjFkNmE1ZTk3ZDFlMWQiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
         ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy82YmMwOGI2My00NTExLTQ2NmYtYmE5Ni1jOWE0MjA0MTc4MDkvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9jNjQ1
-        YjllOC1mZGY3LTRkZGEtOWVmOS1kNDA1Njc1NjAxNDAvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82NmIzNTE3ZS0yNjQx
-        LTQyZWQtYjlkZi1iMzkyOGYyOTk1MGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy81YTBhOGUzYy0yMDU4LTRlOWQtYWIy
-        MS1jZjc1ODk5ZGIyMjYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy8yNDU2MjE3MS0wMzA5LTQxYWEtOTg4MS04NjAxZWMz
-        MTk3YmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9kZTk1OTNkNy1kMTA1LTQ4YTUtYWIzOS05NDk1MjAwOTE4ODgvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9mZDE2
-        MjUwNC1hMGUyLTQ1MTctYWExNS1hYjhiYjgwOTQ5OTkvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83NjE4NzcxMC1hYmEz
-        LTRkODAtYTJkMS1iNDBhYjBjOTE3NzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy82M2NkYjIzOC02YTlmLTRlMGMtOGRh
-        OS1lM2I3ODAyNWRlYmUvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6
+        ZXN0cy9lOTMwOGY1OS00NTZmLTQzZmYtOWY3OS1iMjMxMmZhYmNlZjgvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iZTY1
+        MzE2YS1mNzdmLTQ5Y2EtODAzZS1mODA1NmFmY2JiNTUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83NGIzOWMzNi03ODc0
+        LTQ2ZjQtOGJhNy04NTc4YjlmODFjY2UvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy9mOWJhZjA0OC1iZGExLTQ0NmYtOGRj
+        OS1lNzBhZjc1YWM5ODgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy9iMmRjNDI0Yy05ZjcwLTQ4OGUtODZlMi01MGUyZTVl
+        NjgyNWUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9lMzc0MWM4MC1lNDU5LTRlNDgtOTBlYS1kMzBmMzAwZjM0ZDUvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy80NGUx
+        ZjM1Ny1mN2QyLTQ2YzMtODA4ZS04OWQ5ODA3MDkyYzIvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kNzcxNjNiZi0yMTkx
+        LTRhMzgtODE2Ni03ZjlhZTQ5NDJjY2EvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy8xMDQxMTA5NC0zMWQxLTQyMzgtODU0
+        MC00YjFmM2FhMWVlY2EvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6
         W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy81YjY4MWVhNS0zMTUwLTQ5NDgtYTdhMy0zNDZhM2Q3
-        ZDQwN2UvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4x
-        OTU2MjhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzVj
-        ZjhiYmYwLWMwNzUtNGZjMC05ODJiLWEwMmM1MWEyZmFiZS8iLCJkaWdlc3Qi
+        bmVyL21hbmlmZXN0cy81YjM2ZjYyOC01NTViLTQzODAtODY4Ni1jOWEwM2Q2
+        OTRiMzgvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi40
+        MTExMjhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzli
+        NDA2OTYxLTk5MDAtNGYzZC1iNDFiLWIyNmU2YmJkYjJlZS8iLCJkaWdlc3Qi
         OiJzaGEyNTY6MzBkMTQxMmMwZjQ1YmU2N2QzOGI5OTE3OTg2Njg2OGIxZjA5
         ZmQ5MDEzY2JhY2YyMjgxMzkyNmFlZTQyOGNmNyIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlm
         ZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzLzQ2YWZjMmJhLTMwNjAtNDRjYi05ODUyLTNjZTU3MTFjYTRjMC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzI0NTYy
-        MTcxLTAzMDktNDFhYS05ODgxLTg2MDFlYzMxOTdiZS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2RlOTU5M2Q3LWQxMDUt
-        NDhhNS1hYjM5LTk0OTUyMDA5MTg4OC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzL2M5ZDlkY2ZhLTJhZDYtNGNkMi1iNGM3
-        LThhMGY0OWNmMjIxMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzL2M4MmIwNmIyLWZjYmMtNGFjNy1hNDQ4LTQ1ZGFmMzU3
-        ZmZkYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzLzU5YzNkM2Q1LTJlYjEtNDUxOC04Y2ZhLWUyZDE0OGY5Zjg1OS8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2QxMDBm
-        YTVhLWVmMWQtNDU2ZC1iZTZjLTdhZjJiYTYxZTY4Ni8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzVjY2M4OTA3LTA0NDct
-        NDAwYS1iNTE5LTVhZGY3NTM5NTRjZi8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        c3RzL2UzNzQxYzgwLWU0NTktNGU0OC05MGVhLWQzMGYzMDBmMzRkNS8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk5Y2Qy
+        YmM0LWE1Y2UtNDhiMC05MWVkLWY3ZGQ5YjlmYTJiYy8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2Q3NzE2M2JmLTIxOTEt
+        NGEzOC04MTY2LTdmOWFlNDk0MmNjYS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzEwYmZlZDAyLWJhYzYtNDI1Yi1hMjBl
+        LWQ5NjdmYTllN2Q4Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzkyYjYyYWY5LWQ1YjItNGZjNi04MmZhLTQzMzYwMmQ5
+        MjZiYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzL2FiMjM4NzM4LWRlZmItNGIwMi1iOTlkLTVjY2ViNGJiN2YwNS8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzQzMDYx
+        YWE0LTU4OWQtNDhjMy04ZDRjLTU5MzdhZGVjOGM5My8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2YzYjQ0ZTY4LTcwZGUt
+        NDAwNi04ZmQ5LTY5NWQ5OWIxMWQ4NC8iXSwiY29uZmlnX2Jsb2IiOm51bGws
         ImJsb2JzIjpbXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzL2M5YjgzZTZjLTU1NmEtNDBlYy1iYmU0
-        LTExNWRlZjE4MTIwMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIz
-        OjE4OjEzLjE5MzM3M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvMWIxZGYxMTItYWNkZC00NDJmLWI4MWUtYjczMmUwOTFiOWQ5LyIs
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzZjNTFmMTkzLTk1OTQtNDcwMi1hMzY3
+        LWE1YWM3MTg1MTRkNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2
+        OjU0OjMyLjQwNzg1NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvYzczM2E0MTgtNGUwNS00MTU5LWFiZTAtMjRiYTM4MmQxZDQ1LyIs
         ImRpZ2VzdCI6InNoYTI1NjoyMjYzNzc1N2YyZDBmOGUyMGI3NGUzZWYyMjZl
         ZWRkMGJkZjg4MDJjYzc0YWU1OGI2ZTYzMTY4NTdkM2JkZTU2Iiwic2NoZW1h
         X3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9j
         a2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC5saXN0LnYyK2pzb24iLCJsaXN0
         ZWRfbWFuaWZlc3RzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvY2ZkMmNhMDgtZWEyOS00Yzk3LWFjMmYtNGQxOGJjOTFj
-        YTQ4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvZDljNjBjZDUtYWE5OS00OTRmLTg2ODMtNTc5MjViMGMzNTZkLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvMDBlNzlh
-        MTktYjhmNS00NjUxLWJmNDUtNTRiY2M1MjZlY2UyLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvOTVhZDJhNjItNzhkMS00
-        OWE4LWI2OGQtNGU4OTcxOGY0Yzc4LyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L2NvbnRhaW5lci9tYW5pZmVzdHMvNzU1YWI3YjEtOTRiNC00NTZhLThlYTgt
-        MmQ4MWY4M2UwMmNiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNjVmOTNmZmYtMjhhOC00NTQ2LTlmYjctNDFkNjUwNmIy
-        M2FkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvZGVhYTY1ZWEtMjFiOS00Y2VjLTkzNzUtMTk2OTVjZWU5MWVkLyJdLCJj
+        ci9tYW5pZmVzdHMvYTFiNDQxYWUtZWIwMC00MDVlLWI3MzctNmUwODI1ZTAy
+        MjU1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvZGY0ZGJjZTQtMTBlNy00MDZlLWEwMDYtMDA1MjU0ZjIwZWI2LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYWEzN2Y5
+        MzktNDdlNy00NDliLTk5MGMtMWMzODI4YjA2ZGNlLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvM2M2NzM5YTMtYmI4Zi00
+        NWI5LWJjYTMtMjc0NWIzM2M2YzRhLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L2NvbnRhaW5lci9tYW5pZmVzdHMvYWE5YmI2YmItOTQ0My00YWU1LTg2YmQt
+        NjIzMTMzMjllMjRhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9tYW5pZmVzdHMvNzk1YmJhNGEtOThlNS00MTI4LTg1NjctMGJjNmYzNDM5
+        OGYyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvMDFiZDU1MTAtMzE4MC00NTQ2LTg1YWItNjgxN2ExODZjYWI2LyJdLCJj
         b25maWdfYmxvYiI6bnVsbCwiYmxvYnMiOltdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/f25282ff-52be-4cd4-b602-644627c884b6/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/c68a5d87-d93b-42e8-8a83-a9411be5cc50/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2046,7 +2568,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2059,55 +2581,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:18 GMT
+      - Fri, 29 Jul 2022 09:03:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '798'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 141175e6201f4189bfd48b3932f000be
+      - 1f41817e5543434890094f378495e257
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '345'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2MyZWY0M2YyLTdiMTktNDg4Ny04ZGQ4LTQ1MTg1MjgyMjlh
-        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjE1Ljk5NjQx
-        OFoiLCJuYW1lIjoibXVzbCIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYzliODNlNmMtNTU2
-        YS00MGVjLWJiZTQtMTE1ZGVmMTgxMjAzLyJ9LHsicHVscF9ocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvYmMwYmU0NWYtNGFh
-        Yi00MzEzLWIwOGYtM2I2NmExZjJhNGViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTUuOTk1MzQ2WiIsIm5hbWUiOiJsYXRlc3QiLCJ0
+        aW5lci90YWdzL2I3M2NiMmVlLTIwZGItNDE2NS1hNWMzLTUwNGFhNjkxY2Ew
+        Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjQyLjA3NDM2
+        MVoiLCJuYW1lIjoibXVzbCIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNmM1MWYxOTMtOTU5
+        NC00NzAyLWEzNjctYTVhYzcxODUxNGQ1LyJ9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvYTk2ODBjMTMtOTNl
+        OS00ZWZiLWFiZjQtYmI3YjA4ZWEzY2JhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTY6NTQ6NDIuMDcxOTE3WiIsIm5hbWUiOiJsYXRlc3QiLCJ0
         YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzk5YmE2ZTc3LTRhNjgtNGMzNi05MThhLTE5NGVjNDc5
-        ZmVhNC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Nv
-        bnRhaW5lci90YWdzL2IxZjQ2M2ZiLTA0MjctNDc5Yi05YTQ2LTFhYzJiZWIw
-        YzAyMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjE1Ljk5
-        NDAyOFoiLCJuYW1lIjoiZ2xpYmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzViNjgxZWE1
-        LTMxNTAtNDk0OC1hN2EzLTM0NmEzZDdkNDA3ZS8ifV19
+        ZXIvbWFuaWZlc3RzLzIwZDdjODIzLWQ4ZWQtNGY3OS1hNjZiLTNhZTQ2NmE5
+        OGM1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Nv
+        bnRhaW5lci90YWdzLzhiNzg5M2IxLWRiMWEtNDE4Ny04ZjE2LTE5MzdkZWQ2
+        OGI2OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjQyLjA2
+        ODY1OVoiLCJuYW1lIjoiZ2xpYmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzViMzZmNjI4
+        LTU1NWItNDM4MC04Njg2LWM5YTAzZDY5NGIzOC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/d046bbbe-9295-4c64-8b79-9df2296e00dc/remove/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/b05b9638-0d49-4592-8028-d41654e2abe9/remove/
     body:
       encoding: UTF-8
       base64_string: 'eyJjb250ZW50X3VuaXRzIjpbIioiXX0=
@@ -2117,7 +2639,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2130,7 +2652,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:18 GMT
+      - Fri, 29 Jul 2022 09:03:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2148,33 +2670,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eae18888090c4ac0878202db68e6fbee
+      - 05147c4078744f54b3b6ec7871ddd841
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiNDZiN2ZmLWIwZmMtNGU0
-        Ny1hMzQzLTk0NTFiMmYzZTJhOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlY2E5YTc4LTgzZmMtNGUz
+        Zi1hM2QwLWE3NDdmZTY1OGI2Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/d046bbbe-9295-4c64-8b79-9df2296e00dc/add/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/b05b9638-0d49-4592-8028-d41654e2abe9/add/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X3VuaXRzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2IxZjQ2M2ZiLTA0MjctNDc5Yi05YTQ2LTFhYzJiZWIwYzAy
-        MC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9jMmVm
-        NDNmMi03YjE5LTQ4ODctOGRkOC00NTE4NTI4MjI5YWQvIl19
+        aW5lci90YWdzLzhiNzg5M2IxLWRiMWEtNDE4Ny04ZjE2LTE5MzdkZWQ2OGI2
+        OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9iNzNj
+        YjJlZS0yMGRiLTQxNjUtYTVjMy01MDRhYTY5MWNhMDIvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2187,7 +2709,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:18 GMT
+      - Fri, 29 Jul 2022 09:03:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2205,21 +2727,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9341465010a34f11be4e8ecb8c8ef038
+      - 2ea435aad7194026a21a3b5eef492a04
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjYWYwMmRlLWI2YjMtNGYz
-        MC04NjQyLTU1NjZmYzY0NzMyMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzN2IyMTJjLTBkYzItNGZm
+        My05ZWYzLTFmODdlZDE2ZmIyMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3b46b7ff-b0fc-4e47-a343-9451b2f3e2a9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0eca9a78-83fc-4e3f-a3d0-a747fe658b6f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2240,52 +2762,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:18 GMT
+      - Fri, 29 Jul 2022 09:03:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '647'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dc5f665789ae4d938723b4355f61b63d
+      - 24d7bfc4c554415088a8e4dc9fb6e22f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2I0NmI3ZmYtYjBm
-        Yy00ZTQ3LWEzNDMtOTQ1MWIyZjNlMmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTguNDI0NDQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGVjYTlhNzgtODNm
+        Yy00ZTNmLWEzZDAtYTc0N2ZlNjU4YjZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTkuMzQwNTk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsImxvZ2dpbmdfY2lk
-        IjoiZWFlMTg4ODgwOTBjNGFjMDg3ODIwMmRiNjhlNmZiZWUiLCJzdGFydGVk
-        X2F0IjoiMjAyMi0wNS0yM1QyMzoxODoxOC40NjM5NDhaIiwiZmluaXNoZWRf
-        YXQiOiIyMDIyLTA1LTIzVDIzOjE4OjE4LjU0OTIxOFoiLCJlcnJvciI6bnVs
-        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGRmMThhZmYtNjRi
-        OC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBhcmVudF90YXNrIjpudWxs
+        IjoiMDUxNDdjNDA3ODc0NGY1NGIzYjZlYzc4NzFkZGQ4NDEiLCJzdGFydGVk
+        X2F0IjoiMjAyMi0wNy0yOVQwOTowMzoxOS4zOTg0MzhaIiwiZmluaXNoZWRf
+        YXQiOiIyMDIyLTA3LTI5VDA5OjAzOjE5LjU1NTM0OVoiLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNTlkZTU1NzUtM2Rk
+        Ny00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBhcmVudF90YXNrIjpudWxs
         LCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNz
         X3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9jb250YWluZXIvY29udGFpbmVyL2QwNDZiYmJlLTkyOTUtNGM2NC04Yjc5
-        LTlkZjIyOTZlMDBkYy8iXX0=
+        cy9jb250YWluZXIvY29udGFpbmVyL2IwNWI5NjM4LTBkNDktNDU5Mi04MDI4
+        LWQ0MTY1NGUyYWJlOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3b46b7ff-b0fc-4e47-a343-9451b2f3e2a9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0eca9a78-83fc-4e3f-a3d0-a747fe658b6f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2306,52 +2828,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:18 GMT
+      - Fri, 29 Jul 2022 09:03:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '647'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c43bec47e5d4e4fa734933740f0cc4a
+      - 876165dc193343dd897634d3d4b2ecf4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2I0NmI3ZmYtYjBm
-        Yy00ZTQ3LWEzNDMtOTQ1MWIyZjNlMmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTguNDI0NDQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGVjYTlhNzgtODNm
+        Yy00ZTNmLWEzZDAtYTc0N2ZlNjU4YjZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTkuMzQwNTk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsImxvZ2dpbmdfY2lk
-        IjoiZWFlMTg4ODgwOTBjNGFjMDg3ODIwMmRiNjhlNmZiZWUiLCJzdGFydGVk
-        X2F0IjoiMjAyMi0wNS0yM1QyMzoxODoxOC40NjM5NDhaIiwiZmluaXNoZWRf
-        YXQiOiIyMDIyLTA1LTIzVDIzOjE4OjE4LjU0OTIxOFoiLCJlcnJvciI6bnVs
-        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGRmMThhZmYtNjRi
-        OC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBhcmVudF90YXNrIjpudWxs
+        IjoiMDUxNDdjNDA3ODc0NGY1NGIzYjZlYzc4NzFkZGQ4NDEiLCJzdGFydGVk
+        X2F0IjoiMjAyMi0wNy0yOVQwOTowMzoxOS4zOTg0MzhaIiwiZmluaXNoZWRf
+        YXQiOiIyMDIyLTA3LTI5VDA5OjAzOjE5LjU1NTM0OVoiLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNTlkZTU1NzUtM2Rk
+        Ny00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBhcmVudF90YXNrIjpudWxs
         LCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNz
         X3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9jb250YWluZXIvY29udGFpbmVyL2QwNDZiYmJlLTkyOTUtNGM2NC04Yjc5
-        LTlkZjIyOTZlMDBkYy8iXX0=
+        cy9jb250YWluZXIvY29udGFpbmVyL2IwNWI5NjM4LTBkNDktNDU5Mi04MDI4
+        LWQ0MTY1NGUyYWJlOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:18 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8caf02de-b6b3-4f30-8642-5566fc647320/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a37b212c-0dc2-4ff3-9ef3-1f87ed16fb20/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2372,54 +2894,54 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:19 GMT
+      - Fri, 29 Jul 2022 09:03:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '737'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e44949c25d0841048186d4ab887d3d9d
+      - 29b048e78c414cbc81e7ec07211379b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGNhZjAyZGUtYjZi
-        My00ZjMwLTg2NDItNTU2NmZjNjQ3MzIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTguNDg5OTg3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTM3YjIxMmMtMGRj
+        Mi00ZmYzLTllZjMtMWY4N2VkMTZmYjIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MTkuNDIyODY2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
-        YWRkLnJlY3Vyc2l2ZV9hZGRfY29udGVudCIsImxvZ2dpbmdfY2lkIjoiOTM0
-        MTQ2NTAxMGEzNGYxMWJlNGU4ZWNiOGM4ZWYwMzgiLCJzdGFydGVkX2F0Ijoi
-        MjAyMi0wNS0yM1QyMzoxODoxOC41ODQ1ODdaIiwiZmluaXNoZWRfYXQiOiIy
-        MDIyLTA1LTIzVDIzOjE4OjE4LjcxOTc0M1oiLCJlcnJvciI6bnVsbCwid29y
-        a2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGRmMThhZmYtNjRiOC00YzZh
-        LTk0MWItNGI0OTgwY2Y4MDNhLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGls
+        YWRkLnJlY3Vyc2l2ZV9hZGRfY29udGVudCIsImxvZ2dpbmdfY2lkIjoiMmVh
+        NDM1YWFkNzE5NDAyNmEyMWEzYjVlZWY0OTJhMDQiLCJzdGFydGVkX2F0Ijoi
+        MjAyMi0wNy0yOVQwOTowMzoxOS41OTM0MzZaIiwiZmluaXNoZWRfYXQiOiIy
+        MDIyLTA3LTI5VDA5OjAzOjE5Ljc4MTIwOFoiLCJlcnJvciI6bnVsbCwid29y
+        a2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNTlkZTU1NzUtM2RkNy00OWVl
+        LTlmNjYtMDU5ODNhNGJmMjA4LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGls
         ZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9y
         dHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZDA0NmJiYmUtOTI5NS00
-        YzY0LThiNzktOWRmMjI5NmUwMGRjL3ZlcnNpb25zLzEvIl0sInJlc2VydmVk
+        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjA1Yjk2MzgtMGQ0OS00
+        NTkyLTgwMjgtZDQxNjU0ZTJhYmU5L3ZlcnNpb25zLzEvIl0sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9jb250YWluZXIvY29udGFpbmVyL2QwNDZiYmJlLTkyOTUtNGM2NC04Yjc5
-        LTlkZjIyOTZlMDBkYy8iXX0=
+        cy9jb250YWluZXIvY29udGFpbmVyL2IwNWI5NjM4LTBkNDktNDU5Mi04MDI4
+        LWQ0MTY1NGUyYWJlOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/d046bbbe-9295-4c64-8b79-9df2296e00dc/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/b05b9638-0d49-4592-8028-d41654e2abe9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2427,7 +2949,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2440,233 +2962,233 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:19 GMT
+      - Fri, 29 Jul 2022 09:03:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8812'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd47fd38376745d89fde3025b73a1c28
+      - f903d13da5a1421892bfffb5521a73bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2438'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTUsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvbWFuaWZlc3RzL2M4MmIwNmIyLWZjYmMtNGFjNy1hNDQ4LTQ1ZGFm
-        MzU3ZmZkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEz
-        LjY2NzEzNFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        NWIxMDE5NGEtMzE3Zi00MDY3LWIzZWMtMjcwYmI4MjJlYzhhLyIsImRpZ2Vz
+        YWluZXIvbWFuaWZlc3RzL2YzYjQ0ZTY4LTcwZGUtNDAwNi04ZmQ5LTY5NWQ5
+        OWIxMWQ4NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMz
+        LjU5MDM3MloiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        N2U5YjhiMDMtM2Q3YS00OThkLWFjMGMtNjQwNDNkMTYwZDBkLyIsImRpZ2Vz
         dCI6InNoYTI1Njo2ZTZkMTMwNTVlZDgxYjcxNDRhZmFhZDE1MTUwZmMxMzdk
         NGY2Mzk0ODJiZWIzMTFhYWEwOTdiYzU3ZTNjYjgwIiwic2NoZW1hX3ZlcnNp
         b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
         c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
         cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL2Jsb2JzL2E0Mzk2NWYzLTdiYjAtNGVhYi05OWZiLTIyNWUwYWIz
-        MjNlOC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvZjg2ZjA5ZDktOTJhYi00NWU4LTk5M2UtYmQzNWIxNTM0ZGI1
+        dGFpbmVyL2Jsb2JzLzQ3MTEyZjk5LTMzZTgtNDdhMC1hMWExLTQ2NGQzODQz
+        ZDhmZS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvM2I5ODg5MjYtM2RkOS00M2I3LWI1ZDMtNGEyZWY3YjY0YmJi
         LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvYzlkOWRjZmEtMmFkNi00Y2QyLWI0YzctOGEwZjQ5
-        Y2YyMjEzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMu
-        NjY0ODQ0WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
-        MmU2OTE3MS1jNzczLTRlZmMtYjU5Ny01ZjE3ODQ2MjA4MDEvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvNDMwNjFhYTQtNTg5ZC00OGMzLThkNGMtNTkzN2Fk
+        ZWM4YzkzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMu
+        NTg0ODg3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        ZjMzMjJkYS0wNjExLTQxZTYtODhmOS03MzA4OTY0N2RiNGMvIiwiZGlnZXN0
         Ijoic2hhMjU2OjIwZThkNmZlNGJiMTEzMTVlMDhmYjY5MmNkNzE2OTYxNjdi
         MDFkYTYxMDUwODIxNTFlZmM0NTRlMDY1OTA4ZjkiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvNGRlMWI1MWUtNTFlOC00OGJhLThkNGYtNDQ1MzIyMmQ5
-        ZmZlLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9kYTYxYjI0Zi05MTM3LTQxYTEtODIzZi1hYzBjYmQ0MWVmNmIv
+        YWluZXIvYmxvYnMvODRlMzFmNTMtNTMwNC00YTljLWI1NjktN2Y0ODQzM2Yx
+        YjAzLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy84YzNiNTNhYi0zM2I3LTQ0OGQtYThkZi1hM2I3NTYzOTFmZWIv
         Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy80NmFmYzJiYS0zMDYwLTQ0Y2ItOTg1Mi0zY2U1NzEx
-        Y2E0YzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41
-        NzkyNzNaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzhj
-        MWYyODYwLWVkMjItNDM1Yi1iNGIxLWQyMGVmOWZkZTUwNi8iLCJkaWdlc3Qi
-        OiJzaGEyNTY6MzI5NjhlNzE3ZTI5Zjc5ZTViODg5NzIxOTA4YjNiZTZkMTU3
-        Mzk5MmUxZjNiYTRjOWE0MTcxOGUyNzI4NDU4YyIsInNjaGVtYV92ZXJzaW9u
+        bmVyL21hbmlmZXN0cy9hYjIzODczOC1kZWZiLTRiMDItYjk5ZC01Y2NlYjRi
+        YjdmMDUvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4x
+        MzE1NjBaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Zk
+        ODIyMDdkLWNmNjUtNDQ5Yy04ZTI1LTNjYTAzOTYzZTE4Ny8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6NmNhOWE1NmIyYjkzYmUxNmE2MmU2ZDQ0YWQ0N2U2ZDMyMDEy
+        NjMzMmQxZTI3NTA5ZTEzZmEyY2M0OWIxMGU5ZSIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
         OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy8yODFiNWJjZi01ZjA4LTRhMDktYjcwYi0wMTEzOTk4YTFk
-        ZWIvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzL2M2ZmMwNmI1LTBmMTQtNGE1Yi1hN2JiLWQxZDYyODFmYzVkMy8i
+        aW5lci9ibG9icy83ODFkNWJkZC1kYjYwLTRjZWYtYjg1MC02MjZlOGU2MWZk
+        YmQvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzL2UzZTkzNDIxLWZiYmQtNDM1NC04MTJmLTY0NWM2NTBmN2U2MC8i
         XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzVjY2M4OTA3LTA0NDctNDAwYS1iNTE5LTVhZGY3NTM5
-        NTRjZi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjU0
-        MjgzM1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTVm
-        NWM2YmYtNGM5ZS00NTU1LWE1YzYtMmY5NTEzMjYwZjdkLyIsImRpZ2VzdCI6
-        InNoYTI1Njo2Y2E5YTU2YjJiOTNiZTE2YTYyZTZkNDRhZDQ3ZTZkMzIwMTI2
-        MzMyZDFlMjc1MDllMTNmYTJjYzQ5YjEwZTllIiwic2NoZW1hX3ZlcnNpb24i
+        ZXIvbWFuaWZlc3RzLzkyYjYyYWY5LWQ1YjItNGZjNi04MmZhLTQzMzYwMmQ5
+        MjZiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjEy
+        NzM2NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMmY1
+        ZGE5ZmEtY2M5Mi00YzBjLTg2NGUtMWMwMThhNWEyNDg2LyIsImRpZ2VzdCI6
+        InNoYTI1NjozMjk2OGU3MTdlMjlmNzllNWI4ODk3MjE5MDhiM2JlNmQxNTcz
+        OTkyZTFmM2JhNGM5YTQxNzE4ZTI3Mjg0NThjIiwic2NoZW1hX3ZlcnNpb24i
         OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
         aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
         W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL2Jsb2JzLzI5YzcxY2I1LTY5YTEtNDA2OC05MDQzLWNmMTNjY2FkY2Nk
-        Mi8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvMWI4NzYxNGQtMzMyYy00YzBjLWI2ZjgtMThlZWFiYTkxMDQ4LyJd
+        bmVyL2Jsb2JzL2NhYzNhOTU2LTZiOTQtNGE2Yy1hNDIyLTYyNmM5NDNhMzQx
+        Ny8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
+        YmxvYnMvMzM1ZmU1MWMtM2Q5OS00YjZiLThkYTItNmRmMTJlODEwODA5LyJd
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvZGU5NTkzZDctZDEwNS00OGE1LWFiMzktOTQ5NTIwMDkx
-        ODg4LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNTQx
-        NjEwWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kYzRi
-        OThiZi1iZDU3LTQzOTUtYTE3NS1lYTlkM2EwZTNiZmEvIiwiZGlnZXN0Ijoi
-        c2hhMjU2OjQyNmM4NTU3NzVmMDI2ZDNmZTc2OTg4YjcxOTM4ZjRjOWRjNjg0
-        MGYwOWMwZjI5ZDhkNGM3NWNjNDIzODUwM2IiLCJzY2hlbWFfdmVyc2lvbiI6
+        ci9tYW5pZmVzdHMvMTBiZmVkMDItYmFjNi00MjViLWEyMGUtZDk2N2ZhOWU3
+        ZDhjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMTI0
+        MDgxWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82Y2Zm
+        YWRkZS0yN2QzLTQ4ODEtYjU3NC0wMmExZGQxOWZhNjkvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OjFmYWFmN2E3NTMxOTQxNzI2MTI2N2IzZGNlZjZhMmIxNGM4YzUx
+        MjJkN2ZjYzdhYmViMDdhMzJiYzE5NzI4ZmQiLCJzY2hlbWFfdmVyc2lvbiI6
         MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
         YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
         XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvMzAyZDRiNjItZjFhZC00ODI5LWJhY2QtNTJmNTA0MzcwYzRm
+        ZXIvYmxvYnMvYmI4MmJkMDAtOGY3Yi00OWY4LWFhMGItZGZlZGU3NGNhNGE4
         LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9hMTFhNDk3Yy1kMDFlLTRiZjAtYjNiMy1hYTJhOWVjMWFhMTMvIl19
+        bG9icy82YTU4MDFjOC04YjNiLTQ1NWUtOGQyYi05NjUyOGIzNzliZWEvIl19
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L21hbmlmZXN0cy9kMTAwZmE1YS1lZjFkLTQ1NmQtYmU2Yy03YWYyYmE2MWU2
-        ODYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41NDAz
-        NzBaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2ZhYjgy
-        MzJiLTViYmQtNDExNC1hYjJiLWRjYzliYWRjOGEyOC8iLCJkaWdlc3QiOiJz
-        aGEyNTY6MWZhYWY3YTc1MzE5NDE3MjYxMjY3YjNkY2VmNmEyYjE0YzhjNTEy
-        MmQ3ZmNjN2FiZWIwN2EzMmJjMTk3MjhmZCIsInNjaGVtYV92ZXJzaW9uIjoy
+        L21hbmlmZXN0cy9kNzcxNjNiZi0yMTkxLTRhMzgtODE2Ni03ZjlhZTQ5NDJj
+        Y2EvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4xMjA5
+        NzVaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzg0MGE1
+        OTg2LTVhOGQtNGI5Ni04N2I3LTYxMTM5ZjFlYzUyZS8iLCJkaWdlc3QiOiJz
+        aGEyNTY6MGExMWE5NTU2OGI2ODBkY2U2OTA2YTAxNWJlZDg4MzgxZTI4YWQx
+        N2IzMWE2M2Y3ZmVjMDU3YjM1NTczMjM1YSIsInNjaGVtYV92ZXJzaW9uIjoy
         LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
         dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
         LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy8xY2U1Y2MzYi04NGMzLTQyYzktYjY0Yi1jNjEyMjhhM2NmODYv
+        ci9ibG9icy81YjQ1NjNiYS1hOTM3LTRkOTUtYjM3YS1lMTA1YjIyNDg3NTMv
         IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzgyNjQzOTg3LTZiMDQtNDE1Yi04YWIwLThlNzBkY2M0YTdhZS8iXX0s
+        b2JzL2ZiMzRmMDU5LWQxODItNDYyYS1hZDBhLTA0ZDY0YmQ2ZThmMy8iXX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        bWFuaWZlc3RzLzI0NTYyMTcxLTAzMDktNDFhYS05ODgxLTg2MDFlYzMxOTdi
-        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjUzOTA0
-        M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZWU1Y2Fj
-        NGQtZjBmYS00MDA3LWE3ZGItOTliMzIyMGZjZGViLyIsImRpZ2VzdCI6InNo
-        YTI1NjowYTExYTk1NTY4YjY4MGRjZTY5MDZhMDE1YmVkODgzODFlMjhhZDE3
-        YjMxYTYzZjdmZWMwNTdiMzU1NzMyMzVhIiwic2NoZW1hX3ZlcnNpb24iOjIs
+        bWFuaWZlc3RzLzk5Y2QyYmM0LWE1Y2UtNDhiMC05MWVkLWY3ZGQ5YjlmYTJi
+        Yy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjExODU3
+        MVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTU5ZDI4
+        ZjEtOGE3ZC00OTFlLTg1MTUtZTkxMDQ4ZDhhOWI0LyIsImRpZ2VzdCI6InNo
+        YTI1NjowNjVhNjcxNDY5N2I0YTZkMjdmYjEzYTEyODMwZjBhOWZmODFhNDA0
+        OThiZWI5ZGE0OWFkYjdjZmQ4N2IwNTRkIiwic2NoZW1hX3ZlcnNpb24iOjIs
         Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
         dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
         ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzIzZGMyNzdmLTY5ZTAtNGM0Zi1hMzk5LTNjMjE4MTM4ZWZlZC8i
+        L2Jsb2JzLzlhZDcyMTlmLTk2ODYtNGY4MS1hOGZkLWZhMTlmZjY5MTI1ZC8i
         LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvNDkxYzY4ZGQtNWI4NC00MzQ2LWEwMDUtZDFiMjc0NmQyOTMzLyJdfSx7
+        YnMvZDFjMmRmMGUtYTI2Ni00OGQxLTk3ODgtNTEzMDkzMjA4MjY0LyJdfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
-        YW5pZmVzdHMvNTljM2QzZDUtMmViMS00NTE4LThjZmEtZTJkMTQ4ZjlmODU5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNTM3NjQw
-        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84NDI0MWIy
-        Ny1iMjY0LTQyZDUtOTI4MS1iYmQ2NjYzNjViNzIvIiwiZGlnZXN0Ijoic2hh
-        MjU2OjA2NWE2NzE0Njk3YjRhNmQyN2ZiMTNhMTI4MzBmMGE5ZmY4MWE0MDQ5
-        OGJlYjlkYTQ5YWRiN2NmZDg3YjA1NGQiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        YW5pZmVzdHMvZTM3NDFjODAtZTQ1OS00ZTQ4LTkwZWEtZDMwZjMwMGYzNGQ1
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMDcyNzkw
+        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iNzJhNDUx
+        ZS01ODg0LTQwNDctYjA4Ni1lYTdlYjEzMGI0ZTUvIiwiZGlnZXN0Ijoic2hh
+        MjU2OjQyNmM4NTU3NzVmMDI2ZDNmZTc2OTg4YjcxOTM4ZjRjOWRjNjg0MGYw
+        OWMwZjI5ZDhkNGM3NWNjNDIzODUwM2IiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
         bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
         aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
         Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvMDEyY2ZhNGUtYTVjYS00MGY3LWEzOWMtYmRiODcxMTAyOTkwLyIs
+        YmxvYnMvY2NmYmU2OGMtMDAxZi00Nzk2LWI4ZDMtNGQ1M2JiZTZhNDM4LyIs
         ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy8wMTMwNDdkMS00NjJiLTQ4MGEtOTUzMC0yMjE5MDkwMmQxYWIvIl19LHsi
+        cy81ZGM5MmMxZS0zZTEyLTRmOGUtYTAxYS0zOTg5MzdhMjE1ODIvIl19LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
-        bmlmZXN0cy9kZWFhNjVlYS0yMWI5LTRjZWMtOTM3NS0xOTY5NWNlZTkxZWQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4zOTg5MDFa
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzJjOWExYzNl
-        LTcyMTYtNDE4Ni05OGMwLWJmODJkOTFhYzY5Mi8iLCJkaWdlc3QiOiJzaGEy
+        bmlmZXN0cy8wMWJkNTUxMC0zMTgwLTQ1NDYtODVhYi02ODE3YTE4NmNhYjYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi43MjQyNDla
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzBlNGIxMTRh
+        LTE1ZTAtNDkyNi04YWYwLTkwYTZlN2M5NTY3Zi8iLCJkaWdlc3QiOiJzaGEy
         NTY6ZDYzOTMzMGE0MjU0OWMwMjYyOTRiMTZmNDAzOWE3MGVmMjk0YmJiMzc3
         Y2FlZmQ5MjNlMzBkZDAxMTM1YzdkNiIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
         ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
         b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
         b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9hMTBjNTUxYy05NTU5LTQxYzQtOWQ3OC1hNzQ4MDUwYjY2ODIvIiwi
+        bG9icy9mM2U4Mjk2Mi1mOWYxLTQ3YmEtODhlOC02MDA1YzE3ODNlNzgvIiwi
         YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzFkODJkNDQzLWZkZWUtNDVmYS04NGZiLTc4MTEzNDY3ZGRjMi8iXX0seyJw
+        LzkwNjkzNDNhLThhYTUtNDJhMC04ZWQ1LWQ3NzA0YmMzMDJlMC8iXX0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFu
-        aWZlc3RzLzY1ZjkzZmZmLTI4YTgtNDU0Ni05ZmI3LTQxZDY1MDZiMjNhZC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjM5MDgxNFoi
-        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjg4ZGE1MWIt
-        NjhkOS00NDRmLTgwYjctM2IwNTJhMjk1MGZjLyIsImRpZ2VzdCI6InNoYTI1
-        NjphMTlhMDJkZTMwNWU4M2QxNGQ3Y2E0ZDQxNGQ4ZDIzNjAwYjc5NTNhMGE2
-        OTNkMmQxYzg1ZDNjZTI2ZmI3MmViIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        aWZlc3RzLzc5NWJiYTRhLTk4ZTUtNDEyOC04NTY3LTBiYzZmMzQzOThmMi8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjY1Mjg0NFoi
+        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOWQwOWEzNDgt
+        NTk3OC00NzU1LTlhMDYtZDFmYjAzNjRjNzVhLyIsImRpZ2VzdCI6InNoYTI1
+        NjpkMmNkMDI4NWVjZWE4MDlhOTk5MDY5YTk2MDc1ZTUwZGZmNzJlYTBhMWY2
+        ZTE3NGE2ZmJkMjYzMDAyNTA2MjllIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
         ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
         bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
         bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzL2JkYzA2ODEzLTIzZjgtNGYwYi1hNjNhLTJiZWEyN2M3N2I0OS8iLCJi
+        b2JzL2JkZDNlY2U0LTM5MTUtNDEyZS05MWI3LThhM2FmNDIyYWEzNi8iLCJi
         bG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        N2YwY2M1NTctNDg0Ny00MWEyLTkzZWMtNzAwMGVkYjI3Zjk3LyJdfSx7InB1
+        Yjk5Zjc5NGQtNzI1Ni00OGU4LWJiNzctYTVkZTdkZmVkM2RjLyJdfSx7InB1
         bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5p
-        ZmVzdHMvNzU1YWI3YjEtOTRiNC00NTZhLThlYTgtMmQ4MWY4M2UwMmNiLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMzE0NzUwWiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iOTFhZGFkNS02
-        OWE0LTQ2NjUtODExYi1hMjcwYWJmNDRiNWQvIiwiZGlnZXN0Ijoic2hhMjU2
-        OmQyY2QwMjg1ZWNlYTgwOWE5OTkwNjlhOTYwNzVlNTBkZmY3MmVhMGExZjZl
-        MTc0YTZmYmQyNjMwMDI1MDYyOWUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        ZmVzdHMvYWE5YmI2YmItOTQ0My00YWU1LTg2YmQtNjIzMTMzMjllMjRhLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNjUwNzA5WiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy83MzZjYzQ4Yy0z
+        OGZjLTQzNWEtYTExMS05NDYyNWU2NGRkYTEvIiwiZGlnZXN0Ijoic2hhMjU2
+        OmI0OWI5NWNjMTFmY2QxYmI3OTQzNDIxNGFlYmUxY2MxMWNkYTQyNmExYzg3
+        NjdhNTg4OWMwYjc2ODc0MjdiZjIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
         aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
         Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
         ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvNGQ1NjViMTAtYTBhYy00MDczLWJhNTctZTQzZWJlOTU3ODM1LyIsImJs
-        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9h
-        OGJlYjc5Yy1mM2I1LTQ1NzYtYjIyYi0xMDViMmZlZWY2MjcvIl19LHsicHVs
+        YnMvNjFhODRlMmQtODAxMy00ZTM1LTg4YjgtMGQ2N2Q1NzdmOTE3LyIsImJs
+        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9l
+        YTMyYjI0Mi1lNzI0LTQ2ZTQtYTE1OS00NGY3MmYwOWY3NTEvIl19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy85NWFkMmE2Mi03OGQxLTQ5YTgtYjY4ZC00ZTg5NzE4ZjRjNzgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4zMTI5MzdaIiwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzk3YzRlYTA0LWU2
-        NzktNDA4Ni1hOTQyLTcxZDhmN2ViZDAwYy8iLCJkaWdlc3QiOiJzaGEyNTY6
-        OGU4ZDY3MjUyNmM3Y2E4MThmMTg5MjI1YWU1OWVlOWFkMzUzY2IxZTJmZWM3
-        ZDAxMWI3OGVmNzBlY2Q4MDVhZSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
+        ZXN0cy8zYzY3MzlhMy1iYjhmLTQ1YjktYmNhMy0yNzQ1YjMzYzZjNGEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi42NDgzNzVaIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2EzZGZiMjc2LWNi
+        OGItNDA2OC05ZTRhLWJhN2NmMjk4ZGQ5NC8iLCJkaWdlc3QiOiJzaGEyNTY6
+        YTE5YTAyZGUzMDVlODNkMTRkN2NhNGQ0MTRkOGQyMzYwMGI3OTUzYTBhNjkz
+        ZDJkMWM4NWQzY2UyNmZiNzJlYiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
         YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
         bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
         aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy80ZjY1Yjk5Ny04MTJkLTQ5MTgtYmJmMS1lZmNiNjBiY2Q4MTgvIiwiYmxv
-        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzgw
-        Mjg0MDEyLTk0OTItNDM5Zi05YzA0LTAyMDRiNGM0MmNmZS8iXX0seyJwdWxw
+        cy9mNGNhZjlkZi05OTI4LTQ5MzctOTRhNy05OGJkZTI5MDZlMGMvIiwiYmxv
+        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzdi
+        ZDc2MzIwLWVhYjAtNDJkOS04NTdkLWU4YzA2OWFjZDFkYi8iXX0seyJwdWxw
         X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzLzAwZTc5YTE5LWI4ZjUtNDY1MS1iZjQ1LTU0YmNjNTI2ZWNlMi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjI3ODM4NFoiLCJh
-        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTA2YTFhNGUtMWRl
-        YS00ZmMyLTljNTMtZjE1Y2MzNzk4MWZiLyIsImRpZ2VzdCI6InNoYTI1Njpi
-        NDliOTVjYzExZmNkMWJiNzk0MzQyMTRhZWJlMWNjMTFjZGE0MjZhMWM4NzY3
-        YTU4ODljMGI3Njg3NDI3YmYyIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
+        c3RzL2FhMzdmOTM5LTQ3ZTctNDQ5Yi05OTBjLTFjMzgyOGIwNmRjZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjY0NjA3OVoiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjIzMDk4ZTEtMjEy
+        OC00Y2YwLTkxY2YtMGE5NzQzNWEwNDc4LyIsImRpZ2VzdCI6InNoYTI1Njo4
+        ZThkNjcyNTI2YzdjYTgxOGYxODkyMjVhZTU5ZWU5YWQzNTNjYjFlMmZlYzdk
+        MDExYjc4ZWY3MGVjZDgwNWFlIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
         X3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5t
         YW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZp
         Z19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzllZGZhYjIxLTc0NjItNGZjNy1hNDAxLTA5MzgyM2MyZmRmNC8iLCJibG9i
-        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvMGRh
-        NGEzM2MtNWZiZS00NzlhLTkzNzMtOTc1NmVhZWMyMzRiLyJdfSx7InB1bHBf
+        LzQyYWVkNWUzLWQ4ODUtNGY4Zi1hZjEyLWZjYTNiMTg3ODhlYy8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvZWMz
+        NzI1YWQtNzhlZC00NmQ0LWJmNzgtNmIwNjA1Yjg4NmM5LyJdfSx7InB1bHBf
         aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvZDljNjBjZDUtYWE5OS00OTRmLTg2ODMtNTc5MjViMGMzNTZkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMjc3MTM3WiIsImFy
-        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9jMjc2Y2Q0Zi04N2Mx
-        LTRkNTYtYjdjMC0xNjI1YzZhOWRiMDUvIiwiZGlnZXN0Ijoic2hhMjU2OjFj
+        dHMvZGY0ZGJjZTQtMTBlNy00MDZlLWEwMDYtMDA1MjU0ZjIwZWI2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNjM4Njg5WiIsImFy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80YTQzMzI0OC0xYTI5
+        LTQzZmUtOGFiOC00MTM2MTc5OTM5MDUvIiwiZGlnZXN0Ijoic2hhMjU2OjFj
         ZWU4NzI3ZmIxNWEzYzNlMzg5ZWIwYmU5NTc0MGY2NmY3OWIzZWRkYzU3ZDJi
         M2Q5NjhmYjhhMDQ2ZmM3NmEiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
         dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
         bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
         X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        YzhmYTk2NDUtNWQyMy00NjAzLTk5ZTAtN2VlNWMyZTY1MWQ0LyIsImJsb2Jz
-        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy8xMjkx
-        NGNjYy0yYTkwLTRiMTAtOWZmZi1mOTY1NDI5YTI1ZDEvIl19LHsicHVscF9o
+        YTVhMzI0ZjgtZjQyNC00YmY5LTgyYjctOWFkMGY3YWQ4MjA5LyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9jYzA2
+        YzI2Ny05NmI2LTQ3ZmQtYjM4YS1hYTEzMjgyNTc4ODUvIl19LHsicHVscF9o
         cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0
-        cy9jZmQyY2EwOC1lYTI5LTRjOTctYWMyZi00ZDE4YmM5MWNhNDgvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4xOTY5ODBaIiwiYXJ0
-        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzA3N2FhOGY2LTU2MGUt
-        NDM3MC04MjcyLTA5MzFmZWU1MzcwMi8iLCJkaWdlc3QiOiJzaGEyNTY6OTU4
+        cy9hMWI0NDFhZS1lYjAwLTQwNWUtYjczNy02ZTA4MjVlMDIyNTUvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi40MTMyMzhaIiwiYXJ0
+        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2JjM2EwZDI2LWYzZjYt
+        NDY3ZS1hMzBiLWFhN2JiYTc1Nzg1OC8iLCJkaWdlc3QiOiJzaGEyNTY6OTU4
         ZTQzM2JjZmE2YzNmYWFjZGNiYmUyMDU4NjBjOGFlNDQ3NGQ5Yzg2NWY5MzJj
         OTE4MjdmMmUyOTJiOTJkYyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
         eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFu
         aWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdf
-        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy85
-        NzRmMTE5OC02ZDExLTRmOTctYjQ5MC05ZDkyOGM5MzM1MjUvIiwiYmxvYnMi
-        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzg0NWM0
-        ZWYyLTFhMTgtNGE1NS05NjI2LWVmNjRlN2M5NmI4MC8iXX1dfQ==
+        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy83
+        ZDA3YzczOC0wZjUxLTRjOGQtOWYyNS0xMDBmNWEwZWViNDIvIiwiYmxvYnMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzljNTZl
+        YjFmLWJkYTUtNGUxMC1hZDdlLTc2YWNiOTI1YTEzNi8iXX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/d046bbbe-9295-4c64-8b79-9df2296e00dc/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/b05b9638-0d49-4592-8028-d41654e2abe9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2674,7 +3196,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2687,85 +3209,85 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:19 GMT
+      - Fri, 29 Jul 2022 09:03:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2146'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eadfa43e459543c2ba194d0efcb156a4
+      - dce7d4d1fe8f42a8a0ad494b43ee7c20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '822'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvNWI2ODFlYTUtMzE1MC00OTQ4LWE3YTMtMzQ2YTNk
-        N2Q0MDdlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMu
-        MTk1NjI4WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        Y2Y4YmJmMC1jMDc1LTRmYzAtOTgyYi1hMDJjNTFhMmZhYmUvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvNWIzNmY2MjgtNTU1Yi00MzgwLTg2ODYtYzlhMDNk
+        Njk0YjM4LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIu
+        NDExMTI4WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85
+        YjQwNjk2MS05OTAwLTRmM2QtYjQxYi1iMjZlNmJiZGIyZWUvIiwiZGlnZXN0
         Ijoic2hhMjU2OjMwZDE0MTJjMGY0NWJlNjdkMzhiOTkxNzk4NjY4NjhiMWYw
         OWZkOTAxM2NiYWNmMjI4MTM5MjZhZWU0MjhjZjciLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
         ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy80NmFmYzJiYS0zMDYwLTQ0Y2ItOTg1Mi0zY2U1NzExY2E0YzAvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8yNDU2
-        MjE3MS0wMzA5LTQxYWEtOTg4MS04NjAxZWMzMTk3YmUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kZTk1OTNkNy1kMTA1
-        LTQ4YTUtYWIzOS05NDk1MjAwOTE4ODgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy9jOWQ5ZGNmYS0yYWQ2LTRjZDItYjRj
-        Ny04YTBmNDljZjIyMTMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy9jODJiMDZiMi1mY2JjLTRhYzctYTQ0OC00NWRhZjM1
-        N2ZmZGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy81OWMzZDNkNS0yZWIxLTQ1MTgtOGNmYS1lMmQxNDhmOWY4NTkvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kMTAw
-        ZmE1YS1lZjFkLTQ1NmQtYmU2Yy03YWYyYmE2MWU2ODYvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy81Y2NjODkwNy0wNDQ3
-        LTQwMGEtYjUxOS01YWRmNzUzOTU0Y2YvIl0sImNvbmZpZ19ibG9iIjpudWxs
+        ZXN0cy9lMzc0MWM4MC1lNDU5LTRlNDgtOTBlYS1kMzBmMzAwZjM0ZDUvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy85OWNk
+        MmJjNC1hNWNlLTQ4YjAtOTFlZC1mN2RkOWI5ZmEyYmMvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kNzcxNjNiZi0yMTkx
+        LTRhMzgtODE2Ni03ZjlhZTQ5NDJjY2EvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy8xMGJmZWQwMi1iYWM2LTQyNWItYTIw
+        ZS1kOTY3ZmE5ZTdkOGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy85MmI2MmFmOS1kNWIyLTRmYzYtODJmYS00MzM2MDJk
+        OTI2YmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9hYjIzODczOC1kZWZiLTRiMDItYjk5ZC01Y2NlYjRiYjdmMDUvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy80MzA2
+        MWFhNC01ODlkLTQ4YzMtOGQ0Yy01OTM3YWRlYzhjOTMvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9mM2I0NGU2OC03MGRl
+        LTQwMDYtOGZkOS02OTVkOTliMTFkODQvIl0sImNvbmZpZ19ibG9iIjpudWxs
         LCJibG9icyI6W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy9jOWI4M2U2Yy01NTZhLTQwZWMtYmJl
-        NC0xMTVkZWYxODEyMDMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxODoxMy4xOTMzNzNaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
-        aWZhY3RzLzFiMWRmMTEyLWFjZGQtNDQyZi1iODFlLWI3MzJlMDkxYjlkOS8i
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy82YzUxZjE5My05NTk0LTQ3MDItYTM2
+        Ny1hNWFjNzE4NTE0ZDUvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        Njo1NDozMi40MDc4NTVaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzL2M3MzNhNDE4LTRlMDUtNDE1OS1hYmUwLTI0YmEzODJkMWQ0NS8i
         LCJkaWdlc3QiOiJzaGEyNTY6MjI2Mzc3NTdmMmQwZjhlMjBiNzRlM2VmMjI2
         ZWVkZDBiZGY4ODAyY2M3NGFlNThiNmU2MzE2ODU3ZDNiZGU1NiIsInNjaGVt
         YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
         Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlz
         dGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzL2NmZDJjYTA4LWVhMjktNGM5Ny1hYzJmLTRkMThiYzkx
-        Y2E0OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2Q5YzYwY2Q1LWFhOTktNDk0Zi04NjgzLTU3OTI1YjBjMzU2ZC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzAwZTc5
-        YTE5LWI4ZjUtNDY1MS1iZjQ1LTU0YmNjNTI2ZWNlMi8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk1YWQyYTYyLTc4ZDEt
-        NDlhOC1iNjhkLTRlODk3MThmNGM3OC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzLzc1NWFiN2IxLTk0YjQtNDU2YS04ZWE4
-        LTJkODFmODNlMDJjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzY1ZjkzZmZmLTI4YTgtNDU0Ni05ZmI3LTQxZDY1MDZi
-        MjNhZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2RlYWE2NWVhLTIxYjktNGNlYy05Mzc1LTE5Njk1Y2VlOTFlZC8iXSwi
+        ZXIvbWFuaWZlc3RzL2ExYjQ0MWFlLWViMDAtNDA1ZS1iNzM3LTZlMDgyNWUw
+        MjI1NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzL2RmNGRiY2U0LTEwZTctNDA2ZS1hMDA2LTAwNTI1NGYyMGViNi8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2FhMzdm
+        OTM5LTQ3ZTctNDQ5Yi05OTBjLTFjMzgyOGIwNmRjZS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzNjNjczOWEzLWJiOGYt
+        NDViOS1iY2EzLTI3NDViMzNjNmM0YS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzL2FhOWJiNmJiLTk0NDMtNGFlNS04NmJk
+        LTYyMzEzMzI5ZTI0YS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzc5NWJiYTRhLTk4ZTUtNDEyOC04NTY3LTBiYzZmMzQz
+        OThmMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzLzAxYmQ1NTEwLTMxODAtNDU0Ni04NWFiLTY4MTdhMTg2Y2FiNi8iXSwi
         Y29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/d046bbbe-9295-4c64-8b79-9df2296e00dc/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/b05b9638-0d49-4592-8028-d41654e2abe9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2773,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2786,45 +3308,45 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:19 GMT
+      - Fri, 29 Jul 2022 09:03:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '548'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d2ecf34de53b46df87c95c568e64211a
+      - 33e3976c0e8a4b3ca0b38b99ba1bbfb8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '287'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2MyZWY0M2YyLTdiMTktNDg4Ny04ZGQ4LTQ1MTg1MjgyMjlh
-        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjE1Ljk5NjQx
-        OFoiLCJuYW1lIjoibXVzbCIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYzliODNlNmMtNTU2
-        YS00MGVjLWJiZTQtMTE1ZGVmMTgxMjAzLyJ9LHsicHVscF9ocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvYjFmNDYzZmItMDQy
-        Ny00NzliLTlhNDYtMWFjMmJlYjBjMDIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTUuOTk0MDI4WiIsIm5hbWUiOiJnbGliYyIsInRh
+        aW5lci90YWdzL2I3M2NiMmVlLTIwZGItNDE2NS1hNWMzLTUwNGFhNjkxY2Ew
+        Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjQyLjA3NDM2
+        MVoiLCJuYW1lIjoibXVzbCIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNmM1MWYxOTMtOTU5
+        NC00NzAyLWEzNjctYTVhYzcxODUxNGQ1LyJ9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvOGI3ODkzYjEtZGIx
+        YS00MTg3LThmMTYtMTkzN2RlZDY4YjY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTY6NTQ6NDIuMDY4NjU5WiIsIm5hbWUiOiJnbGliYyIsInRh
         Z2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNWI2ODFlYTUtMzE1MC00OTQ4LWE3YTMtMzQ2YTNkN2Q0
-        MDdlLyJ9XX0=
+        ci9tYW5pZmVzdHMvNWIzNmY2MjgtNTU1Yi00MzgwLTg2ODYtYzlhMDNkNjk0
+        YjM4LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:19 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:20 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_units_docker_repository/inclusion_docker_filters.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_units_docker_repository/inclusion_docker_filters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,50 +23,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:20 GMT
+      - Fri, 29 Jul 2022 09:03:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '555'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 771cc0de6cb64d8bb1488a1b526ebbac
+      - f7334965b8e94434bc179a1506c0cda9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '268'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9mMjUyODJmZi01MmJlLTRjZDQtYjYwMi02
-        NDQ2MjdjODg0YjYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        ODoxMS4zOTA2NzdaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mMjUyODJmZi01MmJl
-        LTRjZDQtYjYwMi02NDQ2MjdjODg0YjYvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        Y29udGFpbmVyL2NvbnRhaW5lci9jNjhhNWQ4Ny1kOTNiLTQyZTgtOGE4My1h
+        OTQxMWJlNWNjNTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTow
+        MzoxMS4wNjU4MjhaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9jNjhhNWQ4Ny1kOTNi
+        LTQyZTgtOGE4My1hOTQxMWJlNWNjNTAvdmVyc2lvbnMvIiwicHVscF9sYWJl
         bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2YyNTI4MmZmLTUyYmUt
-        NGNkNC1iNjAyLTY0NDYyN2M4ODRiNi92ZXJzaW9ucy8xLyIsIm5hbWUiOiJE
+        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2M2OGE1ZDg3LWQ5M2It
+        NDJlOC04YTgzLWE5NDExYmU1Y2M1MC92ZXJzaW9ucy8xLyIsIm5hbWUiOiJE
         ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsImRl
         c2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwi
         cmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:22 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/f25282ff-52be-4cd4-b602-644627c884b6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/c68a5d87-d93b-42e8-8a83-a9411be5cc50/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -87,7 +87,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:20 GMT
+      - Fri, 29 Jul 2022 09:03:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -105,21 +105,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1954585fe8b34345a1becc18f83e1979
+      - 2dc2bf0243c547b99aedeb692bb984d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FhMGJiMTMzLWY5ZDctNGM4
-        ZC04YTJhLWIxYWIzNzQ0NzViOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkNjY1NjI3LWM3MTYtNDY0
+        NC04MmQ0LWMzNmIyY2UyY2ViYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:20 GMT
+      - Fri, 29 Jul 2022 09:03:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -158,21 +158,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3892a18a7ac04b858d39514b38bbe82b
+      - 61be810594d04f3791e455726018c961
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/aa0bb133-f9d7-4c8d-8a2a-b1ab374475b8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6d665627-c716-4644-82d4-c36b2ce2cebb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -193,51 +193,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:20 GMT
+      - Fri, 29 Jul 2022 09:03:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '619'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d220e540e7b4774bffac9b2da3fdb81
+      - eb4423b6002b466aad309a082b2a2bb7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWEwYmIxMzMtZjlk
-        Ny00YzhkLThhMmEtYjFhYjM3NDQ3NWI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjAuNDkyMTIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmQ2NjU2MjctYzcx
+        Ni00NjQ0LTgyZDQtYzM2YjJjZTJjZWJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MjIuMjQ5NjIwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxOTU0NTg1ZmU4YjM0MzQ1YTFiZWNjMThm
-        ODNlMTk3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE4OjIwLjUy
-        NTY1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTg6MjAuNjAx
-        MTE4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyZGMyYmYwMjQzYzU0N2I5OWFlZGViNjky
+        YmI5ODRkMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjIyLjMw
+        MzgwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MjIuNDIy
+        NDMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZjI1Mjgy
-        ZmYtNTJiZS00Y2Q0LWI2MDItNjQ0NjI3Yzg4NGI2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYzY4YTVk
+        ODctZDkzYi00MmU4LThhODMtYTk0MTFiZTVjYzUwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -245,7 +245,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -258,7 +258,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:20 GMT
+      - Fri, 29 Jul 2022 09:03:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -276,21 +276,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff55a1305f0e411ca55c95a5654b2a66
+      - ea30926810d340bf9fdf88ee443876cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -298,7 +298,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -311,53 +311,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:20 GMT
+      - Fri, 29 Jul 2022 09:03:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '691'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ee313f3921c948eda47a4f2301263dec
+      - ce3a63479a6e423bb1bee6fa5c07ad71
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '409'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2NvbnRhaW5lci9jb250YWluZXIvYWIxZDZjNDItMzRkYS00YjljLThmNDMt
-        YjFjMGY3ZGE2NDA1LyIsImNvbnRlbnRfZ3VhcmQiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudGd1YXJkcy9jb250YWluZXIvY29udGVudF9yZWRpcmVjdC9jMTk4
-        YzVkNS1lYWJiLTQzMTMtYjE3MS0zNDNjNjM4N2M4ZDYvIiwibmFtZSI6IkRl
-        ZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1kZXYiLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjE3LjQ1NzA2MVoiLCJyZXBvc2l0
-        b3J5IjpudWxsLCJiYXNlX3BhdGgiOiJlbXB0eV9vcmdhbml6YXRpb24tcHVw
-        cGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfbGFiZWxzIjp7fSwicmVwb3Np
+        dHMiOlt7ImJhc2VfcGF0aCI6ImVtcHR5X29yZ2FuaXphdGlvbi1wdXBwZXRf
+        cHJvZHVjdC1idXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rp
+        c3RyaWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci9lYzJlMjQxNy1iM2My
+        LTRlYTYtYmZiZS1hMTBhZjA4YWJlNTMvIiwicmVwb3NpdG9yeSI6bnVsbCwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTowMzoxNy44MTcxNjNaIiwi
+        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1kZXYi
+        LCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y29udGFpbmVyL2NvbnRlbnRfcmVkaXJlY3QvODY3MDMzYmYtOTIyNi00ODg4
+        LWI5YjMtZTYwMGZlYjhhMmJjLyIsInB1bHBfbGFiZWxzIjp7fSwicmVwb3Np
         dG9yeV92ZXJzaW9uIjpudWxsLCJyZWdpc3RyeV9wYXRoIjoiY2VudG9zOC1r
-        YXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9lbXB0eV9vcmdh
-        bml6YXRpb24tcHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsIm5hbWVzcGFjZSI6
-        Ii9wdWxwL2FwaS92My9wdWxwX2NvbnRhaW5lci9uYW1lc3BhY2VzL2U2NzI4
-        YWEwLTFmMzctNDk2ZS04YzgwLThhYTkyNGViMjI4YS8iLCJwcml2YXRlIjpm
-        YWxzZSwiZGVzY3JpcHRpb24iOm51bGx9XX0=
+        YXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL2VtcHR5X29yZ2FuaXphdGlvbi1w
+        dXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZXNwYWNlIjoiL3B1bHAvYXBp
+        L3YzL3B1bHBfY29udGFpbmVyL25hbWVzcGFjZXMvODAwZDllMDUtZDIzNC00
+        M2U4LWI0YzUtZmIyOTgzNDc5ZDVkLyIsInByaXZhdGUiOmZhbHNlLCJkZXNj
+        cmlwdGlvbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:22 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/ab1d6c42-34da-4b9c-8f43-b1c0f7da6405/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/ec2e2417-b3c2-4ea6-bfbe-a10af08abe53/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -365,7 +365,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -378,7 +378,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:20 GMT
+      - Fri, 29 Jul 2022 09:03:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -396,21 +396,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 393775165aba41c58909823b763a2a28
+      - ff1fa0b952a54289a8f6e1de2e77229a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViZDIwNmE3LTVmMWMtNGRl
-        Ny1iOTQxLTBhNjhlYmE5ZDAxYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg3NDRiZTZmLTQwMWQtNDhl
+        Ni04YTQ2LWI0ZWM0YWI1ZjIzMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:20 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ebd206a7-5f1c-4de7-b941-0a68eba9d01a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8744be6f-401d-48e6-8a46-b4ec4ab5f232/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -431,51 +431,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '626'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 777caacd07d7445fa8ed45040920f77b
+      - 51bc0f99f50448918a98a29da146d951
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '384'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWJkMjA2YTctNWYx
-        Yy00ZGU3LWI5NDEtMGE2OGViYTlkMDFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjAuOTMwMDYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODc0NGJlNmYtNDAx
+        ZC00OGU2LThhNDYtYjRlYzRhYjVmMjMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MjIuNzM5MjI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfbXVs
-        dGlfZGVsZXRlIiwibG9nZ2luZ19jaWQiOiIzOTM3NzUxNjVhYmE0MWM1ODkw
-        OTgyM2I3NjNhMmEyOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE4
-        OjIwLjk2NDY2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTg6
-        MjEuMDA4NTQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        dGlfZGVsZXRlIiwibG9nZ2luZ19jaWQiOiJmZjFmYTBiOTUyYTU0Mjg5YThm
+        NmUxZGUyZTc3MjI5YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAz
+        OjIyLjc4NDIyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6
+        MjIuODM4NjI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
         cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9jb250YWluZXIvY29udGFpbmVy
-        L2FiMWQ2YzQyLTM0ZGEtNGI5Yy04ZjQzLWIxYzBmN2RhNjQwNS8iXX0=
+        L2VjMmUyNDE3LWIzYzItNGVhNi1iZmJlLWExMGFmMDhhYmU1My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -483,7 +483,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -496,7 +496,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -514,21 +514,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b1439ab588547218cb999c780d83cad
+      - abc413db720841928210636aa2cfcef1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -536,7 +536,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -549,7 +549,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -567,21 +567,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21fa77484e224f5ba64581fed33868e6
+      - d0540696fa5a49e895ebfab5ea609d40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -589,7 +589,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -602,7 +602,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -620,21 +620,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9a1bab1822ed4813b7b7467de9276d18
+      - 27fb560356ac48d982de8288321bec86
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -642,7 +642,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -655,7 +655,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -673,21 +673,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bebc1f3fe04041c8864797c7995d824f
+      - 60d5d7630c2c458bb62edd6641361e10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -705,7 +705,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -718,13 +718,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/e4484b60-1f98-4e54-9ec3-eb24d9ff1700/"
+      - "/pulp/api/v3/remotes/container/container/8f6e7ad9-6655-4bb7-9de5-4ec4d16734af/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -738,22 +738,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 69e5182dd83a45cc8bad17ab44868d39
+      - 5161957d2c4a4e12bb7a89f9aad8adfa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyL2U0NDg0YjYwLTFmOTgtNGU1NC05ZWMzLWViMjRkOWZmMTcw
-        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjIxLjQyNjc1
-        NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyLzhmNmU3YWQ5LTY2NTUtNGJiNy05ZGU1LTRlYzRkMTY3MzRh
+        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAzOjIzLjMxODA1
+        MFoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3F1YXkuaW8iLCJjYV9jZXJ0Ijpu
         dWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUs
         InByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3Rf
-        dXBkYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MjEuNDI2NzgyWiIsImRvd25s
+        dXBkYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MjMuMzE4MDc0WiIsImRvd25s
         b2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9s
         aWN5IjoiaW1tZWRpYXRlIiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25u
         ZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4w
@@ -762,10 +762,10 @@ http_interactions:
         LCJpbmNsdWRlX3RhZ3MiOlsibGF0ZXN0IiwiZ2xpYmMiLCJtdXNsIl0sImV4
         Y2x1ZGVfdGFncyI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -775,7 +775,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -788,13 +788,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/1b1f93b5-9840-4a33-80da-7d520f5b41f4/"
+      - "/pulp/api/v3/repositories/container/container/06b388ce-f77d-4453-a962-035a777f61ba/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -808,31 +808,31 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1811d04f8d2407e82d0c2c7ffb94091
+      - 5247e27f67fd4071816233e98d93f33d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMWIxZjkzYjUtOTg0MC00YTMzLTgwZGEtN2Q1MjBm
-        NWI0MWY0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MjEu
-        NTY1MTI5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMWIxZjkzYjUtOTg0MC00YTMz
-        LTgwZGEtN2Q1MjBmNWI0MWY0L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
+        aW5lci9jb250YWluZXIvMDZiMzg4Y2UtZjc3ZC00NDUzLWE5NjItMDM1YTc3
+        N2Y2MWJhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MjMu
+        NDk3NzgzWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDZiMzg4Y2UtZjc3ZC00NDUz
+        LWE5NjItMDM1YTc3N2Y2MWJhL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
         fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8xYjFmOTNiNS05ODQwLTRhMzMt
-        ODBkYS03ZDUyMGY1YjQxZjQvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
+        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8wNmIzODhjZS1mNzdkLTQ0NTMt
+        YTk2Mi0wMzVhNzc3ZjYxYmEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
         dF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlw
         dGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90
         ZSI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -840,7 +840,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -853,50 +853,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '551'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 30d7a590feae4eddb3e07efbd9f3d524
+      - 4fde94b57c7c422da0cb3bb797a28cc5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '264'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kMDQ2YmJiZS05Mjk1LTRjNjQtOGI3OS05
-        ZGYyMjk2ZTAwZGMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        ODoxMS45MzEzNDhaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kMDQ2YmJiZS05Mjk1
-        LTRjNjQtOGI3OS05ZGYyMjk2ZTAwZGMvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        Y29udGFpbmVyL2NvbnRhaW5lci9iMDViOTYzOC0wZDQ5LTQ1OTItODAyOC1k
+        NDE2NTRlMmFiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOTow
+        MzoxMi4wOTk4NDZaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iMDViOTYzOC0wZDQ5
+        LTQ1OTItODAyOC1kNDE2NTRlMmFiZTkvdmVyc2lvbnMvIiwicHVscF9sYWJl
         bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2QwNDZiYmJlLTkyOTUt
-        NGM2NC04Yjc5LTlkZjIyOTZlMDBkYy92ZXJzaW9ucy8xLyIsIm5hbWUiOiJE
+        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2IwNWI5NjM4LTBkNDkt
+        NDU5Mi04MDI4LWQ0MTY1NGUyYWJlOS92ZXJzaW9ucy8xLyIsIm5hbWUiOiJE
         ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
         cHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1v
         dGUiOm51bGx9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/d046bbbe-9295-4c64-8b79-9df2296e00dc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/b05b9638-0d49-4592-8028-d41654e2abe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -904,7 +904,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -917,7 +917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -935,21 +935,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57fed6cae4144ce6aed2a9537447e5e4
+      - 68aa9052f65145e990871eceb5f28587
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1YzgzNzk2LTA4MGUtNDkz
-        Ni05ZWE5LTlmM2QwMDQxYTBmOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FhMjkwYWFjLWUyNTQtNDc3
+        Yi04ODFiLTk5ZDM5MmIzYmIzOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -957,7 +957,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -970,41 +970,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '695'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dce1a064ba9e4cceb8a2f46e2abfc0f6
+      - dc24d1b964e74c258080aaa42fd14bcf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '416'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMmUzYjBlNzgtZWNiNi00ZTdmLWI1ZDYtZmVkYjUx
-        YjNhNjdmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTEu
-        MTg4Njk1WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        aW5lci9jb250YWluZXIvYzJjMDJjYzctNmYzZC00YTI3LTkyOGYtNGIyMjBj
+        MzIyMDdkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MTAu
+        ODgwMTUzWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
         c3lib3gtZGV2IiwidXJsIjoiaHR0cHM6Ly9xdWF5LmlvIiwiY2FfY2VydCI6
         bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVl
         LCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0
-        X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEyLjI5MjkwOVoiLCJkb3du
+        X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA5OjAzOjEyLjcyMTY5NFoiLCJkb3du
         bG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBv
         bGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29u
         bmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAu
@@ -1013,10 +1013,10 @@ http_interactions:
         IiwiaW5jbHVkZV90YWdzIjpbImxhdGVzdCIsImdsaWJjIiwibXVzbCJdLCJl
         eGNsdWRlX3RhZ3MiOm51bGx9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/2e3b0e78-ecb6-4e7f-b5d6-fedb51b3a67f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/c2c02cc7-6f3d-4a27-928f-4b220c32207d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1024,7 +1024,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1037,7 +1037,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1055,21 +1055,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eebb4fec68474d66bb6f4d98aba8bcb8
+      - 90a8fedaafec421789102a112e766241
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1NzUyYjljLThmZDgtNDhk
-        OS1iNTYyLTkxNzBlNDZjMzM0Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmYmVlMjc2LWViN2EtNDVk
+        MS04M2UxLTI4NmQxMzExOGRlOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/35c83796-080e-4936-9ea9-9f3d0041a0f9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/aa290aac-e254-477b-881b-99d392b3bb38/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1090,51 +1090,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:21 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '619'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73a6a61559b3498da8b401264a5f39a0
+      - df3522d46dda474ba45079bb85060b9e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzVjODM3OTYtMDgw
-        ZS00OTM2LTllYTktOWYzZDAwNDFhMGY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjEuNzczMTgyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWEyOTBhYWMtZTI1
+        NC00NzdiLTg4MWItOTlkMzkyYjNiYjM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MjMuNzg0ODQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1N2ZlZDZjYWU0MTQ0Y2U2YWVkMmE5NTM3
-        NDQ3ZTVlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE4OjIxLjgw
-        NjUxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTg6MjEuODc4
-        ODUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2OGFhOTA1MmY2NTE0NWU5OTA4NzFlY2Vi
+        NWYyODU4NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjIzLjgy
+        MzEwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MjMuOTE3
+        NjAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZDA0NmJi
-        YmUtOTI5NS00YzY0LThiNzktOWRmMjI5NmUwMGRjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjA1Yjk2
+        MzgtMGQ0OS00NTkyLTgwMjgtZDQxNjU0ZTJhYmU5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:21 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/95752b9c-8fd8-48d9-b562-9170e46c3346/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6fbee276-eb7a-45d1-83e1-286d13118de9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1155,51 +1155,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '614'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c6e5ba90017d459e9cea241058705361
+      - 996d51ccaae8418fbb6fb5e2791e7b24
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTU3NTJiOWMtOGZk
-        OC00OGQ5LWI1NjItOTE3MGU0NmMzMzQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjEuODkyODc3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmZiZWUyNzYtZWI3
+        YS00NWQxLTgzZTEtMjg2ZDEzMTE4ZGU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MjMuOTE4MTMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlZWJiNGZlYzY4NDc0ZDY2YmI2ZjRkOThh
-        YmE4YmNiOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE4OjIxLjky
-        NTQxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTg6MjEuOTc1
-        NTQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5MGE4ZmVkYWFmZWM0MjE3ODkxMDJhMTEy
+        ZTc2NjI0MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjIzLjk3
+        MzY3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MjQuMDM5
+        Mjk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzJlM2IwZTc4LWVj
-        YjYtNGU3Zi1iNWQ2LWZlZGI1MWIzYTY3Zi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyL2MyYzAyY2M3LTZm
+        M2QtNGEyNy05MjhmLTRiMjIwYzMyMjA3ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1207,7 +1207,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1220,7 +1220,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1238,21 +1238,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f2fb80b6c8a4b6b8af9e05f2d7e2e9f
+      - f609da5913bb4e6ba0a762e842c2de1d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1260,7 +1260,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1273,7 +1273,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1291,21 +1291,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 61137300d6eb4488ad4b229db3e643cb
+      - e8fb07ca821e4b0294f3af4b90d2fe4d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1313,7 +1313,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1326,7 +1326,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1344,21 +1344,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9b6dc653d6f4b2db6b830bf03a97e4f
+      - c1849bc11cfb4265bda621058ad42662
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1366,7 +1366,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1379,7 +1379,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1397,21 +1397,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f58a8a3f6934ee9bcf96e6dd8fa11f3
+      - 3e1d2b3d1b8b49c698f290d9ddc7b304
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1419,7 +1419,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1432,7 +1432,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1450,21 +1450,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7554542cd86a45bc83d618030d1d501d
+      - aae1412f7a6340daa6c10900e6606d42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1472,7 +1472,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1485,7 +1485,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1503,21 +1503,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9a76fd0116704c84aea00eab41adbc46
+      - 9d452b0851844f7995a9f1e4957df774
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1527,7 +1527,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1540,13 +1540,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/06e67c5b-db38-4ae8-8620-59501c5088af/"
+      - "/pulp/api/v3/repositories/container/container/b403306b-d772-48d8-981a-c24a12ff2d76/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1560,31 +1560,31 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c070b7a017f4c29b88b7f16deb88784
+      - 87f150e898d94b4fb3ae2107d5b2fb09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMDZlNjdjNWItZGIzOC00YWU4LTg2MjAtNTk1MDFj
-        NTA4OGFmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MjIu
-        MzY2ODA0WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDZlNjdjNWItZGIzOC00YWU4
-        LTg2MjAtNTk1MDFjNTA4OGFmL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
+        aW5lci9jb250YWluZXIvYjQwMzMwNmItZDc3Mi00OGQ4LTk4MWEtYzI0YTEy
+        ZmYyZDc2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MjQu
+        NTQ5NzkxWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjQwMzMwNmItZDc3Mi00OGQ4
+        LTk4MWEtYzI0YTEyZmYyZDc2L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
         fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8wNmU2N2M1Yi1kYjM4LTRhZTgt
-        ODYyMC01OTUwMWM1MDg4YWYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
+        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iNDAzMzA2Yi1kNzcyLTQ4ZDgt
+        OTgxYS1jMjRhMTJmZjJkNzYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
         dF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWRldiIsImRlc2NyaXB0aW9u
         IjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpu
         dWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/container/container/e4484b60-1f98-4e54-9ec3-eb24d9ff1700/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/container/container/8f6e7ad9-6655-4bb7-9de5-4ec4d16734af/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1603,7 +1603,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1616,7 +1616,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1634,21 +1634,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 314c6e9d13494d5c9271375870ea97a7
+      - b6bdeedb37474736b7ea0107651bd3c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4YjIyZTliLTM5MjQtNGUz
-        MC1iMTY4LWY5ZGZjNzRiZjgzNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiZmUzYjEzLWFhYzAtNDky
+        MC1hMTAyLTQ4YWIxNjBkYTI5Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/58b22e9b-3924-4e30-b168-f9dfc74bf834/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0bfe3b13-aac0-4920-a102-48ab160da29b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1669,62 +1669,62 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:22 GMT
+      - Fri, 29 Jul 2022 09:03:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '614'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9f43e8ddc2bd4267a1a24a6899d1a861
+      - 6c2c913735d649e98302e1e5b9c03a22
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNThiMjJlOWItMzky
-        NC00ZTMwLWIxNjgtZjlkZmM3NGJmODM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjIuODY3NTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGJmZTNiMTMtYWFj
+        MC00OTIwLWExMDItNDhhYjE2MGRhMjliLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MjQuOTUxNTk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIzMTRjNmU5ZDEzNDk0ZDVjOTI3MTM3NTg3
-        MGVhOTdhNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE4OjIyLjkw
-        MjM1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTg6MjIuOTI4
-        MjU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiNmJkZWVkYjM3NDc0NzM2YjdlYTAxMDc2
+        NTFiZDNjNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjI0Ljk5
+        MjcxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MjUuMDE4
+        NjMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyL2U0NDg0YjYwLTFm
-        OTgtNGU1NC05ZWMzLWViMjRkOWZmMTcwMC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzhmNmU3YWQ5LTY2
+        NTUtNGJiNy05ZGU1LTRlYzRkMTY3MzRhZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:22 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:25 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/1b1f93b5-9840-4a33-80da-7d520f5b41f4/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/06b388ce-f77d-4453-a962-035a777f61ba/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyL2U0NDg0YjYwLTFmOTgtNGU1NC05ZWMzLWViMjRkOWZmMTcwMC8i
+        dGFpbmVyLzhmNmU3YWQ5LTY2NTUtNGJiNy05ZGU1LTRlYzRkMTY3MzRhZi8i
         LCJtaXJyb3IiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1737,7 +1737,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:23 GMT
+      - Fri, 29 Jul 2022 09:03:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1755,21 +1755,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c5a731d07182423fae1dd0aa9bd627f6
+      - 3f395c684221488bba67550d7e82aa8b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgwZDQwMmRmLWM1YmUtNDA3
-        ZS1hYzQ1LTkzYTY1YmUxMDZiMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E4MGQ2YTRhLWNiODAtNGM3
+        MC1hMDc5LTU4ODcxZmU2YjcxNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:23 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/80d402df-c5be-407e-ac45-93a65be106b1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a80d6a4a-cb80-4c70-a079-58871fe6b717/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1790,69 +1790,69 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:25 GMT
+      - Fri, 29 Jul 2022 09:03:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1420'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1651bc1b651c413ab7e4b08a3180ba3d
+      - 9e2f5e53f8464858922985bac241cd30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '583'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODBkNDAyZGYtYzVi
-        ZS00MDdlLWFjNDUtOTNhNjViZTEwNmIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjMuMDYwMDcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTgwZDZhNGEtY2I4
+        MC00YzcwLWEwNzktNTg4NzFmZTZiNzE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MjUuMTI4NTI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsImxvZ2dpbmdfY2lkIjoiYzVhNzMxZDA3MTgyNDIz
-        ZmFlMWRkMGFhOWJkNjI3ZjYiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1Qy
-        MzoxODoyMy4wOTY5ODRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIz
-        OjE4OjI1LjAyMDgwOVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4Nzgw
-        ZDI5MDUxLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
+        ZS5zeW5jaHJvbml6ZSIsImxvZ2dpbmdfY2lkIjoiM2YzOTVjNjg0MjIxNDg4
+        YmJhNjc1NTBkN2U4MmFhOGIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQw
+        OTowMzoyNS4xNjUzNTZaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDA5
+        OjAzOjI4Ljc0NzQzNloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJi
+        MzdjOWQwLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
         InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3Nh
-        Z2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoic3luYy5wcm9jZXNzaW5n
-        LnRhZyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxp
-        c3QiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy50YWdfbGlzdCIsInN0YXRl
-        IjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVs
-        bH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwiY29kZSI6
-        InN5bmMuZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0
-        ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MjQsInN1ZmZpeCI6bnVsbH0seyJt
-        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lh
-        dGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVs
-        bCwiZG9uZSI6NzQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNz
+        Z2UiOiJEb3dubG9hZGluZyB0YWcgbGlzdCIsImNvZGUiOiJzeW5jLmRvd25s
+        b2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9h
+        ZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRp
+        ZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
+        IjoyNCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBD
+        b250ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo3Miwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoic3lu
+        Yy5wcm9jZXNzaW5nLnRhZyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNz
         b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRl
         bnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjow
         LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzFiMWY5
-        M2I1LTk4NDAtNGEzMy04MGRhLTdkNTIwZjViNDFmNC92ZXJzaW9ucy8xLyJd
+        YXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzA2YjM4
+        OGNlLWY3N2QtNDQ1My1hOTYyLTAzNWE3NzdmNjFiYS92ZXJzaW9ucy8xLyJd
         LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8xYjFmOTNiNS05ODQw
-        LTRhMzMtODBkYS03ZDUyMGY1YjQxZjQvIiwic2hhcmVkOi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2NvbnRhaW5lci9jb250YWluZXIvZTQ0ODRiNjAtMWY5OC00
-        ZTU0LTllYzMtZWIyNGQ5ZmYxNzAwLyJdfQ==
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8wNmIzODhjZS1mNzdk
+        LTQ0NTMtYTk2Mi0wMzVhNzc3ZjYxYmEvIiwic2hhcmVkOi9wdWxwL2FwaS92
+        My9yZW1vdGVzL2NvbnRhaW5lci9jb250YWluZXIvOGY2ZTdhZDktNjY1NS00
+        YmI3LTlkZTUtNGVjNGQxNjczNGFmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/?base_path=empty_organization-puppet_product-busybox
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1860,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,7 +1873,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:25 GMT
+      - Fri, 29 Jul 2022 09:03:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1891,34 +1891,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d89973565e0467e96c21dc32950ea3b
+      - 38e0f934b49343629a2e163d1e8caa03
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:29 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWRl
         diIsImJhc2VfcGF0aCI6ImVtcHR5X29yZ2FuaXphdGlvbi1wdXBwZXRfcHJv
         ZHVjdC1idXN5Ym94IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzFiMWY5M2I1
-        LTk4NDAtNGEzMy04MGRhLTdkNTIwZjViNDFmNC92ZXJzaW9ucy8xLyJ9
+        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzA2YjM4OGNl
+        LWY3N2QtNDQ1My1hOTYyLTAzNWE3NzdmNjFiYS92ZXJzaW9ucy8xLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1931,7 +1931,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:25 GMT
+      - Fri, 29 Jul 2022 09:03:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1949,21 +1949,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6e866017db4d434190a2531f67b81e21
+      - da8189c54fc14705af13e41462f77f70
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiMjcyODU4LTIxOTktNDIw
-        MS05NTE0LWEyNGMxYWVhM2U2MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI3Y2E0ZWJmLTVmOTktNGE0
+        ZS1iZmM1LWM1OWI2ZGFhNzYxMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2b272858-2199-4201-9514-a24c1aea3e61/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/27ca4ebf-5f99-4a4e-bfc5-c59b6daa7611/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1984,52 +1984,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:25 GMT
+      - Fri, 29 Jul 2022 09:03:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '644'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11e5780fa6544bd7b448dda33931b593
+      - aadf280f4f824dd18bbcd3d7301031fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '382'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmIyNzI4NTgtMjE5
-        OS00MjAxLTk1MTQtYTI0YzFhZWEzZTYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjUuNDM0NjI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjdjYTRlYmYtNWY5
+        OS00YTRlLWJmYzUtYzU5YjZkYWE3NjExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MjkuMzIzNjg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwibG9nZ2luZ19jaWQiOiI2ZTg2NjAxN2RiNGQ0MzQxOTBhMjUzMWY2
-        N2I4MWUyMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE4OjI1LjQ4
-        NDE2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTg6MjUuNzQ1
-        Mjc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkYTgxODljNTRmYzE0NzA1YWYxM2U0MTQ2
+        MmY3N2Y3MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDA5OjAzOjI5LjM2
+        NTQyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMDk6MDM6MjkuOTA3
+        Mzc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2NvbnRhaW5lci9j
-        b250YWluZXIvOWFjNTYzZDItN2JlYy00ZTM3LTgzOGMtZDAxYjg4NTA5ZGFj
+        b250YWluZXIvOGJiMzdkZmItYWRjZS00NGRmLTljY2ItYjE0MmVlYjRiZmU0
         LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/9ac563d2-7bec-4e37-838c-d01b88509dac/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/container/container/8bb37dfb-adce-44df-9ccb-b142eeb4bfe4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2037,7 +2037,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2050,54 +2050,54 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:25 GMT
+      - Fri, 29 Jul 2022 09:03:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '731'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3fc8e4b645474f78a1f8e58788670245
+      - 29c08b61e2cc4d4799ee410c2d1ccc20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '422'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9jb250
-        YWluZXIvY29udGFpbmVyLzlhYzU2M2QyLTdiZWMtNGUzNy04MzhjLWQwMWI4
-        ODUwOWRhYy8iLCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnRndWFyZHMvY29udGFpbmVyL2NvbnRlbnRfcmVkaXJlY3QvYzE5OGM1ZDUt
-        ZWFiYi00MzEzLWIxNzEtMzQzYzYzODdjOGQ2LyIsIm5hbWUiOiJEZWZhdWx0
-        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwicHVscF9jcmVhdGVk
-        IjoiMjAyMi0wNS0yM1QyMzoxODoyNS42Mzk4NTJaIiwicmVwb3NpdG9yeSI6
-        bnVsbCwiYmFzZV9wYXRoIjoiZW1wdHlfb3JnYW5pemF0aW9uLXB1cHBldF9w
-        cm9kdWN0LWJ1c3lib3giLCJwdWxwX2xhYmVscyI6e30sInJlcG9zaXRvcnlf
+        eyJiYXNlX3BhdGgiOiJlbXB0eV9vcmdhbml6YXRpb24tcHVwcGV0X3Byb2R1
+        Y3QtYnVzeWJveCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmli
+        dXRpb25zL2NvbnRhaW5lci9jb250YWluZXIvOGJiMzdkZmItYWRjZS00NGRm
+        LTljY2ItYjE0MmVlYjRiZmU0LyIsInJlcG9zaXRvcnkiOm51bGwsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MDM6MjkuNjkzNjM5WiIsIm5hbWUi
+        OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiY29u
+        dGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRzL2NvbnRh
+        aW5lci9jb250ZW50X3JlZGlyZWN0Lzg2NzAzM2JmLTkyMjYtNDg4OC1iOWIz
+        LWU2MDBmZWI4YTJiYy8iLCJwdWxwX2xhYmVscyI6e30sInJlcG9zaXRvcnlf
         dmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVy
-        L2NvbnRhaW5lci8xYjFmOTNiNS05ODQwLTRhMzMtODBkYS03ZDUyMGY1YjQx
-        ZjQvdmVyc2lvbnMvMS8iLCJyZWdpc3RyeV9wYXRoIjoiY2VudG9zOC1rYXRl
-        bGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9lbXB0eV9vcmdhbml6
-        YXRpb24tcHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsIm5hbWVzcGFjZSI6Ii9w
-        dWxwL2FwaS92My9wdWxwX2NvbnRhaW5lci9uYW1lc3BhY2VzL2U2NzI4YWEw
-        LTFmMzctNDk2ZS04YzgwLThhYTkyNGViMjI4YS8iLCJwcml2YXRlIjpmYWxz
-        ZSwiZGVzY3JpcHRpb24iOm51bGx9
+        L2NvbnRhaW5lci8wNmIzODhjZS1mNzdkLTQ0NTMtYTk2Mi0wMzVhNzc3ZjYx
+        YmEvdmVyc2lvbnMvMS8iLCJyZWdpc3RyeV9wYXRoIjoiY2VudG9zOC1rYXRl
+        bGxvLWRldmVsLmV4YW1wbGUuY29tL2VtcHR5X29yZ2FuaXphdGlvbi1wdXBw
+        ZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZXNwYWNlIjoiL3B1bHAvYXBpL3Yz
+        L3B1bHBfY29udGFpbmVyL25hbWVzcGFjZXMvODAwZDllMDUtZDIzNC00M2U4
+        LWI0YzUtZmIyOTgzNDc5ZDVkLyIsInByaXZhdGUiOmZhbHNlLCJkZXNjcmlw
+        dGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:25 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1b1f93b5-9840-4a33-80da-7d520f5b41f4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/06b388ce-f77d-4453-a962-035a777f61ba/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2105,7 +2105,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2118,324 +2118,324 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:26 GMT
+      - Fri, 29 Jul 2022 09:03:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '12900'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5e0ed4f04d24ec2a745cf0c1da83463
+      - cdd2bc73d2cb47929fd2febf88a41364
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3446'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MjIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvbWFuaWZlc3RzL2M4MmIwNmIyLWZjYmMtNGFjNy1hNDQ4LTQ1ZGFm
-        MzU3ZmZkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEz
-        LjY2NzEzNFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        NWIxMDE5NGEtMzE3Zi00MDY3LWIzZWMtMjcwYmI4MjJlYzhhLyIsImRpZ2Vz
+        YWluZXIvbWFuaWZlc3RzL2YzYjQ0ZTY4LTcwZGUtNDAwNi04ZmQ5LTY5NWQ5
+        OWIxMWQ4NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMz
+        LjU5MDM3MloiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        N2U5YjhiMDMtM2Q3YS00OThkLWFjMGMtNjQwNDNkMTYwZDBkLyIsImRpZ2Vz
         dCI6InNoYTI1Njo2ZTZkMTMwNTVlZDgxYjcxNDRhZmFhZDE1MTUwZmMxMzdk
         NGY2Mzk0ODJiZWIzMTFhYWEwOTdiYzU3ZTNjYjgwIiwic2NoZW1hX3ZlcnNp
         b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
         c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
         cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL2Jsb2JzL2E0Mzk2NWYzLTdiYjAtNGVhYi05OWZiLTIyNWUwYWIz
-        MjNlOC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvZjg2ZjA5ZDktOTJhYi00NWU4LTk5M2UtYmQzNWIxNTM0ZGI1
+        dGFpbmVyL2Jsb2JzLzQ3MTEyZjk5LTMzZTgtNDdhMC1hMWExLTQ2NGQzODQz
+        ZDhmZS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvM2I5ODg5MjYtM2RkOS00M2I3LWI1ZDMtNGEyZWY3YjY0YmJi
         LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvYzlkOWRjZmEtMmFkNi00Y2QyLWI0YzctOGEwZjQ5
-        Y2YyMjEzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMu
-        NjY0ODQ0WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
-        MmU2OTE3MS1jNzczLTRlZmMtYjU5Ny01ZjE3ODQ2MjA4MDEvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvNDMwNjFhYTQtNTg5ZC00OGMzLThkNGMtNTkzN2Fk
+        ZWM4YzkzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMu
+        NTg0ODg3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        ZjMzMjJkYS0wNjExLTQxZTYtODhmOS03MzA4OTY0N2RiNGMvIiwiZGlnZXN0
         Ijoic2hhMjU2OjIwZThkNmZlNGJiMTEzMTVlMDhmYjY5MmNkNzE2OTYxNjdi
         MDFkYTYxMDUwODIxNTFlZmM0NTRlMDY1OTA4ZjkiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvNGRlMWI1MWUtNTFlOC00OGJhLThkNGYtNDQ1MzIyMmQ5
-        ZmZlLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9kYTYxYjI0Zi05MTM3LTQxYTEtODIzZi1hYzBjYmQ0MWVmNmIv
+        YWluZXIvYmxvYnMvODRlMzFmNTMtNTMwNC00YTljLWI1NjktN2Y0ODQzM2Yx
+        YjAzLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy84YzNiNTNhYi0zM2I3LTQ0OGQtYThkZi1hM2I3NTYzOTFmZWIv
         Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy81YTBhOGUzYy0yMDU4LTRlOWQtYWIyMS1jZjc1ODk5
-        ZGIyMjYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41
-        ODA3ODhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzgw
-        ODhkNDQzLTkwNDYtNDVmYS1hOTI0LTE0OWQzZTE5NGViNy8iLCJkaWdlc3Qi
-        OiJzaGEyNTY6YmE2NWU4ZDM5ZTg5YjVjMTZmMDM2Yzg4Yzg1OTUyNzU2Nzc3
-        YmY1Mzg1YmNlMTQ4YmM0NGJlNDhmYWMzN2Q5NCIsInNjaGVtYV92ZXJzaW9u
+        bmVyL21hbmlmZXN0cy8xMDQxMTA5NC0zMWQxLTQyMzgtODU0MC00YjFmM2Fh
+        MWVlY2EvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4x
+        MzM3NDZaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M1
+        MWZhYzAzLWQxOTctNGZkMi04YThhLWY3ZTA1ODRiNTQ3ZC8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6ZDdlODMzMTZkNzRlMTUwODY2ZDgyYzQ1ZGUzNDJlNzhmNjYy
+        ZmUwYWVmYmRiODIyZDdkMTBjOGI4ZTM5Y2M0YiIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
         OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy9mNTU0ODYzYS0xODcxLTRhNDktOGY2Zi1iZmNiNDhiOTVh
-        NWQvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzA0YWJjNmU4LWQwYzctNDRjNy1iODVjLWZlZmM5N2MwNTdhZC8i
+        aW5lci9ibG9icy82ZDA2YWRmNS1kNzQ4LTQ3ZDAtODFmYi1jYzE3Y2Y2YWNi
+        MTkvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzL2JlZjlkMTg3LTQ3Y2MtNGQ2YS04ZjUyLTVhZDY5ZjJkMjc2Ny8i
         XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzQ2YWZjMmJhLTMwNjAtNDRjYi05ODUyLTNjZTU3MTFj
-        YTRjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjU3
-        OTI3M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGMx
-        ZjI4NjAtZWQyMi00MzViLWI0YjEtZDIwZWY5ZmRlNTA2LyIsImRpZ2VzdCI6
-        InNoYTI1NjozMjk2OGU3MTdlMjlmNzllNWI4ODk3MjE5MDhiM2JlNmQxNTcz
-        OTkyZTFmM2JhNGM5YTQxNzE4ZTI3Mjg0NThjIiwic2NoZW1hX3ZlcnNpb24i
+        ZXIvbWFuaWZlc3RzL2FiMjM4NzM4LWRlZmItNGIwMi1iOTlkLTVjY2ViNGJi
+        N2YwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjEz
+        MTU2MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmQ4
+        MjIwN2QtY2Y2NS00NDljLThlMjUtM2NhMDM5NjNlMTg3LyIsImRpZ2VzdCI6
+        InNoYTI1Njo2Y2E5YTU2YjJiOTNiZTE2YTYyZTZkNDRhZDQ3ZTZkMzIwMTI2
+        MzMyZDFlMjc1MDllMTNmYTJjYzQ5YjEwZTllIiwic2NoZW1hX3ZlcnNpb24i
         OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
         aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
         W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL2Jsb2JzLzI4MWI1YmNmLTVmMDgtNGEwOS1iNzBiLTAxMTM5OThhMWRl
-        Yi8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvYzZmYzA2YjUtMGYxNC00YTViLWE3YmItZDFkNjI4MWZjNWQzLyJd
+        bmVyL2Jsb2JzLzc4MWQ1YmRkLWRiNjAtNGNlZi1iODUwLTYyNmU4ZTYxZmRi
+        ZC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
+        YmxvYnMvZTNlOTM0MjEtZmJiZC00MzU0LTgxMmYtNjQ1YzY1MGY3ZTYwLyJd
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNjNjZGIyMzgtNmE5Zi00ZTBjLThkYTktZTNiNzgwMjVk
-        ZWJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNTQ0
-        MDMyWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iODEw
-        ODRjZC0yMmE4LTQ4ZmMtYTFiMi0zMGY2YjJkNWRhYTAvIiwiZGlnZXN0Ijoi
-        c2hhMjU2OmI4OTQ2MTg0Y2UzYWQ2YjRhMDllYmFkMmQ4NWU4MWNmY2FhZGM2
-        ODk3YmZhZTJlOWM2ZTJhNGZlNmFmYTZlZTAiLCJzY2hlbWFfdmVyc2lvbiI6
+        ci9tYW5pZmVzdHMvOTJiNjJhZjktZDViMi00ZmM2LTgyZmEtNDMzNjAyZDky
+        NmJiLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMTI3
+        MzY1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8yZjVk
+        YTlmYS1jYzkyLTRjMGMtODY0ZS0xYzAxOGE1YTI0ODYvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OjMyOTY4ZTcxN2UyOWY3OWU1Yjg4OTcyMTkwOGIzYmU2ZDE1NzM5
+        OTJlMWYzYmE0YzlhNDE3MThlMjcyODQ1OGMiLCJzY2hlbWFfdmVyc2lvbiI6
         MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
         YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
         XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvYzEwZDQ2OTAtOWIxZi00NDI4LTgxYjEtZWM3OGQyYTMyNDgz
+        ZXIvYmxvYnMvY2FjM2E5NTYtNmI5NC00YTZjLWE0MjItNjI2Yzk0M2EzNDE3
         LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9jM2RlYzJjZi0wZjYwLTQ0ZjktOTkxMS1jNTc0ODM1ZDMyMGEvIl19
+        bG9icy8zMzVmZTUxYy0zZDk5LTRiNmItOGRhMi02ZGYxMmU4MTA4MDkvIl19
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L21hbmlmZXN0cy81Y2NjODkwNy0wNDQ3LTQwMGEtYjUxOS01YWRmNzUzOTU0
-        Y2YvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41NDI4
-        MzNaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U1ZjVj
-        NmJmLTRjOWUtNDU1NS1hNWM2LTJmOTUxMzI2MGY3ZC8iLCJkaWdlc3QiOiJz
-        aGEyNTY6NmNhOWE1NmIyYjkzYmUxNmE2MmU2ZDQ0YWQ0N2U2ZDMyMDEyNjMz
-        MmQxZTI3NTA5ZTEzZmEyY2M0OWIxMGU5ZSIsInNjaGVtYV92ZXJzaW9uIjoy
+        L21hbmlmZXN0cy8xMGJmZWQwMi1iYWM2LTQyNWItYTIwZS1kOTY3ZmE5ZTdk
+        OGMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4xMjQw
+        ODFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzZjZmZh
+        ZGRlLTI3ZDMtNDg4MS1iNTc0LTAyYTFkZDE5ZmE2OS8iLCJkaWdlc3QiOiJz
+        aGEyNTY6MWZhYWY3YTc1MzE5NDE3MjYxMjY3YjNkY2VmNmEyYjE0YzhjNTEy
+        MmQ3ZmNjN2FiZWIwN2EzMmJjMTk3MjhmZCIsInNjaGVtYV92ZXJzaW9uIjoy
         LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
         dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
         LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy8yOWM3MWNiNS02OWExLTQwNjgtOTA0My1jZjEzY2NhZGNjZDIv
+        ci9ibG9icy9iYjgyYmQwMC04ZjdiLTQ5ZjgtYWEwYi1kZmVkZTc0Y2E0YTgv
         IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzFiODc2MTRkLTMzMmMtNGMwYy1iNmY4LTE4ZWVhYmE5MTA0OC8iXX0s
+        b2JzLzZhNTgwMWM4LThiM2ItNDU1ZS04ZDJiLTk2NTI4YjM3OWJlYS8iXX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        bWFuaWZlc3RzL2RlOTU5M2Q3LWQxMDUtNDhhNS1hYjM5LTk0OTUyMDA5MTg4
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjU0MTYx
-        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZGM0Yjk4
-        YmYtYmQ1Ny00Mzk1LWExNzUtZWE5ZDNhMGUzYmZhLyIsImRpZ2VzdCI6InNo
-        YTI1Njo0MjZjODU1Nzc1ZjAyNmQzZmU3Njk4OGI3MTkzOGY0YzlkYzY4NDBm
-        MDljMGYyOWQ4ZDRjNzVjYzQyMzg1MDNiIiwic2NoZW1hX3ZlcnNpb24iOjIs
+        bWFuaWZlc3RzL2Q3NzE2M2JmLTIxOTEtNGEzOC04MTY2LTdmOWFlNDk0MmNj
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjEyMDk3
+        NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODQwYTU5
+        ODYtNWE4ZC00Yjk2LTg3YjctNjExMzlmMWVjNTJlLyIsImRpZ2VzdCI6InNo
+        YTI1NjowYTExYTk1NTY4YjY4MGRjZTY5MDZhMDE1YmVkODgzODFlMjhhZDE3
+        YjMxYTYzZjdmZWMwNTdiMzU1NzMyMzVhIiwic2NoZW1hX3ZlcnNpb24iOjIs
         Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
         dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
         ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzMwMmQ0YjYyLWYxYWQtNDgyOS1iYWNkLTUyZjUwNDM3MGM0Zi8i
+        L2Jsb2JzLzViNDU2M2JhLWE5MzctNGQ5NS1iMzdhLWUxMDViMjI0ODc1My8i
         LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvYTExYTQ5N2MtZDAxZS00YmYwLWIzYjMtYWEyYTllYzFhYTEzLyJdfSx7
+        YnMvZmIzNGYwNTktZDE4Mi00NjJhLWFkMGEtMDRkNjRiZDZlOGYzLyJdfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
-        YW5pZmVzdHMvZDEwMGZhNWEtZWYxZC00NTZkLWJlNmMtN2FmMmJhNjFlNjg2
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNTQwMzcw
-        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mYWI4MjMy
-        Yi01YmJkLTQxMTQtYWIyYi1kY2M5YmFkYzhhMjgvIiwiZGlnZXN0Ijoic2hh
-        MjU2OjFmYWFmN2E3NTMxOTQxNzI2MTI2N2IzZGNlZjZhMmIxNGM4YzUxMjJk
-        N2ZjYzdhYmViMDdhMzJiYzE5NzI4ZmQiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        YW5pZmVzdHMvOTljZDJiYzQtYTVjZS00OGIwLTkxZWQtZjdkZDliOWZhMmJj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMTE4NTcx
+        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9lNTlkMjhm
+        MS04YTdkLTQ5MWUtODUxNS1lOTEwNDhkOGE5YjQvIiwiZGlnZXN0Ijoic2hh
+        MjU2OjA2NWE2NzE0Njk3YjRhNmQyN2ZiMTNhMTI4MzBmMGE5ZmY4MWE0MDQ5
+        OGJlYjlkYTQ5YWRiN2NmZDg3YjA1NGQiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
         bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
         aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
         Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvMWNlNWNjM2ItODRjMy00MmM5LWI2NGItYzYxMjI4YTNjZjg2LyIs
+        YmxvYnMvOWFkNzIxOWYtOTY4Ni00ZjgxLWE4ZmQtZmExOWZmNjkxMjVkLyIs
         ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy84MjY0Mzk4Ny02YjA0LTQxNWItOGFiMC04ZTcwZGNjNGE3YWUvIl19LHsi
+        cy9kMWMyZGYwZS1hMjY2LTQ4ZDEtOTc4OC01MTMwOTMyMDgyNjQvIl19LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
-        bmlmZXN0cy8yNDU2MjE3MS0wMzA5LTQxYWEtOTg4MS04NjAxZWMzMTk3YmUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41MzkwNDNa
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2VlNWNhYzRk
-        LWYwZmEtNDAwNy1hN2RiLTk5YjMyMjBmY2RlYi8iLCJkaWdlc3QiOiJzaGEy
-        NTY6MGExMWE5NTU2OGI2ODBkY2U2OTA2YTAxNWJlZDg4MzgxZTI4YWQxN2Iz
-        MWE2M2Y3ZmVjMDU3YjM1NTczMjM1YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
+        bmlmZXN0cy80NGUxZjM1Ny1mN2QyLTQ2YzMtODA4ZS04OWQ5ODA3MDkyYzIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4wNzUyNTBa
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2I2Y2YxYzhm
+        LTkwNDQtNDk3Zi1hYWI2LWM4ODk4MDAzNTMzZi8iLCJkaWdlc3QiOiJzaGEy
+        NTY6YmE2NWU4ZDM5ZTg5YjVjMTZmMDM2Yzg4Yzg1OTUyNzU2Nzc3YmY1Mzg1
+        YmNlMTQ4YmM0NGJlNDhmYWMzN2Q5NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
         ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
         b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
         b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy8yM2RjMjc3Zi02OWUwLTRjNGYtYTM5OS0zYzIxODEzOGVmZWQvIiwi
+        bG9icy8zYTY1N2Y5MC05OTEyLTRhMDgtYjk0OC01YzU4MDZlMjI3N2MvIiwi
         YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzQ5MWM2OGRkLTViODQtNDM0Ni1hMDA1LWQxYjI3NDZkMjkzMy8iXX0seyJw
+        Lzk1Y2RlYTEzLTQ5ODYtNDE1YS1hYzc2LTZkYjZiNzU0NjY2ZC8iXX0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFu
-        aWZlc3RzLzU5YzNkM2Q1LTJlYjEtNDUxOC04Y2ZhLWUyZDE0OGY5Zjg1OS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjUzNzY0MFoi
-        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODQyNDFiMjct
-        YjI2NC00MmQ1LTkyODEtYmJkNjY2MzY1YjcyLyIsImRpZ2VzdCI6InNoYTI1
-        NjowNjVhNjcxNDY5N2I0YTZkMjdmYjEzYTEyODMwZjBhOWZmODFhNDA0OThi
-        ZWI5ZGE0OWFkYjdjZmQ4N2IwNTRkIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        aWZlc3RzL2UzNzQxYzgwLWU0NTktNGU0OC05MGVhLWQzMGYzMDBmMzRkNS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjA3Mjc5MFoi
+        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjcyYTQ1MWUt
+        NTg4NC00MDQ3LWIwODYtZWE3ZWIxMzBiNGU1LyIsImRpZ2VzdCI6InNoYTI1
+        Njo0MjZjODU1Nzc1ZjAyNmQzZmU3Njk4OGI3MTkzOGY0YzlkYzY4NDBmMDlj
+        MGYyOWQ4ZDRjNzVjYzQyMzg1MDNiIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
         ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
         bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
         bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzAxMmNmYTRlLWE1Y2EtNDBmNy1hMzljLWJkYjg3MTEwMjk5MC8iLCJi
+        b2JzL2NjZmJlNjhjLTAwMWYtNDc5Ni1iOGQzLTRkNTNiYmU2YTQzOC8iLCJi
         bG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MDEzMDQ3ZDEtNDYyYi00ODBhLTk1MzAtMjIxOTA5MDJkMWFiLyJdfSx7InB1
+        NWRjOTJjMWUtM2UxMi00ZjhlLWEwMWEtMzk4OTM3YTIxNTgyLyJdfSx7InB1
         bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5p
-        ZmVzdHMvNzYxODc3MTAtYWJhMy00ZDgwLWEyZDEtYjQwYWIwYzkxNzc0LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNDk3NDUxWiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82NmM3NzU2OS03
-        NTE2LTQ2MWUtYWJhNS1jYzQ3MTcwZDRiZTIvIiwiZGlnZXN0Ijoic2hhMjU2
-        OmQ3ZTgzMzE2ZDc0ZTE1MDg2NmQ4MmM0NWRlMzQyZTc4ZjY2MmZlMGFlZmJk
-        YjgyMmQ3ZDEwYzhiOGUzOWNjNGIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        ZmVzdHMvYjJkYzQyNGMtOWY3MC00ODhlLTg2ZTItNTBlMmU1ZTY4MjVlLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMDI2NjUyWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9hN2ViZDM5Ni1l
+        MmVlLTQzN2UtYjAyNS0yMjMyYzgzNGY2MzUvIiwiZGlnZXN0Ijoic2hhMjU2
+        OmI4OTQ2MTg0Y2UzYWQ2YjRhMDllYmFkMmQ4NWU4MWNmY2FhZGM2ODk3YmZh
+        ZTJlOWM2ZTJhNGZlNmFmYTZlZTAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
         aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
         Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
         ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvZjQ2MmFkNmItNDRmYi00Njg1LWEwMTktNzA5Mjc5NThiMzA2LyIsImJs
-        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9m
-        ZWI2YTYzMi0xMDVhLTQzMzQtYTgyZS04OTM1OTQ0Zjk5MzQvIl19LHsicHVs
+        YnMvOWU5OTJjNDYtZWEwYS00ZDAwLThlOWYtYTE3YjkzM2E1ODhmLyIsImJs
+        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9j
+        MjgyZmRkMi0yMTUwLTQ3MjctOGZiNi0zZmFjYmM3NDBiN2EvIl19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9mZDE2MjUwNC1hMGUyLTQ1MTctYWExNS1hYjhiYjgwOTQ5OTkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy40OTYxNTBaIiwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzdjZDhhMDk0LWY2
-        YTgtNDQwNS05YTYxLTQxODQ5YjY0NDZhNS8iLCJkaWdlc3QiOiJzaGEyNTY6
+        ZXN0cy9mOWJhZjA0OC1iZGExLTQ0NmYtOGRjOS1lNzBhZjc1YWM5ODgvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi44ODgzNjBaIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Q5MDBhYTViLWM2
+        N2EtNDM1NC1hNDQ0LWIzZTM3Y2ZmZGJhMy8iLCJkaWdlc3QiOiJzaGEyNTY6
         NjY1NWRmMDRhM2RmODUzYjAyOWE1ZmFjODgzNjAzNWFjNGZhYjExNzgwMGM5
         YTZjNGI2OTM0MWJiNTMwNmMzZCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
         YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
         bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
         aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy84ZDU2ZGFlYS03YmYyLTQzMjUtYTk4Yy04ZjJlYzhhMTlhODYvIiwiYmxv
-        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Y5
-        NzQ2YjVmLTRkNTQtNGM0OC04YTEyLThhYTJiMzQ4MzBjZi8iXX0seyJwdWxw
+        cy82YTEyMTJkNS1jZTZmLTRjNDYtOWMzZC0yZTAxYjU2MDQwNTYvIiwiYmxv
+        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Zl
+        ZjBmYmZlLTMxNTQtNDM4Ni05OGY3LTZiNTg3MzI5OGM0OC8iXX0seyJwdWxw
         X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2RlYWE2NWVhLTIxYjktNGNlYy05Mzc1LTE5Njk1Y2VlOTFlZC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjM5ODkwMVoiLCJh
-        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMmM5YTFjM2UtNzIx
-        Ni00MTg2LTk4YzAtYmY4MmQ5MWFjNjkyLyIsImRpZ2VzdCI6InNoYTI1Njpk
-        NjM5MzMwYTQyNTQ5YzAyNjI5NGIxNmY0MDM5YTcwZWYyOTRiYmIzNzdjYWVm
-        ZDkyM2UzMGRkMDExMzVjN2Q2Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
+        c3RzLzc0YjM5YzM2LTc4NzQtNDZmNC04YmE3LTg1NzhiOWY4MWNjZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjc1NTUzM1oiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMTlmNzVmMDUtYzI5
+        Mi00ZTdhLTgxY2ItODZkYjMzNDk0MzY0LyIsImRpZ2VzdCI6InNoYTI1Njpj
+        ZTgwMDg3MjA5MmMzN2M1ZjIwZWYxMTFhNWE2OWM1YzhlOTRkMGM1ZTA1NWY3
+        NmY1MzBjYjVlNzhhMjZlYzAzIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
         X3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5t
         YW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZp
         Z19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        L2ExMGM1NTFjLTk1NTktNDFjNC05ZDc4LWE3NDgwNTBiNjY4Mi8iLCJibG9i
-        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvMWQ4
-        MmQ0NDMtZmRlZS00NWZhLTg0ZmItNzgxMTM0NjdkZGMyLyJdfSx7InB1bHBf
+        Lzc2MzExNDA0LWE4NDktNGM5NC04YzQ0LTc0NTYyM2ViNWQyOC8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvYWVi
+        NTMwNzMtZjMwOC00NDE2LWJhNTgtMDkwYWZkNzkyOTkxLyJdfSx7InB1bHBf
         aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvNjZiMzUxN2UtMjY0MS00MmVkLWI5ZGYtYjM5MjhmMjk5NTBiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMzk2NzQ0WiIsImFy
-        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wNWY0MWFjNS1mN2Iw
-        LTQxZGUtOGMwYS0wMzM3ZDNkZTU4OWEvIiwiZGlnZXN0Ijoic2hhMjU2OmNl
-        ODAwODcyMDkyYzM3YzVmMjBlZjExMWE1YTY5YzVjOGU5NGQwYzVlMDU1Zjc2
-        ZjUzMGNiNWU3OGEyNmVjMDMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHMvYmU2NTMxNmEtZjc3Zi00OWNhLTgwM2UtZjgwNTZhZmNiYjU1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNzUyMjYxWiIsImFy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wNGU3Yjc4NC0xMmYz
+        LTQ1ZDgtYmQ0My0xNTI5N2FjNDdhODcvIiwiZGlnZXN0Ijoic2hhMjU2OmM5
+        MjQ5ZmRmNTYxMzhmMGQ5MjllMjA4MGFlOThlZTljYjI5NDZmNzE0OThmYzE0
+        ODQyODhlNmE5MzViNWU1YmMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
         dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
         bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
         X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MmQyODE2MmQtZDZiZC00YjRkLWE5NDktNjcyYzcwNDgyMzg3LyIsImJsb2Jz
-        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy80ODgw
-        MWI0ZS01MzYwLTRmZDMtYTJiOS1iMjNlNGNhM2I4YzIvIl19LHsicHVscF9o
+        OTc0ZGRhMjAtYjk1Ny00OGU4LWJhMWItOTAyY2UxYTU3YWE2LyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9hNzQ2
+        ZjFlNy1kOTBjLTRmZWItYWE1Ni04NzQ5NTA5MTk4ZTMvIl19LHsicHVscF9o
         cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0
-        cy9jNjQ1YjllOC1mZGY3LTRkZGEtOWVmOS1kNDA1Njc1NjAxNDAvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4zOTQ4MjJaIiwiYXJ0
-        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M4NTU3ZmE5LTE5NTMt
-        NDU2ZS05OTNmLTNmNDg5YTlhYWQ5NS8iLCJkaWdlc3QiOiJzaGEyNTY6Yzky
-        NDlmZGY1NjEzOGYwZDkyOWUyMDgwYWU5OGVlOWNiMjk0NmY3MTQ5OGZjMTQ4
-        NDI4OGU2YTkzNWI1ZTViYyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
+        cy8wMWJkNTUxMC0zMTgwLTQ1NDYtODVhYi02ODE3YTE4NmNhYjYvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi43MjQyNDlaIiwiYXJ0
+        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzBlNGIxMTRhLTE1ZTAt
+        NDkyNi04YWYwLTkwYTZlN2M5NTY3Zi8iLCJkaWdlc3QiOiJzaGEyNTY6ZDYz
+        OTMzMGE0MjU0OWMwMjYyOTRiMTZmNDAzOWE3MGVmMjk0YmJiMzc3Y2FlZmQ5
+        MjNlMzBkZDAxMTM1YzdkNiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
         eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFu
         aWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdf
-        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy8w
-        OTg5MmYzOC1mNDM5LTRhMzAtOWVhNS00NGE5Zjc1MDY3YjMvIiwiYmxvYnMi
-        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzJjYTI1
-        NzE3LTVhZWMtNGI1Ny04MTA3LTJmOTg1NzMxYjgzYi8iXX0seyJwdWxwX2hy
+        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9m
+        M2U4Mjk2Mi1mOWYxLTQ3YmEtODhlOC02MDA1YzE3ODNlNzgvIiwiYmxvYnMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzkwNjkz
+        NDNhLThhYTUtNDJhMC04ZWQ1LWQ3NzA0YmMzMDJlMC8iXX0seyJwdWxwX2hy
         ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3Rz
-        LzZiYzA4YjYzLTQ1MTEtNDY2Zi1iYTk2LWM5YTQyMDQxNzgwOS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjM5Mjc5MFoiLCJhcnRp
-        ZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZGY3ZjIzYjMtMmQyOS00
-        YzZjLWFmNDctNjcxYTBjMjkyYTJiLyIsImRpZ2VzdCI6InNoYTI1NjphN2M1
+        L2U5MzA4ZjU5LTQ1NmYtNDNmZi05Zjc5LWIyMzEyZmFiY2VmOC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjcyMTcyNVoiLCJhcnRp
+        ZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTJhYmE0ZmMtNmE5OC00
+        NWUzLWI3YWMtN2IwOTQ4ZTBkYjlkLyIsImRpZ2VzdCI6InNoYTI1NjphN2M1
         NzJjMjZjYTQ3MGIzMTQ4ZDZjMWU0OGFkM2RiOTA3MDhhMjc2OWZkZjgzNmFh
         NDRkNzRiODMxOTA0OTZkIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5
         cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5p
         ZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19i
-        bG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzNl
-        ZTE0NjhiLTJmZWYtNGRlYi04ZWVlLTdhMTU2NzUyODZiMC8iLCJibG9icyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvOGMwZjU0
-        M2ItZDhjMS00OWI2LWI3NDctMzg3NWRhYzgxZGY1LyJdfSx7InB1bHBfaHJl
+        bG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzEz
+        ZmE4OTlhLWYxOWItNDJmNS05ZTE0LTRiMzFkNjIzZGMxNy8iLCJibG9icyI6
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvOWM4ZGY5
+        NDctOWYxNS00YWU2LWIyZGUtZGFhNTkyMzlmYmJkLyJdfSx7InB1bHBfaHJl
         ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMv
-        NjVmOTNmZmYtMjhhOC00NTQ2LTlmYjctNDFkNjUwNmIyM2FkLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMzkwODE0WiIsImFydGlm
-        YWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iODhkYTUxYi02OGQ5LTQ0
-        NGYtODBiNy0zYjA1MmEyOTUwZmMvIiwiZGlnZXN0Ijoic2hhMjU2OmExOWEw
-        MmRlMzA1ZTgzZDE0ZDdjYTRkNDE0ZDhkMjM2MDBiNzk1M2EwYTY5M2QyZDFj
-        ODVkM2NlMjZmYjcyZWIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlw
+        Nzk1YmJhNGEtOThlNS00MTI4LTg1NjctMGJjNmYzNDM5OGYyLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNjUyODQ0WiIsImFydGlm
+        YWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85ZDA5YTM0OC01OTc4LTQ3
+        NTUtOWEwNi1kMWZiMDM2NGM3NWEvIiwiZGlnZXN0Ijoic2hhMjU2OmQyY2Qw
+        Mjg1ZWNlYTgwOWE5OTkwNjlhOTYwNzVlNTBkZmY3MmVhMGExZjZlMTc0YTZm
+        YmQyNjMwMDI1MDYyOWUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlw
         ZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlm
         ZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Js
-        b2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvYmRj
-        MDY4MTMtMjNmOC00ZjBiLWE2M2EtMmJlYTI3Yzc3YjQ5LyIsImJsb2JzIjpb
-        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy83ZjBjYzU1
-        Ny00ODQ3LTQxYTItOTNlYy03MDAwZWRiMjdmOTcvIl19LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83
-        NTVhYjdiMS05NGI0LTQ1NmEtOGVhOC0yZDgxZjgzZTAyY2IvIiwicHVscF9j
-        cmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4zMTQ3NTBaIiwiYXJ0aWZh
-        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2I5MWFkYWQ1LTY5YTQtNDY2
-        NS04MTFiLWEyNzBhYmY0NGI1ZC8iLCJkaWdlc3QiOiJzaGEyNTY6ZDJjZDAy
-        ODVlY2VhODA5YTk5OTA2OWE5NjA3NWU1MGRmZjcyZWEwYTFmNmUxNzRhNmZi
-        ZDI2MzAwMjUwNjI5ZSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBl
+        b2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvYmRk
+        M2VjZTQtMzkxNS00MTJlLTkxYjctOGEzYWY0MjJhYTM2LyIsImJsb2JzIjpb
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9iOTlmNzk0
+        ZC03MjU2LTQ4ZTgtYmI3Ny1hNWRlN2RmZWQzZGMvIl19LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9h
+        YTliYjZiYi05NDQzLTRhZTUtODZiZC02MjMxMzMyOWUyNGEvIiwicHVscF9j
+        cmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi42NTA3MDlaIiwiYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzczNmNjNDhjLTM4ZmMtNDM1
+        YS1hMTExLTk0NjI1ZTY0ZGRhMS8iLCJkaWdlc3QiOiJzaGEyNTY6YjQ5Yjk1
+        Y2MxMWZjZDFiYjc5NDM0MjE0YWViZTFjYzExY2RhNDI2YTFjODc2N2E1ODg5
+        YzBiNzY4NzQyN2JmMiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBl
         IjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZl
         c3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxv
-        YiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy80ZDU2
-        NWIxMC1hMGFjLTQwNzMtYmE1Ny1lNDNlYmU5NTc4MzUvIiwiYmxvYnMiOlsi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2E4YmViNzlj
-        LWYzYjUtNDU3Ni1iMjJiLTEwNWIyZmVlZjYyNy8iXX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk1
-        YWQyYTYyLTc4ZDEtNDlhOC1iNjhkLTRlODk3MThmNGM3OC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjMxMjkzN1oiLCJhcnRpZmFj
-        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTdjNGVhMDQtZTY3OS00MDg2
-        LWE5NDItNzFkOGY3ZWJkMDBjLyIsImRpZ2VzdCI6InNoYTI1Njo4ZThkNjcy
-        NTI2YzdjYTgxOGYxODkyMjVhZTU5ZWU5YWQzNTNjYjFlMmZlYzdkMDExYjc4
-        ZWY3MGVjZDgwNWFlIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        YiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy82MWE4
+        NGUyZC04MDEzLTRlMzUtODhiOC0wZDY3ZDU3N2Y5MTcvIiwiYmxvYnMiOlsi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2VhMzJiMjQy
+        LWU3MjQtNDZlNC1hMTU5LTQ0ZjcyZjA5Zjc1MS8iXX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzNj
+        NjczOWEzLWJiOGYtNDViOS1iY2EzLTI3NDViMzNjNmM0YS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjY0ODM3NVoiLCJhcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTNkZmIyNzYtY2I4Yi00MDY4
+        LTllNGEtYmE3Y2YyOThkZDk0LyIsImRpZ2VzdCI6InNoYTI1NjphMTlhMDJk
+        ZTMwNWU4M2QxNGQ3Y2E0ZDQxNGQ4ZDIzNjAwYjc5NTNhMGE2OTNkMmQxYzg1
+        ZDNjZTI2ZmI3MmViIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
         OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
         dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzRmNjVi
-        OTk3LTgxMmQtNDkxOC1iYmYxLWVmY2I2MGJjZDgxOC8iLCJibG9icyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvODAyODQwMTIt
-        OTQ5Mi00MzlmLTljMDQtMDIwNGI0YzQyY2ZlLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvMDBl
-        NzlhMTktYjhmNS00NjUxLWJmNDUtNTRiY2M1MjZlY2UyLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMjc4Mzg0WiIsImFydGlmYWN0
-        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9lMDZhMWE0ZS0xZGVhLTRmYzIt
-        OWM1My1mMTVjYzM3OTgxZmIvIiwiZGlnZXN0Ijoic2hhMjU2OmI0OWI5NWNj
-        MTFmY2QxYmI3OTQzNDIxNGFlYmUxY2MxMWNkYTQyNmExYzg3NjdhNTg4OWMw
-        Yjc2ODc0MjdiZjIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Y0Y2Fm
+        OWRmLTk5MjgtNDkzNy05NGE3LTk4YmRlMjkwNmUwYy8iLCJibG9icyI6WyIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvN2JkNzYzMjAt
+        ZWFiMC00MmQ5LTg1N2QtZThjMDY5YWNkMWRiLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYWEz
+        N2Y5MzktNDdlNy00NDliLTk5MGMtMWMzODI4YjA2ZGNlLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNjQ2MDc5WiIsImFydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8yMjMwOThlMS0yMTI4LTRjZjAt
+        OTFjZi0wYTk3NDM1YTA0NzgvIiwiZGlnZXN0Ijoic2hhMjU2OjhlOGQ2NzI1
+        MjZjN2NhODE4ZjE4OTIyNWFlNTllZTlhZDM1M2NiMWUyZmVjN2QwMTFiNzhl
+        ZjcwZWNkODA1YWUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
         ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0
         LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2Ii
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvOWVkZmFi
-        MjEtNzQ2Mi00ZmM3LWE0MDEtMDkzODIzYzJmZGY0LyIsImJsb2JzIjpbIi9w
-        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy8wZGE0YTMzYy01
-        ZmJlLTQ3OWEtOTM3My05NzU2ZWFlYzIzNGIvIl19LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kOWM2
-        MGNkNS1hYTk5LTQ5NGYtODY4My01NzkyNWIwYzM1NmQvIiwicHVscF9jcmVh
-        dGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4yNzcxMzdaIiwiYXJ0aWZhY3Qi
-        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2MyNzZjZDRmLTg3YzEtNGQ1Ni1i
-        N2MwLTE2MjVjNmE5ZGIwNS8iLCJkaWdlc3QiOiJzaGEyNTY6MWNlZTg3Mjdm
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvNDJhZWQ1
+        ZTMtZDg4NS00ZjhmLWFmMTItZmNhM2IxODc4OGVjLyIsImJsb2JzIjpbIi9w
+        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9lYzM3MjVhZC03
+        OGVkLTQ2ZDQtYmY3OC02YjA2MDViODg2YzkvIl19LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kZjRk
+        YmNlNC0xMGU3LTQwNmUtYTAwNi0wMDUyNTRmMjBlYjYvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi42Mzg2ODlaIiwiYXJ0aWZhY3Qi
+        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzRhNDMzMjQ4LTFhMjktNDNmZS04
+        YWI4LTQxMzYxNzk5MzkwNS8iLCJkaWdlc3QiOiJzaGEyNTY6MWNlZTg3Mjdm
         YjE1YTNjM2UzODllYjBiZTk1NzQwZjY2Zjc5YjNlZGRjNTdkMmIzZDk2OGZi
         OGEwNDZmYzc2YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoi
         YXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3Qu
         djIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9jOGZhOTY0
-        NS01ZDIzLTQ2MDMtOTllMC03ZWU1YzJlNjUxZDQvIiwiYmxvYnMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzEyOTE0Y2NjLTJh
-        OTAtNGIxMC05ZmZmLWY5NjU0MjlhMjVkMS8iXX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2NmZDJj
-        YTA4LWVhMjktNGM5Ny1hYzJmLTRkMThiYzkxY2E0OC8iLCJwdWxwX2NyZWF0
-        ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjE5Njk4MFoiLCJhcnRpZmFjdCI6
-        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDc3YWE4ZjYtNTYwZS00MzcwLTgy
-        NzItMDkzMWZlZTUzNzAyLyIsImRpZ2VzdCI6InNoYTI1Njo5NThlNDMzYmNm
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9hNWEzMjRm
+        OC1mNDI0LTRiZjktODJiNy05YWQwZjdhZDgyMDkvIiwiYmxvYnMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2NjMDZjMjY3LTk2
+        YjYtNDdmZC1iMzhhLWFhMTMyODI1Nzg4NS8iXX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2ExYjQ0
+        MWFlLWViMDAtNDA1ZS1iNzM3LTZlMDgyNWUwMjI1NS8iLCJwdWxwX2NyZWF0
+        ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjQxMzIzOFoiLCJhcnRpZmFjdCI6
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYmMzYTBkMjYtZjNmNi00NjdlLWEz
+        MGItYWE3YmJhNzU3ODU4LyIsImRpZ2VzdCI6InNoYTI1Njo5NThlNDMzYmNm
         YTZjM2ZhYWNkY2JiZTIwNTg2MGM4YWU0NDc0ZDljODY1ZjkzMmM5MTgyN2Yy
         ZTI5MmI5MmRjIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJh
         cHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52
         Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzk3NGYxMTk4
-        LTZkMTEtNGY5Ny1iNDkwLTlkOTI4YzkzMzUyNS8iLCJibG9icyI6WyIvcHVs
-        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvODQ1YzRlZjItMWEx
-        OC00YTU1LTk2MjYtZWY2NGU3Yzk2YjgwLyJdfV19
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzdkMDdjNzM4
+        LTBmNTEtNGM4ZC05ZjI1LTEwMGY1YTBlZWI0Mi8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvOWM1NmViMWYtYmRh
+        NS00ZTEwLWFkN2UtNzZhY2I5MjVhMTM2LyJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1b1f93b5-9840-4a33-80da-7d520f5b41f4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/06b388ce-f77d-4453-a962-035a777f61ba/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2443,7 +2443,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2456,111 +2456,111 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:26 GMT
+      - Fri, 29 Jul 2022 09:03:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '3315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1780999d01624baeaf22ca3693d999e1
+      - 2b4212f40c9742d88be39ecd2ccd8874
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1090'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvOTliYTZlNzctNGE2OC00YzM2LTkxOGEtMTk0ZWM0
-        NzlmZWE0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMu
-        MTk4NDAyWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        MmRmMTBiNS0xZjc2LTQ3ZTYtOThhOC0zOGFmNGM4NjI1NjMvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvMjBkN2M4MjMtZDhlZC00Zjc5LWE2NmItM2FlNDY2
+        YTk4YzU2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIu
+        NDE2MjQ3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9h
+        ZTRhM2ViNC0xZTY5LTRkNmYtYjdmMy1jOWQ2NmQ4YWU2ZGUvIiwiZGlnZXN0
         Ijoic2hhMjU2OmE5Mjg2ZGVmYWJhN2IzYTUxOWQ1ODViYTBlMzdkMGIyY2Jl
         ZTc0ZWJmZTU5MDk2MGIwYjFkNmE1ZTk3ZDFlMWQiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
         ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9jNjQ1YjllOC1mZGY3LTRkZGEtOWVmOS1kNDA1Njc1NjAxNDAvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82YmMw
-        OGI2My00NTExLTQ2NmYtYmE5Ni1jOWE0MjA0MTc4MDkvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82NmIzNTE3ZS0yNjQx
-        LTQyZWQtYjlkZi1iMzkyOGYyOTk1MGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy83NjE4NzcxMC1hYmEzLTRkODAtYTJk
-        MS1iNDBhYjBjOTE3NzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy82M2NkYjIzOC02YTlmLTRlMGMtOGRhOS1lM2I3ODAy
-        NWRlYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy8yNDU2MjE3MS0wMzA5LTQxYWEtOTg4MS04NjAxZWMzMTk3YmUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy81YTBh
-        OGUzYy0yMDU4LTRlOWQtYWIyMS1jZjc1ODk5ZGIyMjYvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9mZDE2MjUwNC1hMGUy
-        LTQ1MTctYWExNS1hYjhiYjgwOTQ5OTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy9kZTk1OTNkNy1kMTA1LTQ4YTUtYWIz
-        OS05NDk1MjAwOTE4ODgvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6
+        ZXN0cy9lOTMwOGY1OS00NTZmLTQzZmYtOWY3OS1iMjMxMmZhYmNlZjgvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iZTY1
+        MzE2YS1mNzdmLTQ5Y2EtODAzZS1mODA1NmFmY2JiNTUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83NGIzOWMzNi03ODc0
+        LTQ2ZjQtOGJhNy04NTc4YjlmODFjY2UvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy9mOWJhZjA0OC1iZGExLTQ0NmYtOGRj
+        OS1lNzBhZjc1YWM5ODgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy9iMmRjNDI0Yy05ZjcwLTQ4OGUtODZlMi01MGUyZTVl
+        NjgyNWUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9lMzc0MWM4MC1lNDU5LTRlNDgtOTBlYS1kMzBmMzAwZjM0ZDUvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy80NGUx
+        ZjM1Ny1mN2QyLTQ2YzMtODA4ZS04OWQ5ODA3MDkyYzIvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kNzcxNjNiZi0yMTkx
+        LTRhMzgtODE2Ni03ZjlhZTQ5NDJjY2EvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy8xMDQxMTA5NC0zMWQxLTQyMzgtODU0
+        MC00YjFmM2FhMWVlY2EvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6
         W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy81YjY4MWVhNS0zMTUwLTQ5NDgtYTdhMy0zNDZhM2Q3
-        ZDQwN2UvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4x
-        OTU2MjhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzVj
-        ZjhiYmYwLWMwNzUtNGZjMC05ODJiLWEwMmM1MWEyZmFiZS8iLCJkaWdlc3Qi
+        bmVyL21hbmlmZXN0cy81YjM2ZjYyOC01NTViLTQzODAtODY4Ni1jOWEwM2Q2
+        OTRiMzgvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi40
+        MTExMjhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzli
+        NDA2OTYxLTk5MDAtNGYzZC1iNDFiLWIyNmU2YmJkYjJlZS8iLCJkaWdlc3Qi
         OiJzaGEyNTY6MzBkMTQxMmMwZjQ1YmU2N2QzOGI5OTE3OTg2Njg2OGIxZjA5
         ZmQ5MDEzY2JhY2YyMjgxMzkyNmFlZTQyOGNmNyIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlm
         ZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzLzQ2YWZjMmJhLTMwNjAtNDRjYi05ODUyLTNjZTU3MTFjYTRjMC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzU5YzNk
-        M2Q1LTJlYjEtNDUxOC04Y2ZhLWUyZDE0OGY5Zjg1OS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzVjY2M4OTA3LTA0NDct
-        NDAwYS1iNTE5LTVhZGY3NTM5NTRjZi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzL2M5ZDlkY2ZhLTJhZDYtNGNkMi1iNGM3
-        LThhMGY0OWNmMjIxMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzL2QxMDBmYTVhLWVmMWQtNDU2ZC1iZTZjLTdhZjJiYTYx
-        ZTY4Ni8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2M4MmIwNmIyLWZjYmMtNGFjNy1hNDQ4LTQ1ZGFmMzU3ZmZkYy8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzI0NTYy
-        MTcxLTAzMDktNDFhYS05ODgxLTg2MDFlYzMxOTdiZS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2RlOTU5M2Q3LWQxMDUt
-        NDhhNS1hYjM5LTk0OTUyMDA5MTg4OC8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        c3RzL2UzNzQxYzgwLWU0NTktNGU0OC05MGVhLWQzMGYzMDBmMzRkNS8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk5Y2Qy
+        YmM0LWE1Y2UtNDhiMC05MWVkLWY3ZGQ5YjlmYTJiYy8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2Q3NzE2M2JmLTIxOTEt
+        NGEzOC04MTY2LTdmOWFlNDk0MmNjYS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzEwYmZlZDAyLWJhYzYtNDI1Yi1hMjBl
+        LWQ5NjdmYTllN2Q4Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzkyYjYyYWY5LWQ1YjItNGZjNi04MmZhLTQzMzYwMmQ5
+        MjZiYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzL2FiMjM4NzM4LWRlZmItNGIwMi1iOTlkLTVjY2ViNGJiN2YwNS8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzQzMDYx
+        YWE0LTU4OWQtNDhjMy04ZDRjLTU5MzdhZGVjOGM5My8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2YzYjQ0ZTY4LTcwZGUt
+        NDAwNi04ZmQ5LTY5NWQ5OWIxMWQ4NC8iXSwiY29uZmlnX2Jsb2IiOm51bGws
         ImJsb2JzIjpbXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzL2M5YjgzZTZjLTU1NmEtNDBlYy1iYmU0
-        LTExNWRlZjE4MTIwMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIz
-        OjE4OjEzLjE5MzM3M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvMWIxZGYxMTItYWNkZC00NDJmLWI4MWUtYjczMmUwOTFiOWQ5LyIs
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzZjNTFmMTkzLTk1OTQtNDcwMi1hMzY3
+        LWE1YWM3MTg1MTRkNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2
+        OjU0OjMyLjQwNzg1NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvYzczM2E0MTgtNGUwNS00MTU5LWFiZTAtMjRiYTM4MmQxZDQ1LyIs
         ImRpZ2VzdCI6InNoYTI1NjoyMjYzNzc1N2YyZDBmOGUyMGI3NGUzZWYyMjZl
         ZWRkMGJkZjg4MDJjYzc0YWU1OGI2ZTYzMTY4NTdkM2JkZTU2Iiwic2NoZW1h
         X3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9j
         a2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC5saXN0LnYyK2pzb24iLCJsaXN0
         ZWRfbWFuaWZlc3RzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvY2ZkMmNhMDgtZWEyOS00Yzk3LWFjMmYtNGQxOGJjOTFj
-        YTQ4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvMDBlNzlhMTktYjhmNS00NjUxLWJmNDUtNTRiY2M1MjZlY2UyLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNzU1YWI3
-        YjEtOTRiNC00NTZhLThlYTgtMmQ4MWY4M2UwMmNiLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvZDljNjBjZDUtYWE5OS00
-        OTRmLTg2ODMtNTc5MjViMGMzNTZkLyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L2NvbnRhaW5lci9tYW5pZmVzdHMvOTVhZDJhNjItNzhkMS00OWE4LWI2OGQt
-        NGU4OTcxOGY0Yzc4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNjVmOTNmZmYtMjhhOC00NTQ2LTlmYjctNDFkNjUwNmIy
-        M2FkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvZGVhYTY1ZWEtMjFiOS00Y2VjLTkzNzUtMTk2OTVjZWU5MWVkLyJdLCJj
+        ci9tYW5pZmVzdHMvYTFiNDQxYWUtZWIwMC00MDVlLWI3MzctNmUwODI1ZTAy
+        MjU1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvZGY0ZGJjZTQtMTBlNy00MDZlLWEwMDYtMDA1MjU0ZjIwZWI2LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYWEzN2Y5
+        MzktNDdlNy00NDliLTk5MGMtMWMzODI4YjA2ZGNlLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvM2M2NzM5YTMtYmI4Zi00
+        NWI5LWJjYTMtMjc0NWIzM2M2YzRhLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L2NvbnRhaW5lci9tYW5pZmVzdHMvYWE5YmI2YmItOTQ0My00YWU1LTg2YmQt
+        NjIzMTMzMjllMjRhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9tYW5pZmVzdHMvNzk1YmJhNGEtOThlNS00MTI4LTg1NjctMGJjNmYzNDM5
+        OGYyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvMDFiZDU1MTAtMzE4MC00NTQ2LTg1YWItNjgxN2ExODZjYWI2LyJdLCJj
         b25maWdfYmxvYiI6bnVsbCwiYmxvYnMiOltdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1b1f93b5-9840-4a33-80da-7d520f5b41f4/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/06b388ce-f77d-4453-a962-035a777f61ba/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2568,7 +2568,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2581,55 +2581,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:26 GMT
+      - Fri, 29 Jul 2022 09:03:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '798'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2426f598135042588e2eb8078c3f46b9
+      - 361c62ff16044a2ca2b3554f1e94682d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '345'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2MyZWY0M2YyLTdiMTktNDg4Ny04ZGQ4LTQ1MTg1MjgyMjlh
-        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjE1Ljk5NjQx
-        OFoiLCJuYW1lIjoibXVzbCIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYzliODNlNmMtNTU2
-        YS00MGVjLWJiZTQtMTE1ZGVmMTgxMjAzLyJ9LHsicHVscF9ocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvYmMwYmU0NWYtNGFh
-        Yi00MzEzLWIwOGYtM2I2NmExZjJhNGViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MTUuOTk1MzQ2WiIsIm5hbWUiOiJsYXRlc3QiLCJ0
+        aW5lci90YWdzL2I3M2NiMmVlLTIwZGItNDE2NS1hNWMzLTUwNGFhNjkxY2Ew
+        Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjQyLjA3NDM2
+        MVoiLCJuYW1lIjoibXVzbCIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNmM1MWYxOTMtOTU5
+        NC00NzAyLWEzNjctYTVhYzcxODUxNGQ1LyJ9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvYTk2ODBjMTMtOTNl
+        OS00ZWZiLWFiZjQtYmI3YjA4ZWEzY2JhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTY6NTQ6NDIuMDcxOTE3WiIsIm5hbWUiOiJsYXRlc3QiLCJ0
         YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzk5YmE2ZTc3LTRhNjgtNGMzNi05MThhLTE5NGVjNDc5
-        ZmVhNC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Nv
-        bnRhaW5lci90YWdzL2IxZjQ2M2ZiLTA0MjctNDc5Yi05YTQ2LTFhYzJiZWIw
-        YzAyMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjE1Ljk5
-        NDAyOFoiLCJuYW1lIjoiZ2xpYmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzViNjgxZWE1
-        LTMxNTAtNDk0OC1hN2EzLTM0NmEzZDdkNDA3ZS8ifV19
+        ZXIvbWFuaWZlc3RzLzIwZDdjODIzLWQ4ZWQtNGY3OS1hNjZiLTNhZTQ2NmE5
+        OGM1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Nv
+        bnRhaW5lci90YWdzLzhiNzg5M2IxLWRiMWEtNDE4Ny04ZjE2LTE5MzdkZWQ2
+        OGI2OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjQyLjA2
+        ODY1OVoiLCJuYW1lIjoiZ2xpYmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzViMzZmNjI4
+        LTU1NWItNDM4MC04Njg2LWM5YTAzZDY5NGIzOC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:30 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/06e67c5b-db38-4ae8-8620-59501c5088af/remove/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/b403306b-d772-48d8-981a-c24a12ff2d76/remove/
     body:
       encoding: UTF-8
       base64_string: 'eyJjb250ZW50X3VuaXRzIjpbIioiXX0=
@@ -2639,7 +2639,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2652,7 +2652,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:26 GMT
+      - Fri, 29 Jul 2022 09:03:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2670,33 +2670,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc896aafebba4b9ab45b1dd5f2c83da9
+      - 8acf926df5c04c359f3bdfbb2487fed1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1NTFjZGMzLWE5YzQtNDVm
-        YS04MzBhLWRlZmQzZDNhM2Q3Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5YjNkNzhkLTc0NGMtNDQw
+        MS05YWM5LThmNTIwOGEyZTcwNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:31 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/06e67c5b-db38-4ae8-8620-59501c5088af/add/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/container/container/b403306b-d772-48d8-981a-c24a12ff2d76/add/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X3VuaXRzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2IxZjQ2M2ZiLTA0MjctNDc5Yi05YTQ2LTFhYzJiZWIwYzAy
-        MC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9iYzBi
-        ZTQ1Zi00YWFiLTQzMTMtYjA4Zi0zYjY2YTFmMmE0ZWIvIl19
+        aW5lci90YWdzLzhiNzg5M2IxLWRiMWEtNDE4Ny04ZjE2LTE5MzdkZWQ2OGI2
+        OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9hOTY4
+        MGMxMy05M2U5LTRlZmItYWJmNC1iYjdiMDhlYTNjYmEvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2709,7 +2709,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:26 GMT
+      - Fri, 29 Jul 2022 09:03:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2727,21 +2727,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb6d4b46557e4894bb8106637276849a
+      - dc8762c606814a38b125f1864f6959eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliMjMyM2VjLTkxMzQtNDY5
-        YS1hNGRjLTU3MWY1NDA3OWFjNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwMDIxODJiLTEwYWUtNDA1
+        OC1iNDgyLWVkZDA2ZjM1OWY5Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0551cdc3-a9c4-45fa-830a-defd3d3a3d72/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/99b3d78d-744c-4401-9ac9-8f5208a2e706/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2762,52 +2762,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:26 GMT
+      - Fri, 29 Jul 2022 09:03:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '647'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f4396eccccb4e9dad57baa43bddd739
+      - f1ff08d84fc244d6a9ee1cf68e9c1a77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '382'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDU1MWNkYzMtYTlj
-        NC00NWZhLTgzMGEtZGVmZDNkM2EzZDcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjYuNTg2NDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTliM2Q3OGQtNzQ0
+        Yy00NDAxLTlhYzktOGY1MjA4YTJlNzA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MzEuMzg0NzUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsImxvZ2dpbmdfY2lk
-        IjoiYmM4OTZhYWZlYmJhNGI5YWI0NWIxZGQ1ZjJjODNkYTkiLCJzdGFydGVk
-        X2F0IjoiMjAyMi0wNS0yM1QyMzoxODoyNi42MjU3NjNaIiwiZmluaXNoZWRf
-        YXQiOiIyMDIyLTA1LTIzVDIzOjE4OjI2LjcxMDgzNloiLCJlcnJvciI6bnVs
-        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGRmMThhZmYtNjRi
-        OC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBhcmVudF90YXNrIjpudWxs
+        IjoiOGFjZjkyNmRmNWMwNGMzNTlmM2JkZmJiMjQ4N2ZlZDEiLCJzdGFydGVk
+        X2F0IjoiMjAyMi0wNy0yOVQwOTowMzozMS40Njk4NTlaIiwiZmluaXNoZWRf
+        YXQiOiIyMDIyLTA3LTI5VDA5OjAzOjMxLjcxMjk5N1oiLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMWQ2YzIzMTYtNDZl
+        My00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBhcmVudF90YXNrIjpudWxs
         LCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNz
         X3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9jb250YWluZXIvY29udGFpbmVyLzA2ZTY3YzViLWRiMzgtNGFlOC04NjIw
-        LTU5NTAxYzUwODhhZi8iXX0=
+        cy9jb250YWluZXIvY29udGFpbmVyL2I0MDMzMDZiLWQ3NzItNDhkOC05ODFh
+        LWMyNGExMmZmMmQ3Ni8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0551cdc3-a9c4-45fa-830a-defd3d3a3d72/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/99b3d78d-744c-4401-9ac9-8f5208a2e706/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2828,52 +2828,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:26 GMT
+      - Fri, 29 Jul 2022 09:03:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '647'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ba801dd360c44546bb0cc1417a2983ff
+      - bce54208efd14862bb9017e7dad7e3fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '382'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDU1MWNkYzMtYTlj
-        NC00NWZhLTgzMGEtZGVmZDNkM2EzZDcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjYuNTg2NDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTliM2Q3OGQtNzQ0
+        Yy00NDAxLTlhYzktOGY1MjA4YTJlNzA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MzEuMzg0NzUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsImxvZ2dpbmdfY2lk
-        IjoiYmM4OTZhYWZlYmJhNGI5YWI0NWIxZGQ1ZjJjODNkYTkiLCJzdGFydGVk
-        X2F0IjoiMjAyMi0wNS0yM1QyMzoxODoyNi42MjU3NjNaIiwiZmluaXNoZWRf
-        YXQiOiIyMDIyLTA1LTIzVDIzOjE4OjI2LjcxMDgzNloiLCJlcnJvciI6bnVs
-        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGRmMThhZmYtNjRi
-        OC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBhcmVudF90YXNrIjpudWxs
+        IjoiOGFjZjkyNmRmNWMwNGMzNTlmM2JkZmJiMjQ4N2ZlZDEiLCJzdGFydGVk
+        X2F0IjoiMjAyMi0wNy0yOVQwOTowMzozMS40Njk4NTlaIiwiZmluaXNoZWRf
+        YXQiOiIyMDIyLTA3LTI5VDA5OjAzOjMxLjcxMjk5N1oiLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMWQ2YzIzMTYtNDZl
+        My00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBhcmVudF90YXNrIjpudWxs
         LCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNz
         X3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9jb250YWluZXIvY29udGFpbmVyLzA2ZTY3YzViLWRiMzgtNGFlOC04NjIw
-        LTU5NTAxYzUwODhhZi8iXX0=
+        cy9jb250YWluZXIvY29udGFpbmVyL2I0MDMzMDZiLWQ3NzItNDhkOC05ODFh
+        LWMyNGExMmZmMmQ3Ni8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:26 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9b2323ec-9134-469a-a4dc-571f54079ac5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4002182b-10ae-4058-b482-edd06f359f9b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2894,54 +2894,54 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:27 GMT
+      - Fri, 29 Jul 2022 09:03:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '737'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2ccea2fd53b4c6fb677b66d949bff80
+      - 134823afa41f4fc198a79a5ebd5c30b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '393'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWIyMzIzZWMtOTEz
-        NC00NjlhLWE0ZGMtNTcxZjU0MDc5YWM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTg6MjYuNjQyODcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDAwMjE4MmItMTBh
+        ZS00MDU4LWI0ODItZWRkMDZmMzU5ZjliLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMDk6MDM6MzEuNTEyNTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
-        YWRkLnJlY3Vyc2l2ZV9hZGRfY29udGVudCIsImxvZ2dpbmdfY2lkIjoiZWI2
-        ZDRiNDY1NTdlNDg5NGJiODEwNjYzNzI3Njg0OWEiLCJzdGFydGVkX2F0Ijoi
-        MjAyMi0wNS0yM1QyMzoxODoyNi43NDI5OTlaIiwiZmluaXNoZWRfYXQiOiIy
-        MDIyLTA1LTIzVDIzOjE4OjI2Ljg2MDc2NFoiLCJlcnJvciI6bnVsbCwid29y
-        a2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvYjc2MzgxOGYtMDM5Mi00ZmUx
-        LWFlZGEtNjUzZmQxYTExY2Q5LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGls
+        YWRkLnJlY3Vyc2l2ZV9hZGRfY29udGVudCIsImxvZ2dpbmdfY2lkIjoiZGM4
+        NzYyYzYwNjgxNGEzOGIxMjVmMTg2NGY2OTU5ZWIiLCJzdGFydGVkX2F0Ijoi
+        MjAyMi0wNy0yOVQwOTowMzozMS43NjU3MTFaIiwiZmluaXNoZWRfYXQiOiIy
+        MDIyLTA3LTI5VDA5OjAzOjMxLjk2MDQ1OFoiLCJlcnJvciI6bnVsbCwid29y
+        a2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNTlkZTU1NzUtM2RkNy00OWVl
+        LTlmNjYtMDU5ODNhNGJmMjA4LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGls
         ZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9y
         dHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDZlNjdjNWItZGIzOC00
-        YWU4LTg2MjAtNTk1MDFjNTA4OGFmL3ZlcnNpb25zLzEvIl0sInJlc2VydmVk
+        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjQwMzMwNmItZDc3Mi00
+        OGQ4LTk4MWEtYzI0YTEyZmYyZDc2L3ZlcnNpb25zLzEvIl0sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9jb250YWluZXIvY29udGFpbmVyLzA2ZTY3YzViLWRiMzgtNGFlOC04NjIw
-        LTU5NTAxYzUwODhhZi8iXX0=
+        cy9jb250YWluZXIvY29udGFpbmVyL2I0MDMzMDZiLWQ3NzItNDhkOC05ODFh
+        LWMyNGExMmZmMmQ3Ni8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/06e67c5b-db38-4ae8-8620-59501c5088af/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/b403306b-d772-48d8-981a-c24a12ff2d76/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2949,7 +2949,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2962,233 +2962,233 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:27 GMT
+      - Fri, 29 Jul 2022 09:03:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8812'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d06467fae37d499cbc2cb8fdfb4d8a49
+      - e4b276818b0b4d7684d2d24e97d87dcd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2443'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTUsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvbWFuaWZlc3RzL2M4MmIwNmIyLWZjYmMtNGFjNy1hNDQ4LTQ1ZGFm
-        MzU3ZmZkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEz
-        LjY2NzEzNFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        NWIxMDE5NGEtMzE3Zi00MDY3LWIzZWMtMjcwYmI4MjJlYzhhLyIsImRpZ2Vz
+        YWluZXIvbWFuaWZlc3RzL2YzYjQ0ZTY4LTcwZGUtNDAwNi04ZmQ5LTY5NWQ5
+        OWIxMWQ4NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMz
+        LjU5MDM3MloiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        N2U5YjhiMDMtM2Q3YS00OThkLWFjMGMtNjQwNDNkMTYwZDBkLyIsImRpZ2Vz
         dCI6InNoYTI1Njo2ZTZkMTMwNTVlZDgxYjcxNDRhZmFhZDE1MTUwZmMxMzdk
         NGY2Mzk0ODJiZWIzMTFhYWEwOTdiYzU3ZTNjYjgwIiwic2NoZW1hX3ZlcnNp
         b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
         c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
         cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL2Jsb2JzL2E0Mzk2NWYzLTdiYjAtNGVhYi05OWZiLTIyNWUwYWIz
-        MjNlOC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvZjg2ZjA5ZDktOTJhYi00NWU4LTk5M2UtYmQzNWIxNTM0ZGI1
+        dGFpbmVyL2Jsb2JzLzQ3MTEyZjk5LTMzZTgtNDdhMC1hMWExLTQ2NGQzODQz
+        ZDhmZS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvM2I5ODg5MjYtM2RkOS00M2I3LWI1ZDMtNGEyZWY3YjY0YmJi
         LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvYzlkOWRjZmEtMmFkNi00Y2QyLWI0YzctOGEwZjQ5
-        Y2YyMjEzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMu
-        NjY0ODQ0WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
-        MmU2OTE3MS1jNzczLTRlZmMtYjU5Ny01ZjE3ODQ2MjA4MDEvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvNDMwNjFhYTQtNTg5ZC00OGMzLThkNGMtNTkzN2Fk
+        ZWM4YzkzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMu
+        NTg0ODg3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        ZjMzMjJkYS0wNjExLTQxZTYtODhmOS03MzA4OTY0N2RiNGMvIiwiZGlnZXN0
         Ijoic2hhMjU2OjIwZThkNmZlNGJiMTEzMTVlMDhmYjY5MmNkNzE2OTYxNjdi
         MDFkYTYxMDUwODIxNTFlZmM0NTRlMDY1OTA4ZjkiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvNGRlMWI1MWUtNTFlOC00OGJhLThkNGYtNDQ1MzIyMmQ5
-        ZmZlLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9kYTYxYjI0Zi05MTM3LTQxYTEtODIzZi1hYzBjYmQ0MWVmNmIv
+        YWluZXIvYmxvYnMvODRlMzFmNTMtNTMwNC00YTljLWI1NjktN2Y0ODQzM2Yx
+        YjAzLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy84YzNiNTNhYi0zM2I3LTQ0OGQtYThkZi1hM2I3NTYzOTFmZWIv
         Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy81YTBhOGUzYy0yMDU4LTRlOWQtYWIyMS1jZjc1ODk5
-        ZGIyMjYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41
-        ODA3ODhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzgw
-        ODhkNDQzLTkwNDYtNDVmYS1hOTI0LTE0OWQzZTE5NGViNy8iLCJkaWdlc3Qi
-        OiJzaGEyNTY6YmE2NWU4ZDM5ZTg5YjVjMTZmMDM2Yzg4Yzg1OTUyNzU2Nzc3
-        YmY1Mzg1YmNlMTQ4YmM0NGJlNDhmYWMzN2Q5NCIsInNjaGVtYV92ZXJzaW9u
+        bmVyL21hbmlmZXN0cy8xMDQxMTA5NC0zMWQxLTQyMzgtODU0MC00YjFmM2Fh
+        MWVlY2EvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4x
+        MzM3NDZaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M1
+        MWZhYzAzLWQxOTctNGZkMi04YThhLWY3ZTA1ODRiNTQ3ZC8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6ZDdlODMzMTZkNzRlMTUwODY2ZDgyYzQ1ZGUzNDJlNzhmNjYy
+        ZmUwYWVmYmRiODIyZDdkMTBjOGI4ZTM5Y2M0YiIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
         OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy9mNTU0ODYzYS0xODcxLTRhNDktOGY2Zi1iZmNiNDhiOTVh
-        NWQvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzA0YWJjNmU4LWQwYzctNDRjNy1iODVjLWZlZmM5N2MwNTdhZC8i
+        aW5lci9ibG9icy82ZDA2YWRmNS1kNzQ4LTQ3ZDAtODFmYi1jYzE3Y2Y2YWNi
+        MTkvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzL2JlZjlkMTg3LTQ3Y2MtNGQ2YS04ZjUyLTVhZDY5ZjJkMjc2Ny8i
         XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzQ2YWZjMmJhLTMwNjAtNDRjYi05ODUyLTNjZTU3MTFj
-        YTRjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjU3
-        OTI3M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGMx
-        ZjI4NjAtZWQyMi00MzViLWI0YjEtZDIwZWY5ZmRlNTA2LyIsImRpZ2VzdCI6
-        InNoYTI1NjozMjk2OGU3MTdlMjlmNzllNWI4ODk3MjE5MDhiM2JlNmQxNTcz
-        OTkyZTFmM2JhNGM5YTQxNzE4ZTI3Mjg0NThjIiwic2NoZW1hX3ZlcnNpb24i
+        ZXIvbWFuaWZlc3RzL2FiMjM4NzM4LWRlZmItNGIwMi1iOTlkLTVjY2ViNGJi
+        N2YwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjEz
+        MTU2MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmQ4
+        MjIwN2QtY2Y2NS00NDljLThlMjUtM2NhMDM5NjNlMTg3LyIsImRpZ2VzdCI6
+        InNoYTI1Njo2Y2E5YTU2YjJiOTNiZTE2YTYyZTZkNDRhZDQ3ZTZkMzIwMTI2
+        MzMyZDFlMjc1MDllMTNmYTJjYzQ5YjEwZTllIiwic2NoZW1hX3ZlcnNpb24i
         OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
         aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
         W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL2Jsb2JzLzI4MWI1YmNmLTVmMDgtNGEwOS1iNzBiLTAxMTM5OThhMWRl
-        Yi8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvYzZmYzA2YjUtMGYxNC00YTViLWE3YmItZDFkNjI4MWZjNWQzLyJd
+        bmVyL2Jsb2JzLzc4MWQ1YmRkLWRiNjAtNGNlZi1iODUwLTYyNmU4ZTYxZmRi
+        ZC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
+        YmxvYnMvZTNlOTM0MjEtZmJiZC00MzU0LTgxMmYtNjQ1YzY1MGY3ZTYwLyJd
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNjNjZGIyMzgtNmE5Zi00ZTBjLThkYTktZTNiNzgwMjVk
-        ZWJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNTQ0
-        MDMyWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iODEw
-        ODRjZC0yMmE4LTQ4ZmMtYTFiMi0zMGY2YjJkNWRhYTAvIiwiZGlnZXN0Ijoi
-        c2hhMjU2OmI4OTQ2MTg0Y2UzYWQ2YjRhMDllYmFkMmQ4NWU4MWNmY2FhZGM2
-        ODk3YmZhZTJlOWM2ZTJhNGZlNmFmYTZlZTAiLCJzY2hlbWFfdmVyc2lvbiI6
+        ci9tYW5pZmVzdHMvOTJiNjJhZjktZDViMi00ZmM2LTgyZmEtNDMzNjAyZDky
+        NmJiLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMTI3
+        MzY1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8yZjVk
+        YTlmYS1jYzkyLTRjMGMtODY0ZS0xYzAxOGE1YTI0ODYvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OjMyOTY4ZTcxN2UyOWY3OWU1Yjg4OTcyMTkwOGIzYmU2ZDE1NzM5
+        OTJlMWYzYmE0YzlhNDE3MThlMjcyODQ1OGMiLCJzY2hlbWFfdmVyc2lvbiI6
         MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
         YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
         XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvYzEwZDQ2OTAtOWIxZi00NDI4LTgxYjEtZWM3OGQyYTMyNDgz
+        ZXIvYmxvYnMvY2FjM2E5NTYtNmI5NC00YTZjLWE0MjItNjI2Yzk0M2EzNDE3
         LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9jM2RlYzJjZi0wZjYwLTQ0ZjktOTkxMS1jNTc0ODM1ZDMyMGEvIl19
+        bG9icy8zMzVmZTUxYy0zZDk5LTRiNmItOGRhMi02ZGYxMmU4MTA4MDkvIl19
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L21hbmlmZXN0cy81Y2NjODkwNy0wNDQ3LTQwMGEtYjUxOS01YWRmNzUzOTU0
-        Y2YvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41NDI4
-        MzNaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U1ZjVj
-        NmJmLTRjOWUtNDU1NS1hNWM2LTJmOTUxMzI2MGY3ZC8iLCJkaWdlc3QiOiJz
-        aGEyNTY6NmNhOWE1NmIyYjkzYmUxNmE2MmU2ZDQ0YWQ0N2U2ZDMyMDEyNjMz
-        MmQxZTI3NTA5ZTEzZmEyY2M0OWIxMGU5ZSIsInNjaGVtYV92ZXJzaW9uIjoy
+        L21hbmlmZXN0cy8xMGJmZWQwMi1iYWM2LTQyNWItYTIwZS1kOTY3ZmE5ZTdk
+        OGMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4xMjQw
+        ODFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzZjZmZh
+        ZGRlLTI3ZDMtNDg4MS1iNTc0LTAyYTFkZDE5ZmE2OS8iLCJkaWdlc3QiOiJz
+        aGEyNTY6MWZhYWY3YTc1MzE5NDE3MjYxMjY3YjNkY2VmNmEyYjE0YzhjNTEy
+        MmQ3ZmNjN2FiZWIwN2EzMmJjMTk3MjhmZCIsInNjaGVtYV92ZXJzaW9uIjoy
         LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
         dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
         LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy8yOWM3MWNiNS02OWExLTQwNjgtOTA0My1jZjEzY2NhZGNjZDIv
+        ci9ibG9icy9iYjgyYmQwMC04ZjdiLTQ5ZjgtYWEwYi1kZmVkZTc0Y2E0YTgv
         IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzFiODc2MTRkLTMzMmMtNGMwYy1iNmY4LTE4ZWVhYmE5MTA0OC8iXX0s
+        b2JzLzZhNTgwMWM4LThiM2ItNDU1ZS04ZDJiLTk2NTI4YjM3OWJlYS8iXX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        bWFuaWZlc3RzL2RlOTU5M2Q3LWQxMDUtNDhhNS1hYjM5LTk0OTUyMDA5MTg4
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjU0MTYx
-        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZGM0Yjk4
-        YmYtYmQ1Ny00Mzk1LWExNzUtZWE5ZDNhMGUzYmZhLyIsImRpZ2VzdCI6InNo
-        YTI1Njo0MjZjODU1Nzc1ZjAyNmQzZmU3Njk4OGI3MTkzOGY0YzlkYzY4NDBm
-        MDljMGYyOWQ4ZDRjNzVjYzQyMzg1MDNiIiwic2NoZW1hX3ZlcnNpb24iOjIs
+        bWFuaWZlc3RzL2Q3NzE2M2JmLTIxOTEtNGEzOC04MTY2LTdmOWFlNDk0MmNj
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjEyMDk3
+        NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODQwYTU5
+        ODYtNWE4ZC00Yjk2LTg3YjctNjExMzlmMWVjNTJlLyIsImRpZ2VzdCI6InNo
+        YTI1NjowYTExYTk1NTY4YjY4MGRjZTY5MDZhMDE1YmVkODgzODFlMjhhZDE3
+        YjMxYTYzZjdmZWMwNTdiMzU1NzMyMzVhIiwic2NoZW1hX3ZlcnNpb24iOjIs
         Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
         dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
         ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzMwMmQ0YjYyLWYxYWQtNDgyOS1iYWNkLTUyZjUwNDM3MGM0Zi8i
+        L2Jsb2JzLzViNDU2M2JhLWE5MzctNGQ5NS1iMzdhLWUxMDViMjI0ODc1My8i
         LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvYTExYTQ5N2MtZDAxZS00YmYwLWIzYjMtYWEyYTllYzFhYTEzLyJdfSx7
+        YnMvZmIzNGYwNTktZDE4Mi00NjJhLWFkMGEtMDRkNjRiZDZlOGYzLyJdfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
-        YW5pZmVzdHMvZDEwMGZhNWEtZWYxZC00NTZkLWJlNmMtN2FmMmJhNjFlNjg2
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNTQwMzcw
-        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mYWI4MjMy
-        Yi01YmJkLTQxMTQtYWIyYi1kY2M5YmFkYzhhMjgvIiwiZGlnZXN0Ijoic2hh
-        MjU2OjFmYWFmN2E3NTMxOTQxNzI2MTI2N2IzZGNlZjZhMmIxNGM4YzUxMjJk
-        N2ZjYzdhYmViMDdhMzJiYzE5NzI4ZmQiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        YW5pZmVzdHMvOTljZDJiYzQtYTVjZS00OGIwLTkxZWQtZjdkZDliOWZhMmJj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMTE4NTcx
+        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9lNTlkMjhm
+        MS04YTdkLTQ5MWUtODUxNS1lOTEwNDhkOGE5YjQvIiwiZGlnZXN0Ijoic2hh
+        MjU2OjA2NWE2NzE0Njk3YjRhNmQyN2ZiMTNhMTI4MzBmMGE5ZmY4MWE0MDQ5
+        OGJlYjlkYTQ5YWRiN2NmZDg3YjA1NGQiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
         bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
         aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
         Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvMWNlNWNjM2ItODRjMy00MmM5LWI2NGItYzYxMjI4YTNjZjg2LyIs
+        YmxvYnMvOWFkNzIxOWYtOTY4Ni00ZjgxLWE4ZmQtZmExOWZmNjkxMjVkLyIs
         ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy84MjY0Mzk4Ny02YjA0LTQxNWItOGFiMC04ZTcwZGNjNGE3YWUvIl19LHsi
+        cy9kMWMyZGYwZS1hMjY2LTQ4ZDEtOTc4OC01MTMwOTMyMDgyNjQvIl19LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
-        bmlmZXN0cy8yNDU2MjE3MS0wMzA5LTQxYWEtOTg4MS04NjAxZWMzMTk3YmUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy41MzkwNDNa
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2VlNWNhYzRk
-        LWYwZmEtNDAwNy1hN2RiLTk5YjMyMjBmY2RlYi8iLCJkaWdlc3QiOiJzaGEy
-        NTY6MGExMWE5NTU2OGI2ODBkY2U2OTA2YTAxNWJlZDg4MzgxZTI4YWQxN2Iz
-        MWE2M2Y3ZmVjMDU3YjM1NTczMjM1YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
+        bmlmZXN0cy80NGUxZjM1Ny1mN2QyLTQ2YzMtODA4ZS04OWQ5ODA3MDkyYzIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMy4wNzUyNTBa
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2I2Y2YxYzhm
+        LTkwNDQtNDk3Zi1hYWI2LWM4ODk4MDAzNTMzZi8iLCJkaWdlc3QiOiJzaGEy
+        NTY6YmE2NWU4ZDM5ZTg5YjVjMTZmMDM2Yzg4Yzg1OTUyNzU2Nzc3YmY1Mzg1
+        YmNlMTQ4YmM0NGJlNDhmYWMzN2Q5NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
         ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
         b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
         b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy8yM2RjMjc3Zi02OWUwLTRjNGYtYTM5OS0zYzIxODEzOGVmZWQvIiwi
+        bG9icy8zYTY1N2Y5MC05OTEyLTRhMDgtYjk0OC01YzU4MDZlMjI3N2MvIiwi
         YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzQ5MWM2OGRkLTViODQtNDM0Ni1hMDA1LWQxYjI3NDZkMjkzMy8iXX0seyJw
+        Lzk1Y2RlYTEzLTQ5ODYtNDE1YS1hYzc2LTZkYjZiNzU0NjY2ZC8iXX0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFu
-        aWZlc3RzLzU5YzNkM2Q1LTJlYjEtNDUxOC04Y2ZhLWUyZDE0OGY5Zjg1OS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjUzNzY0MFoi
-        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODQyNDFiMjct
-        YjI2NC00MmQ1LTkyODEtYmJkNjY2MzY1YjcyLyIsImRpZ2VzdCI6InNoYTI1
-        NjowNjVhNjcxNDY5N2I0YTZkMjdmYjEzYTEyODMwZjBhOWZmODFhNDA0OThi
-        ZWI5ZGE0OWFkYjdjZmQ4N2IwNTRkIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        aWZlc3RzL2UzNzQxYzgwLWU0NTktNGU0OC05MGVhLWQzMGYzMDBmMzRkNS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMzLjA3Mjc5MFoi
+        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjcyYTQ1MWUt
+        NTg4NC00MDQ3LWIwODYtZWE3ZWIxMzBiNGU1LyIsImRpZ2VzdCI6InNoYTI1
+        Njo0MjZjODU1Nzc1ZjAyNmQzZmU3Njk4OGI3MTkzOGY0YzlkYzY4NDBmMDlj
+        MGYyOWQ4ZDRjNzVjYzQyMzg1MDNiIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
         ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
         bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
         bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzAxMmNmYTRlLWE1Y2EtNDBmNy1hMzljLWJkYjg3MTEwMjk5MC8iLCJi
+        b2JzL2NjZmJlNjhjLTAwMWYtNDc5Ni1iOGQzLTRkNTNiYmU2YTQzOC8iLCJi
         bG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MDEzMDQ3ZDEtNDYyYi00ODBhLTk1MzAtMjIxOTA5MDJkMWFiLyJdfSx7InB1
+        NWRjOTJjMWUtM2UxMi00ZjhlLWEwMWEtMzk4OTM3YTIxNTgyLyJdfSx7InB1
         bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5p
-        ZmVzdHMvNzYxODc3MTAtYWJhMy00ZDgwLWEyZDEtYjQwYWIwYzkxNzc0LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuNDk3NDUxWiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82NmM3NzU2OS03
-        NTE2LTQ2MWUtYWJhNS1jYzQ3MTcwZDRiZTIvIiwiZGlnZXN0Ijoic2hhMjU2
-        OmQ3ZTgzMzE2ZDc0ZTE1MDg2NmQ4MmM0NWRlMzQyZTc4ZjY2MmZlMGFlZmJk
-        YjgyMmQ3ZDEwYzhiOGUzOWNjNGIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        ZmVzdHMvYjJkYzQyNGMtOWY3MC00ODhlLTg2ZTItNTBlMmU1ZTY4MjVlLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzMuMDI2NjUyWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9hN2ViZDM5Ni1l
+        MmVlLTQzN2UtYjAyNS0yMjMyYzgzNGY2MzUvIiwiZGlnZXN0Ijoic2hhMjU2
+        OmI4OTQ2MTg0Y2UzYWQ2YjRhMDllYmFkMmQ4NWU4MWNmY2FhZGM2ODk3YmZh
+        ZTJlOWM2ZTJhNGZlNmFmYTZlZTAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
         aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
         Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
         ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvZjQ2MmFkNmItNDRmYi00Njg1LWEwMTktNzA5Mjc5NThiMzA2LyIsImJs
-        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9m
-        ZWI2YTYzMi0xMDVhLTQzMzQtYTgyZS04OTM1OTQ0Zjk5MzQvIl19LHsicHVs
+        YnMvOWU5OTJjNDYtZWEwYS00ZDAwLThlOWYtYTE3YjkzM2E1ODhmLyIsImJs
+        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9j
+        MjgyZmRkMi0yMTUwLTQ3MjctOGZiNi0zZmFjYmM3NDBiN2EvIl19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9mZDE2MjUwNC1hMGUyLTQ1MTctYWExNS1hYjhiYjgwOTQ5OTkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy40OTYxNTBaIiwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzdjZDhhMDk0LWY2
-        YTgtNDQwNS05YTYxLTQxODQ5YjY0NDZhNS8iLCJkaWdlc3QiOiJzaGEyNTY6
+        ZXN0cy9mOWJhZjA0OC1iZGExLTQ0NmYtOGRjOS1lNzBhZjc1YWM5ODgvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi44ODgzNjBaIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Q5MDBhYTViLWM2
+        N2EtNDM1NC1hNDQ0LWIzZTM3Y2ZmZGJhMy8iLCJkaWdlc3QiOiJzaGEyNTY6
         NjY1NWRmMDRhM2RmODUzYjAyOWE1ZmFjODgzNjAzNWFjNGZhYjExNzgwMGM5
         YTZjNGI2OTM0MWJiNTMwNmMzZCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
         YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
         bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
         aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy84ZDU2ZGFlYS03YmYyLTQzMjUtYTk4Yy04ZjJlYzhhMTlhODYvIiwiYmxv
-        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Y5
-        NzQ2YjVmLTRkNTQtNGM0OC04YTEyLThhYTJiMzQ4MzBjZi8iXX0seyJwdWxw
+        cy82YTEyMTJkNS1jZTZmLTRjNDYtOWMzZC0yZTAxYjU2MDQwNTYvIiwiYmxv
+        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Zl
+        ZjBmYmZlLTMxNTQtNDM4Ni05OGY3LTZiNTg3MzI5OGM0OC8iXX0seyJwdWxw
         X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzLzY2YjM1MTdlLTI2NDEtNDJlZC1iOWRmLWIzOTI4ZjI5OTUwYi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjEzLjM5Njc0NFoiLCJh
-        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDVmNDFhYzUtZjdi
-        MC00MWRlLThjMGEtMDMzN2QzZGU1ODlhLyIsImRpZ2VzdCI6InNoYTI1Njpj
+        c3RzLzc0YjM5YzM2LTc4NzQtNDZmNC04YmE3LTg1NzhiOWY4MWNjZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjMyLjc1NTUzM1oiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMTlmNzVmMDUtYzI5
+        Mi00ZTdhLTgxY2ItODZkYjMzNDk0MzY0LyIsImRpZ2VzdCI6InNoYTI1Njpj
         ZTgwMDg3MjA5MmMzN2M1ZjIwZWYxMTFhNWE2OWM1YzhlOTRkMGM1ZTA1NWY3
         NmY1MzBjYjVlNzhhMjZlYzAzIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
         X3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5t
         YW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZp
         Z19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzJkMjgxNjJkLWQ2YmQtNGI0ZC1hOTQ5LTY3MmM3MDQ4MjM4Ny8iLCJibG9i
-        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvNDg4
-        MDFiNGUtNTM2MC00ZmQzLWEyYjktYjIzZTRjYTNiOGMyLyJdfSx7InB1bHBf
+        Lzc2MzExNDA0LWE4NDktNGM5NC04YzQ0LTc0NTYyM2ViNWQyOC8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvYWVi
+        NTMwNzMtZjMwOC00NDE2LWJhNTgtMDkwYWZkNzkyOTkxLyJdfSx7InB1bHBf
         aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvYzY0NWI5ZTgtZmRmNy00ZGRhLTllZjktZDQwNTY3NTYwMTQwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMuMzk0ODIyWiIsImFy
-        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9jODU1N2ZhOS0xOTUz
-        LTQ1NmUtOTkzZi0zZjQ4OWE5YWFkOTUvIiwiZGlnZXN0Ijoic2hhMjU2OmM5
+        dHMvYmU2NTMxNmEtZjc3Zi00OWNhLTgwM2UtZjgwNTZhZmNiYjU1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIuNzUyMjYxWiIsImFy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wNGU3Yjc4NC0xMmYz
+        LTQ1ZDgtYmQ0My0xNTI5N2FjNDdhODcvIiwiZGlnZXN0Ijoic2hhMjU2OmM5
         MjQ5ZmRmNTYxMzhmMGQ5MjllMjA4MGFlOThlZTljYjI5NDZmNzE0OThmYzE0
         ODQyODhlNmE5MzViNWU1YmMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
         dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
         bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
         X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MDk4OTJmMzgtZjQzOS00YTMwLTllYTUtNDRhOWY3NTA2N2IzLyIsImJsb2Jz
-        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy8yY2Ey
-        NTcxNy01YWVjLTRiNTctODEwNy0yZjk4NTczMWI4M2IvIl19LHsicHVscF9o
+        OTc0ZGRhMjAtYjk1Ny00OGU4LWJhMWItOTAyY2UxYTU3YWE2LyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9hNzQ2
+        ZjFlNy1kOTBjLTRmZWItYWE1Ni04NzQ5NTA5MTk4ZTMvIl19LHsicHVscF9o
         cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0
-        cy82YmMwOGI2My00NTExLTQ2NmYtYmE5Ni1jOWE0MjA0MTc4MDkvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4zOTI3OTBaIiwiYXJ0
-        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2RmN2YyM2IzLTJkMjkt
-        NGM2Yy1hZjQ3LTY3MWEwYzI5MmEyYi8iLCJkaWdlc3QiOiJzaGEyNTY6YTdj
+        cy9lOTMwOGY1OS00NTZmLTQzZmYtOWY3OS1iMjMxMmZhYmNlZjgvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi43MjE3MjVaIiwiYXJ0
+        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzkyYWJhNGZjLTZhOTgt
+        NDVlMy1iN2FjLTdiMDk0OGUwZGI5ZC8iLCJkaWdlc3QiOiJzaGEyNTY6YTdj
         NTcyYzI2Y2E0NzBiMzE0OGQ2YzFlNDhhZDNkYjkwNzA4YTI3NjlmZGY4MzZh
         YTQ0ZDc0YjgzMTkwNDk2ZCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
         eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFu
         aWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdf
-        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy8z
-        ZWUxNDY4Yi0yZmVmLTRkZWItOGVlZS03YTE1Njc1Mjg2YjAvIiwiYmxvYnMi
-        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzhjMGY1
-        NDNiLWQ4YzEtNDliNi1iNzQ3LTM4NzVkYWM4MWRmNS8iXX1dfQ==
+        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy8x
+        M2ZhODk5YS1mMTliLTQyZjUtOWUxNC00YjMxZDYyM2RjMTcvIiwiYmxvYnMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzljOGRm
+        OTQ3LTlmMTUtNGFlNi1iMmRlLWRhYTU5MjM5ZmJiZC8iXX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/06e67c5b-db38-4ae8-8620-59501c5088af/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/b403306b-d772-48d8-981a-c24a12ff2d76/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3196,7 +3196,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3209,89 +3209,89 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:27 GMT
+      - Fri, 29 Jul 2022 09:03:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2308'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fdfa1292973d40c49609de051ac4310d
+      - 77cdeaad98414e4595fa3f9eef99eee1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '822'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvOTliYTZlNzctNGE2OC00YzM2LTkxOGEtMTk0ZWM0
-        NzlmZWE0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTg6MTMu
-        MTk4NDAyWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        MmRmMTBiNS0xZjc2LTQ3ZTYtOThhOC0zOGFmNGM4NjI1NjMvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvMjBkN2M4MjMtZDhlZC00Zjc5LWE2NmItM2FlNDY2
+        YTk4YzU2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NTQ6MzIu
+        NDE2MjQ3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9h
+        ZTRhM2ViNC0xZTY5LTRkNmYtYjdmMy1jOWQ2NmQ4YWU2ZGUvIiwiZGlnZXN0
         Ijoic2hhMjU2OmE5Mjg2ZGVmYWJhN2IzYTUxOWQ1ODViYTBlMzdkMGIyY2Jl
         ZTc0ZWJmZTU5MDk2MGIwYjFkNmE1ZTk3ZDFlMWQiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
         ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9jNjQ1YjllOC1mZGY3LTRkZGEtOWVmOS1kNDA1Njc1NjAxNDAvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82YmMw
-        OGI2My00NTExLTQ2NmYtYmE5Ni1jOWE0MjA0MTc4MDkvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82NmIzNTE3ZS0yNjQx
-        LTQyZWQtYjlkZi1iMzkyOGYyOTk1MGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy83NjE4NzcxMC1hYmEzLTRkODAtYTJk
-        MS1iNDBhYjBjOTE3NzQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy82M2NkYjIzOC02YTlmLTRlMGMtOGRhOS1lM2I3ODAy
-        NWRlYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy8yNDU2MjE3MS0wMzA5LTQxYWEtOTg4MS04NjAxZWMzMTk3YmUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy81YTBh
-        OGUzYy0yMDU4LTRlOWQtYWIyMS1jZjc1ODk5ZGIyMjYvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9mZDE2MjUwNC1hMGUy
-        LTQ1MTctYWExNS1hYjhiYjgwOTQ5OTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy9kZTk1OTNkNy1kMTA1LTQ4YTUtYWIz
-        OS05NDk1MjAwOTE4ODgvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6
+        ZXN0cy9lOTMwOGY1OS00NTZmLTQzZmYtOWY3OS1iMjMxMmZhYmNlZjgvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iZTY1
+        MzE2YS1mNzdmLTQ5Y2EtODAzZS1mODA1NmFmY2JiNTUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83NGIzOWMzNi03ODc0
+        LTQ2ZjQtOGJhNy04NTc4YjlmODFjY2UvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy9mOWJhZjA0OC1iZGExLTQ0NmYtOGRj
+        OS1lNzBhZjc1YWM5ODgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy9iMmRjNDI0Yy05ZjcwLTQ4OGUtODZlMi01MGUyZTVl
+        NjgyNWUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9lMzc0MWM4MC1lNDU5LTRlNDgtOTBlYS1kMzBmMzAwZjM0ZDUvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy80NGUx
+        ZjM1Ny1mN2QyLTQ2YzMtODA4ZS04OWQ5ODA3MDkyYzIvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9kNzcxNjNiZi0yMTkx
+        LTRhMzgtODE2Ni03ZjlhZTQ5NDJjY2EvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy8xMDQxMTA5NC0zMWQxLTQyMzgtODU0
+        MC00YjFmM2FhMWVlY2EvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6
         W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy81YjY4MWVhNS0zMTUwLTQ5NDgtYTdhMy0zNDZhM2Q3
-        ZDQwN2UvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxODoxMy4x
-        OTU2MjhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzVj
-        ZjhiYmYwLWMwNzUtNGZjMC05ODJiLWEwMmM1MWEyZmFiZS8iLCJkaWdlc3Qi
+        bmVyL21hbmlmZXN0cy81YjM2ZjYyOC01NTViLTQzODAtODY4Ni1jOWEwM2Q2
+        OTRiMzgvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NDozMi40
+        MTExMjhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzli
+        NDA2OTYxLTk5MDAtNGYzZC1iNDFiLWIyNmU2YmJkYjJlZS8iLCJkaWdlc3Qi
         OiJzaGEyNTY6MzBkMTQxMmMwZjQ1YmU2N2QzOGI5OTE3OTg2Njg2OGIxZjA5
         ZmQ5MDEzY2JhY2YyMjgxMzkyNmFlZTQyOGNmNyIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlm
         ZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzLzQ2YWZjMmJhLTMwNjAtNDRjYi05ODUyLTNjZTU3MTFjYTRjMC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzU5YzNk
-        M2Q1LTJlYjEtNDUxOC04Y2ZhLWUyZDE0OGY5Zjg1OS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzVjY2M4OTA3LTA0NDct
-        NDAwYS1iNTE5LTVhZGY3NTM5NTRjZi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzL2M5ZDlkY2ZhLTJhZDYtNGNkMi1iNGM3
-        LThhMGY0OWNmMjIxMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzL2QxMDBmYTVhLWVmMWQtNDU2ZC1iZTZjLTdhZjJiYTYx
-        ZTY4Ni8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2M4MmIwNmIyLWZjYmMtNGFjNy1hNDQ4LTQ1ZGFmMzU3ZmZkYy8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzI0NTYy
-        MTcxLTAzMDktNDFhYS05ODgxLTg2MDFlYzMxOTdiZS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2RlOTU5M2Q3LWQxMDUt
-        NDhhNS1hYjM5LTk0OTUyMDA5MTg4OC8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        c3RzL2UzNzQxYzgwLWU0NTktNGU0OC05MGVhLWQzMGYzMDBmMzRkNS8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk5Y2Qy
+        YmM0LWE1Y2UtNDhiMC05MWVkLWY3ZGQ5YjlmYTJiYy8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2Q3NzE2M2JmLTIxOTEt
+        NGEzOC04MTY2LTdmOWFlNDk0MmNjYS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzEwYmZlZDAyLWJhYzYtNDI1Yi1hMjBl
+        LWQ5NjdmYTllN2Q4Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzkyYjYyYWY5LWQ1YjItNGZjNi04MmZhLTQzMzYwMmQ5
+        MjZiYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzL2FiMjM4NzM4LWRlZmItNGIwMi1iOTlkLTVjY2ViNGJiN2YwNS8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzQzMDYx
+        YWE0LTU4OWQtNDhjMy04ZDRjLTU5MzdhZGVjOGM5My8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2YzYjQ0ZTY4LTcwZGUt
+        NDAwNi04ZmQ5LTY5NWQ5OWIxMWQ4NC8iXSwiY29uZmlnX2Jsb2IiOm51bGws
         ImJsb2JzIjpbXX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/06e67c5b-db38-4ae8-8620-59501c5088af/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/b403306b-d772-48d8-981a-c24a12ff2d76/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3299,7 +3299,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.10.3/ruby
+      - OpenAPI-Generator/2.10.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3312,45 +3312,45 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:18:27 GMT
+      - Fri, 29 Jul 2022 09:03:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '550'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dcc1680e5ae442df8c00afb9e0879e7e
+      - c763104b1f184d4db3b46a1ed4bc2701
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '287'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2JjMGJlNDVmLTRhYWItNDMxMy1iMDhmLTNiNjZhMWYyYTRl
-        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE4OjE1Ljk5NTM0
-        NloiLCJuYW1lIjoibGF0ZXN0IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy85OWJhNmU3Ny00
-        YTY4LTRjMzYtOTE4YS0xOTRlYzQ3OWZlYTQvIn0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9iMWY0NjNmYi0w
-        NDI3LTQ3OWItOWE0Ni0xYWMyYmViMGMwMjAvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMi0wNS0yM1QyMzoxODoxNS45OTQwMjhaIiwibmFtZSI6ImdsaWJjIiwi
+        aW5lci90YWdzL2E5NjgwYzEzLTkzZTktNGVmYi1hYmY0LWJiN2IwOGVhM2Ni
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU0OjQyLjA3MTkx
+        N1oiLCJuYW1lIjoibGF0ZXN0IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8yMGQ3YzgyMy1k
+        OGVkLTRmNzktYTY2Yi0zYWU0NjZhOThjNTYvIn0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy84Yjc4OTNiMS1k
+        YjFhLTQxODctOGYxNi0xOTM3ZGVkNjhiNjgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNy0yOFQxNjo1NDo0Mi4wNjg2NTlaIiwibmFtZSI6ImdsaWJjIiwi
         dGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy81YjY4MWVhNS0zMTUwLTQ5NDgtYTdhMy0zNDZhM2Q3
-        ZDQwN2UvIn1dfQ==
+        bmVyL21hbmlmZXN0cy81YjM2ZjYyOC01NTViLTQzODAtODY4Ni1jOWEwM2Q2
+        OTRiMzgvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:18:27 GMT
+  recorded_at: Fri, 29 Jul 2022 09:03:32 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_distribution_trees_repository/all_distribution_trees_are_copied_by_default.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_distribution_trees_repository/all_distribution_trees_are_copied_by_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4fa526b3be5a4d1da0d5f67556fb9056
+      - a04cb10a80794ae9a0cd8d7f80a44a4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80NjdmMGYyMy01YjZjLTRlYmYtYmM1OS1iMDg1YTY3ZTc0NWEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNzowNC4wMTc2ODBa
+        cnBtL3JwbS81NjA0ZWUzZS1lMjNiLTRmYjYtYTczOS1iYTgzODRlOTEyZDEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjoyNy43NjE1ODFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80NjdmMGYyMy01YjZjLTRlYmYtYmM1OS1iMDg1YTY3ZTc0NWEv
+        cnBtL3JwbS81NjA0ZWUzZS1lMjNiLTRmYjYtYTczOS1iYTgzODRlOTEyZDEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQ2N2Yw
-        ZjIzLTViNmMtNGViZi1iYzU5LWIwODVhNjdlNzQ1YS92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU2MDRl
+        ZTNlLWUyM2ItNGZiNi1hNzM5LWJhODM4NGU5MTJkMS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:41 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c16a2805fc1c4057b24b9aed4461d6e4
+      - 697a8f4bf1f74bba8dd87514dbdf195b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkN2QzM2NhLWU2MTYtNDc3
-        My04ZDhhLTAxNWM2MGZlZDNiNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwMzk2YzA0LTM4NjItNDBl
+        ZC04MGY3LTg0ZjExMzAxODk3Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31858a636ce84d07a2dab053961d904f
+      - '09ce07f9b62b489b82f33771f314491b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ed7d33ca-e616-4773-8d8a-015c60fed3b6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/60396c04-3862-40ed-80f7-84f11301897c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7757647d21ab43c0893c7aa8a1327afd
+      - 49aa377785434ea6836cd458043820d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWQ3ZDMzY2EtZTYx
-        Ni00NzczLThkOGEtMDE1YzYwZmVkM2I2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MjYuNjA5NzM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjAzOTZjMDQtMzg2
+        Mi00MGVkLTgwZjctODRmMTEzMDE4OTdjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NDEuNzg2NTM3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMTZhMjgwNWZjMWM0MDU3YjI0YjlhZWQ0
-        NDYxZDZlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjI2LjY0
-        MDgxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MjYuNjk3
-        ODkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2OTdhOGY0YmYxZjc0YmJhOGRkODc1MTRk
+        YmRmMTk1YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjQxLjg0
+        NjAzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NDIuMTM5
+        MDMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY3ZjBmMjMtNWI2Yy00ZWJm
-        LWJjNTktYjA4NWE2N2U3NDVhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTYwNGVlM2UtZTIzYi00ZmI2
+        LWE3MzktYmE4Mzg0ZTkxMmQxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 903890a16eea4a3eaecd36e8fb72fd82
+      - 50ed9c2275f4403aaea21c75c6ef8df9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7eb32d19ed984fbab7cb4f4f7174fc95
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vYWE4MjgxNzUtYmFjMS00MWY3LWEwYjYtZDFlOTI0ODhiMjI2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MzMuNTcyMTMy
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:42 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/aa828175-bac1-41f7-a0b6-d1e92488b226/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ae02e0f64097404db4fc7c52fe820de3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzZjc0ZjcxLTE3NmQtNDA3
+        ZS05NjU5LThmMDUwNmVjMmI2OS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:42 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/93f74f71-176d-407e-9659-8f0506ec2b69/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5ccf74207bd4468a9ee9d05f4ea03fc1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTNmNzRmNzEtMTc2
+        ZC00MDdlLTk2NTktOGYwNTA2ZWMyYjY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NDIuNTA4OTUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZTAyZTBmNjQwOTc0MDRkYjRmYzdjNTJm
+        ZTgyMGRlMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjQyLjU3
+        NDQwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NDIuNjM2
+        MzUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:42 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 78ff5406d7914835adcd18f533ad3324
+      - 323e8266c32649ee9905f278f2dad6ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 01e760e02a6c42209775ae45a1d9d4fb
+      - 1870e06135714bdcad06bce773d44f51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e069dc4ede84a698f3264d4cc02e9ab
+      - e2262e58a9884c768bb0f64492dc4cc1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:26 GMT
+      - Fri, 29 Jul 2022 11:32:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc1591a88e8f402cb913dd5aa76ab970
+      - c6c1326e3a854259b89617679d96602b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:26 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - eee4fa4e7b774636a702cff8c1ce0d74
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:43 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/a7033960-8769-47d4-89a8-d57186e2d3b4/"
+      - "/pulp/api/v3/remotes/rpm/rpm/8c29567a-e5bb-40d7-8e3b-54e7e374424f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af38de46b27e40af9c82a0f263547cf4
+      - ac05121bc9784f4483a4262d34b9af74
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E3
-        MDMzOTYwLTg3NjktNDdkNC04OWE4LWQ1NzE4NmUyZDNiNC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI3OjI3LjAxNTEzMVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhj
+        Mjk1NjdhLWU1YmItNDBkNy04ZTNiLTU0ZTdlMzc0NDI0Zi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjQzLjE4MDA4OFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI3OjI3LjAxNTE1MFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjMyOjQzLjE4MDExN1oiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:43 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/"
+      - "/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bff8194cc5d34ee0b19a69cb2166e780
+      - 0ce95cf7747d4a74b6bdf04d2eb6bff4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWQwY2RhZjItMjQ3MS00MDE5LTk5MTktN2VhM2E5MTcwMWY3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MjcuMTI2MjQxWiIsInZl
+        cG0vNjZiYzQ5ODgtMDEyYy00MDU3LWE0ODItYjVlNWM1N2U1M2Y3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6NDMuMzkxNzMwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWQwY2RhZjItMjQ3MS00MDE5LTk5MTktN2VhM2E5MTcwMWY3L3ZlcnNp
+        cG0vNjZiYzQ5ODgtMDEyYy00MDU3LWE0ODItYjVlNWM1N2U1M2Y3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xZDBjZGFmMi0y
-        NDcxLTQwMTktOTkxOS03ZWEzYTkxNzAxZjcvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82NmJjNDk4OC0w
+        MTJjLTQwNTctYTQ4Mi1iNWU1YzU3ZTUzZjcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb24e3cb5b6f4c4a81dd5cbc84e1b243
+      - c654182c9f9145008ca8c844a816e3d5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85OWEzZWI4YS0yM2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNzowNC43NDgzMjJa
+        cnBtL3JwbS8zODg1ZTM3Zi1lMDU0LTQ5YTItYmVhNi0yNTMzN2IzODZjYmYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjoyOS4xNzUyNDJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85OWEzZWI4YS0yM2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQv
+        cnBtL3JwbS8zODg1ZTM3Zi1lMDU0LTQ5YTItYmVhNi0yNTMzN2IzODZjYmYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk5YTNl
-        YjhhLTIzYzctNGRiMy1hZDAxLTBkNDhhNTYxODY0ZC92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM4ODVl
+        MzdmLWUwNTQtNDlhMi1iZWE2LTI1MzM3YjM4NmNiZi92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:43 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1cf06922016f479980aa6330c1d824da
+      - 8aacec2f1f0f463eaa5d1034b2fdffc8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiMzc5NDhjLTExZTYtNGFk
-        NS05MGYxLTUwNGRlMmRmNjEyNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQzNzk5MjYyLWM2YWQtNDYz
+        My05Yjc5LTlhMDZmYWFkNGViZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8be556453bb64ccca142661000aa9c04
+      - 6859562ec3434a67b66f5e9665a46bd6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYzZjNTViNjMtNjY2Mi00ZjU0LTgxYmUtZDMyZTBmYmU5Zjc5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MDMuOTA3MjU1WiIsIm5h
+        cG0vOTFlMjJlYmItMGQzYS00NTI0LTk0MmQtNzkxYWUzZjI3ZmE5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MjcuNTY3ODE1WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyNzowNS4wNjQxNDdaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozMjoyOS43NjE5ODFaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:43 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/c6c55b63-6662-4f54-81be-d32e0fbe9f79/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/91e22ebb-0d3a-4524-942d-791ae3f27fa9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e5516f8758e4457b7659e0ca44d42d5
+      - d3b4481d2ff641c5a70cde1ff5adcbf7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdlYTkzYmY2LTY0MTYtNGQ2
-        NC1hYzM0LWM2MGM4OGM0NDM3Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NjOWNiYjBkLTdhZmUtNGFk
+        ZS1hMjg0LTM3YjQ1Y2U1M2VlZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cb37948c-11e6-4ad5-90f1-504de2df6125/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/43799262-c6ad-4633-9b79-9a06faad4ebe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ee0580ba756414e8e2cd4ca90e4b61f
+      - 3ba775a54ace45a788824ec346dd04dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2IzNzk0OGMtMTFl
-        Ni00YWQ1LTkwZjEtNTA0ZGUyZGY2MTI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MjcuMjkzMzE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDM3OTkyNjItYzZh
+        ZC00NjMzLTliNzktOWEwNmZhYWQ0ZWJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NDMuNzEzNzY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxY2YwNjkyMjAxNmY0Nzk5ODBhYTYzMzBj
-        MWQ4MjRkYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjI3LjMy
-        NTQwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MjcuMzc1
-        Nzk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4YWFjZWMyZjFmMGY0NjNlYWE1ZDEwMzRi
+        MmZkZmZjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjQzLjc3
+        NDc1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NDMuOTEx
+        MDc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNjNy00ZGIz
-        LWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1NC00OWEy
+        LWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7ea93bf6-6416-4d64-ac34-c60c88c4437c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/cc9cbb0d-7afe-4ade-a284-37b45ce53eed/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb1d4a042c6b4807ba4e348d304db95b
+      - b847e00a5a514dbe81dac500a9fa52d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2VhOTNiZjYtNjQx
-        Ni00ZDY0LWFjMzQtYzYwYzg4YzQ0MzdjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MjcuMzgzODgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2M5Y2JiMGQtN2Fm
+        ZS00YWRlLWEyODQtMzdiNDVjZTUzZWVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NDMuODg4OTc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZTU1MTZmODc1OGU0NDU3Yjc2NTllMGNh
-        NDRkNDJkNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjI3LjQx
-        ODM5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MjcuNDYx
-        MjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkM2I0NDgxZDJmZjY0MWM1YTcwY2RlMWZm
+        NWFkY2JmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjQzLjk1
+        NjQxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NDQuMDQx
+        NDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M2YzU1YjYzLTY2NjItNGY1NC04MWJl
-        LWQzMmUwZmJlOWY3OS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkxZTIyZWJiLTBkM2EtNDUyNC05NDJk
+        LTc5MWFlM2YyN2ZhOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c613255808bb4c248805c901ac3356dd
+      - bc7455dc4a7b4b96baa3ab2e80375802
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a20f2fa793934e84a72e53eca90b674b
+      - 6c0e209712e04b68aa4e739b968929ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90de9d9cac7f4784b1abb82dc2597575
+      - f953ce0e9c4a487c9de9139d216e985f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a25b148562ca49d787f2beb582e2a573
+      - 2bc8e9ca4b1d42fc97ff881718a84e64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e45e6ba863e4fc0954b8ca545b75abe
+      - f391a33bf4d9468987ae3abe7508bfa1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11d1064fa8204b3e952e0d423f7879ac
+      - ad1122454fed4f8b9120f1d7c7b699c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:27 GMT
+      - Fri, 29 Jul 2022 11:32:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/"
+      - "/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53262755fa984e9db39532f42ad748ee
+      - 976ca693a9d04aa1819800167d42707b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmE1MWY1NjgtNDczNC00MTkzLWI2OTItYTdlYWY4OGM1MDIyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MjcuODI4NzYwWiIsInZl
+        cG0vMmFkN2RlMjAtMTQwNi00ZTllLTkzNmYtNTRiMzE4MGUxYzAxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6NDQuNjcxNDE4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmE1MWY1NjgtNDczNC00MTkzLWI2OTItYTdlYWY4OGM1MDIyL3ZlcnNp
+        cG0vMmFkN2RlMjAtMTQwNi00ZTllLTkzNmYtNTRiMzE4MGUxYzAxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iYTUxZjU2OC00
-        NzM0LTQxOTMtYjY5Mi1hN2VhZjg4YzUwMjIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yYWQ3ZGUyMC0x
+        NDA2LTRlOWUtOTM2Zi01NGIzMTgwZTFjMDEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:44 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a7033960-8769-47d4-89a8-d57186e2d3b4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/8c29567a-e5bb-40d7-8e3b-54e7e374424f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:28 GMT
+      - Fri, 29 Jul 2022 11:32:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d1d4d4e844141178847173c46fa969b
+      - 0bcd7421baa0413abded965dae251f1f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyMzE5NGM5LTJjMTYtNDBj
-        My05MzQzLTg0MDQyNDI5NzY0MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkZTY1ZTM3LTI0NWYtNDBk
+        Zi05NjRiLWY1OWQwZjJlYzdkNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/323194c9-2c16-40c3-9343-840424297640/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6de65e37-245f-40df-964b-f59d0f2ec7d4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:28 GMT
+      - Fri, 29 Jul 2022 11:32:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41a3635b565b4a1fb15003a844a86836
+      - 8d776d54c2e240979e4310feb65a3c24
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzIzMTk0YzktMmMx
-        Ni00MGMzLTkzNDMtODQwNDI0Mjk3NjQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MjguMTEyNDA1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmRlNjVlMzctMjQ1
+        Zi00MGRmLTk2NGItZjU5ZDBmMmVjN2Q0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NDUuMTQwMzQzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIzZDFkNGQ0ZTg0NDE0MTE3ODg0NzE3M2M0
-        NmZhOTY5YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjI4LjE0
-        Mjc5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MjguMTY2
-        MTAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwYmNkNzQyMWJhYTA0MTNhYmRlZDk2NWRh
+        ZTI1MWYxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjQ1LjE5
+        ODA1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NDUuMjM1
+        MTk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E3MDMzOTYwLTg3NjktNDdkNC04OWE4
-        LWQ1NzE4NmUyZDNiNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhjMjk1NjdhLWU1YmItNDBkNy04ZTNi
+        LTU0ZTdlMzc0NDI0Zi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E3MDMz
-        OTYwLTg3NjktNDdkNC04OWE4LWQ1NzE4NmUyZDNiNC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhjMjk1
+        NjdhLWU1YmItNDBkNy04ZTNiLTU0ZTdlMzc0NDI0Zi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:28 GMT
+      - Fri, 29 Jul 2022 11:32:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d68cfab3e554c3e9a105dff40570cb1
+      - 54a5cb31439a4db79804b750fb5be463
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4ZjE2Njg0LWE4MDUtNDdi
-        Ni1iNjZhLWE1NmFhOGE3NzUyNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkNTgxMjFlLTAyMDYtNDNh
+        Zi1iZTkxLWZiMmYyMjcwN2NhNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/38f16684-a805-47b6-b66a-a56aa8a77527/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3d58121e-0206-43af-be91-fb2f22707ca7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:29 GMT
+      - Fri, 29 Jul 2022 11:32:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bca4709e14284a6dabd741713c4062f8
+      - bb69f3fb4b76484d90784a08b4010a51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '660'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzhmMTY2ODQtYTgw
-        NS00N2I2LWI2NmEtYTU2YWE4YTc3NTI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MjguMjk5ODUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Q1ODEyMWUtMDIw
+        Ni00M2FmLWJlOTEtZmIyZjIyNzA3Y2E3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NDUuMzU3MzY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI0ZDY4Y2ZhYjNlNTU0YzNlOWEx
-        MDVkZmY0MDU3MGNiMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjI4LjMzMjE5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MjkuMTMyNjgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI1NGE1Y2IzMTQzOWE0ZGI3OTgw
+        NGI3NTBmYjViZTQ2MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjQ1LjQyMzAwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NDYuNjgxNzM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
-        cnNlZCBNb2R1bGVtZCIsImNvZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRz
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3Vm
-        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQtZGVmYXVs
-        dHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLm1vZHVsZW1kX2RlZmF1bHRzIiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
-        c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiUGFyc2VkIENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRl
-        ZCIsInRvdGFsIjo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
-        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4t
-        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNv
-        bnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
-        IjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQyLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzFkMGNkYWYyLTI0NzEtNDAxOS05OTE5LTdlYTNh
-        OTE3MDFmNy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xZDBj
-        ZGFmMi0yNDcxLTQwMTktOTkxOS03ZWEzYTkxNzAxZjcvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYTcwMzM5NjAtODc2OS00N2Q0
-        LTg5YTgtZDU3MTg2ZTJkM2I0LyJdfQ==
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS82NmJjNDk4OC0wMTJjLTQwNTctYTQ4Mi1iNWU1YzU3
+        ZTUzZjcvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjZiYzQ5
+        ODgtMDEyYy00MDU3LWE0ODItYjVlNWM1N2U1M2Y3LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhjMjk1NjdhLWU1YmItNDBkNy04
+        ZTNiLTU0ZTdlMzc0NDI0Zi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMWQwY2RhZjItMjQ3MS00MDE5LTk5MTktN2VhM2E5MTcw
-        MWY3L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNjZiYzQ5ODgtMDEyYy00MDU3LWE0ODItYjVlNWM1N2U1
+        M2Y3L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:29 GMT
+      - Fri, 29 Jul 2022 11:32:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0264a2c098af4d68a9b2801aee553774
+      - 0f5185df048d487a8bc5a5f76669ff7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IwZDNjMjA3LTk0MDktNGU2
-        Yi05NWQ1LTNjNWRhZGYzY2E2ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlY2FjOTBlLTE4ZmMtNGRk
+        NS04Mzg1LWM5MGI0NjU2MjVkOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b0d3c207-9409-4e6b-95d5-3c5dadf3ca6d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/aecac90e-18fc-4dd5-8385-c90b465625d9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:30 GMT
+      - Fri, 29 Jul 2022 11:32:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 197acdbb2c4042a28845c5bd657733d7
+      - 5fb60b68a221457d8642e8ed7f315350
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjBkM2MyMDctOTQw
-        OS00ZTZiLTk1ZDUtM2M1ZGFkZjNjYTZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MjkuNTczMzE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWVjYWM5MGUtMThm
+        Yy00ZGQ1LTgzODUtYzkwYjQ2NTYyNWQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NDcuMjM0NzUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjAyNjRhMmMwOThhZjRkNjhhOWIyODAxYWVl
-        NTUzNzc0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MjkuNjA0
-        MTUzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNzoyOS45NTQz
-        MzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjBmNTE4NWRmMDQ4ZDQ4N2E4YmM1YTVmNzY2
+        NjlmZjdiIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NDcuMjk3
+        Nzk5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMjo0Ny44ODEw
+        NDRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vM2M0ZDA1
-        ZjItOWRlZC00MDBjLWJhMTQtZjFmNTM3ZGY4NzQ5LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDQ0MDQz
+        NDUtMTQ4MC00MjlkLWJjYjQtNjNmNjA1MDQzODQzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMWQwY2RhZjItMjQ3MS00MDE5LTk5MTktN2VhM2E5
-        MTcwMWY3LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNjZiYzQ5ODgtMDEyYy00MDU3LWE0ODItYjVlNWM1
+        N2U1M2Y3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:30 GMT
+      - Fri, 29 Jul 2022 11:32:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 893d237337bb4be3a995624e2faa2e38
+      - b44d7dbc052c4dc3a0f1dacdcdfa3d52
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/04404345-1480-429d-bcb4-63f605043843/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b019c9600e0c47f9a5a97bbb7a591fee
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMDQ0MDQzNDUtMTQ4MC00MjlkLWJjYjQtNjNmNjA1MDQzODQzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6NDcuMzM2OTA4WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82NmJjNDk4OC0wMTJjLTQwNTctYTQ4Mi1iNWU1YzU3ZTUzZjcv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzY2YmM0OTg4LTAxMmMtNDA1Ny1hNDgyLWI1ZTVj
+        NTdlNTNmNy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:48 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8wNDQwNDM0NS0xNDgwLTQyOWQtYmNiNC02M2Y2MDUwNDM4NDMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6cb57b827ca54eec92e06f374d0900e4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NmNjg1MzQ0LTQ3YjUtNDJl
+        NS04ZGUzLTQ2YjAzMTNjZTg3MS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/cf685344-47b5-42e5-8de3-46b0313ce871/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 418b6c27fd344fe8ba49693df8a253b5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2Y2ODUzNDQtNDdi
+        NS00MmU1LThkZTMtNDZiMDMxM2NlODcxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NDguMjczMTc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2Y2I1N2I4MjdjYTU0ZWVjOTJlMDZmMzc0
+        ZDA5MDBlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjQ4LjMz
+        MDYxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NDguNjEw
+        MTQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYTQ5
+        OWVlOWMtNTg3Ny00NzM3LWI5MTctMDk5ZWQ0MDU4MzNkLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/a499ee9c-5877-4737-b917-099ed405833d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b800af5ffad4e71b9be5c929831fa8b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2E0OTllZTljLTU4NzctNDczNy1iOTE3LTA5OWVkNDA1ODMzZC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjQ4LjU4NjA0NloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMDQ0MDQzNDUtMTQ4MC00MjlkLWJjYjQt
+        NjNmNjA1MDQzODQzLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ec3b7cb71d5147a19d6c21ccf91ddda2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:30 GMT
+      - Fri, 29 Jul 2022 11:32:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d57cd70cca9140c79d274c14464397a8
+      - 1c1647d690244d8285178279e46b7ac1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:30 GMT
+      - Fri, 29 Jul 2022 11:32:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5268e3bcd0e4de4a14588fb90b46b8d
+      - 53ace7b80bdd4f90ad2efe1cb4a71900
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:30 GMT
+      - Fri, 29 Jul 2022 11:32:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9b318ba8118f4f00bae947babfc9be25
+      - 9f6459e8c19544c4a97f770e015f35d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:30 GMT
+      - Fri, 29 Jul 2022 11:32:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d59e49329603450c9ba874a33ec18cb9
+      - 956ebf035b3b4d26b4cab2844de46b69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:30 GMT
+      - Fri, 29 Jul 2022 11:32:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3eca340c8090493cbc58e49e2ad9c173
+      - 6649844d14a0485a8ed4b02691550d43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:30 GMT
+      - Fri, 29 Jul 2022 11:32:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - daa929e37fca48fbb814278424f0ac90
+      - aa0516ebc328464ca47871cfebf68aa6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '07789f58c98a4906bb2268d6e4d0a490'
+      - a1fc25864e3a4931bd6edd37fb019098
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa7cf04dbbe84ee7b9cfd7cdb11a575d
+      - 6e713bed8a25402c93e3f360b1e6e709
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2a8b2de8acde43d49d94771c0f44b827
+      - 61f8d06f645547b8950c64c7b321d801
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66712ff15a184512835243e4212116c8
+      - 1c705eabd184469287289fcb58f06e75
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d0c853f10c14dcfa196e2fc32703040
+      - 8aaa6f822ad54373949a44993178346e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a816eb7df7fa461480833053574fff1f
+      - 2c22a76da14f40ce9837e8002c4987f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 037613bc62464b169d5cfc10116f4a3d
+      - a8de8a67f6414068b5d4fad28134d170
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86f944e3d85c46c7b8540fb4be9805c6
+      - f7de0ccdec474bf9b60e63249755073f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjYzViNjUyLTk0MzAtNGY2
-        Ni05ZDdjLTkyYjIzMGQzMTI0ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2YWQ5ODNiLWZiMDQtNGRm
+        Yi04MmNiLWI5NGM3ZjBjYjJiNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - adc63e6b278d4a1ea32698385314a037
+      - f311587489174fa6bf4bef391be4d963
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg1NDNiZmQxLWEzMjgtNDg5
-        Ni1iNmZhLTU1MTI0MjJjOWIxYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5MGJjZGJhLWYyN2ItNDBh
+        NS04NTdkLTIwNTUwMmVlOWExYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,97 +3935,97 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a20b0f1abe54cee95b4a73c9fa47d02
+      - 7ab480821a524f0990716b746a6e51eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExOWM2YmQzLTM5NWYtNGU3
-        Yy1iNTBmLTE2YzY5NTNkNjAzZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyMWM5MjdlLTg1NzAtNDZh
+        MC1iMDRjLTczYTIwZWQ4ZTYyMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMWQwY2RhZjItMjQ3MS00MDE5LTk5
-        MTktN2VhM2E5MTcwMWY3L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JhNTFmNTY4LTQ3MzQt
-        NDE5My1iNjkyLWE3ZWFmODhjNTAyMi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        Mjk2ZTUwNTQtODIyNS00MzNjLWEzY2QtNjQxYzEwMDk1MTEzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM4NTMwYWU2LTRiYzYt
-        NDE2Zi1iYmVlLTk2MTA2YTRjZjk1MC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQtZDcxNTNhZDc4NDIyLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQy
-        M2QtNDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1
-        ZC1iODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRk
-        NGFhYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRl
-        NTYxMGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhk
-        YS04Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNl
-        YzY5Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5
-        YTY1ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3
-        MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJj
-        ODZhZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
-        cm91cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01
-        YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3Yi1iY2MzLTQ2
-        MzNhMmM3OTkwZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNGI5ZTFkMS1mYWUy
-        LTQ0NWQtYTg3Ny05Mzk5ZjhlNjVjMGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzI5ZTZhMjFkLTJmNjktNGNkMi1iNzExLTYxY2M4
-        OWNmNzBjZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MzdjMzgwYTAtYWFmZi00M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQy
-        YzAtODhmMy0xNTI4OTBlZmE3ZWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzQ5NDNkMTlkLWM1NTItNDVkMi04NTYwLWM3MGFmOTEz
-        N2NjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNTBj
-        ODJlOWQtYWY4OS00MzEzLWJmZWQtZDRjNGE2YzgwZjllLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NjQ2NWZmYS05NTFlLTRlZDUt
-        YjNjMy1hODA2ZWVkZmM4NWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzc2MDhjZTM3LTFjNzEtNGFkMC05MGFjLWVlZDc0NjBjNTYx
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2EzYzU3
-        OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJkNDg4LyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5
-        YS1mMGFjOTY2MjVkZmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzhmNGMwNDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4Zi8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1MjI4ODAt
-        OGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0
-        NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJkLTQ3MGMtYTI2MC1iZWJh
-        NjIwMDM0OWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2ZjMmFlODJlLWI3YTEtNGQ2Zi1iNjNkLWNlNzFlZmU1NmM1YS8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9mNDdh
-        M2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19XSwiZGVwZW5k
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjZiYzQ5ODgtMDEyYy00MDU3LWE0
+        ODItYjVlNWM1N2U1M2Y3L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJhZDdkZTIwLTE0MDYt
+        NGU5ZS05MzZmLTU0YjMxODBlMWMwMS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYy
+        YWItNGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQy
+        OTI5My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1
+        ZWE3ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBl
+        NS1hZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFk
+        MTkxOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYy
+        NTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgx
+        NS04OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJm
+        MjFjYmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
+        cm91cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0y
+        OTFhLTQzMzYtYWRiZC1kODliN2IwMWQ4NDYvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0YzgtNDU5Mi04Mzg0LWIy
+        NzZmZmE3ZTgyNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzViYmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0
+        NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0OTU0ZWVkLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81YTMyODQyNi0yYmFmLTQx
+        ODktOWNjNS02ZDhkYzM1YzEwZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQtNGU0Ni04ZmMzLTFiZmY3OTlm
+        YjYxZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjVm
+        YmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NmQwMjRjMi0xMGZjLTQwMWMt
+        YWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEy
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVm
+        MmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUtOTM2
+        Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMt
+        NTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0y
+        MmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkxLTM2ZWM4ZmMzNTA0OC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVh
+        Mi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2ZkYjk1N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJm
+        NTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19XSwiZGVwZW5k
         ZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3613,7 +4038,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3631,21 +4056,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ce30ba7cc344a198af743bb19993f46
+      - 4a32c5668fc441549c0157a7c30ab493
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmNmVhYmU5LTdjNTItNDM3
-        My05M2QwLTk5MTE1NTQ0MWMzMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViZjY2ODU2LWRjNmYtNDhl
+        Ni1hN2MwLTBjZmU4MGZkN2M0MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dcc5b652-9430-4f66-9d7c-92b230d3124d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/36ad983b-fb04-4dfb-82cb-b94c7f0cb2b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3666,51 +4091,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf2adebb14604a94bab29a38bfcdf2c1
+      - e474717bab4e40eab8b35fc7bd7dc875
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNjNWI2NTItOTQz
-        MC00ZjY2LTlkN2MtOTJiMjMwZDMxMjRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNDE2NzU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzZhZDk4M2ItZmIw
+        NC00ZGZiLTgyY2ItYjk0YzdmMGNiMmI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNDg2Nzk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4NmY5NDRlM2Q4NWM0NmM3Yjg1
-        NDBmYjRiZTk4MDVjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjQ0NzQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuNTk3ODI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmN2RlMGNjZGVjNDc0YmY5YjYw
+        ZTYzMjQ5NzU1MDczZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjUxLjU1NzI3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NTEuOTIyNzQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDcz
-        NC00MTkzLWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQw
+        Ni00ZTllLTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dcc5b652-9430-4f66-9d7c-92b230d3124d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/490bcdba-f27b-40a5-857d-205502ee9a1b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3731,118 +4156,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:31 GMT
+      - Fri, 29 Jul 2022 11:32:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c87100d6134747e3ba8457e77469095a
+      - c2e9a6e62c1640f0bc4cd33f8cfc3dbf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNjNWI2NTItOTQz
-        MC00ZjY2LTlkN2MtOTJiMjMwZDMxMjRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNDE2NzU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDkwYmNkYmEtZjI3
+        Yi00MGE1LTg1N2QtMjA1NTAyZWU5YTFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNTc2OTQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4NmY5NDRlM2Q4NWM0NmM3Yjg1
-        NDBmYjRiZTk4MDVjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjQ0NzQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuNTk3ODI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDcz
-        NC00MTkzLWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8543bfd1-a328-4896-b6fa-5512422c9b1a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:31 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 39929d4b38d04c51a1f6dd2203c4d343
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODU0M2JmZDEtYTMy
-        OC00ODk2LWI2ZmEtNTUxMjQyMmM5YjFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNDcyODM5WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZGM2M2U2YjI3OGQ0YTFlYTMy
-        Njk4Mzg1MzE0YTAzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjYyOTQ0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuNzYxNjcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmMzExNTg3NDg5MTc0ZmE2YmY0
+        YmVmMzkxYmU0ZDk2MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjUxLjk3NjE3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NTIuMjgwNzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iYTUxZjU2OC00NzM0LTQxOTMtYjY5Mi1hN2VhZjg4YzUwMjIvdmVyc2lv
+        bS8yYWQ3ZGUyMC0xNDA2LTRlOWUtOTM2Zi01NGIzMTgwZTFjMDEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDczNC00MTkz
-        LWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQwNi00ZTll
+        LTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dcc5b652-9430-4f66-9d7c-92b230d3124d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/36ad983b-fb04-4dfb-82cb-b94c7f0cb2b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3863,51 +4223,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 81276bb9fa0f42628be851bb1b8bef9a
+      - c655e63b400b4229ad674911475f5890
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNjNWI2NTItOTQz
-        MC00ZjY2LTlkN2MtOTJiMjMwZDMxMjRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNDE2NzU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzZhZDk4M2ItZmIw
+        NC00ZGZiLTgyY2ItYjk0YzdmMGNiMmI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNDg2Nzk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4NmY5NDRlM2Q4NWM0NmM3Yjg1
-        NDBmYjRiZTk4MDVjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjQ0NzQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuNTk3ODI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmN2RlMGNjZGVjNDc0YmY5YjYw
+        ZTYzMjQ5NzU1MDczZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjUxLjU1NzI3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NTEuOTIyNzQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDcz
-        NC00MTkzLWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQw
+        Ni00ZTllLTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8543bfd1-a328-4896-b6fa-5512422c9b1a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/490bcdba-f27b-40a5-857d-205502ee9a1b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3928,53 +4288,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2cec310bd111470db446c59e09929885
+      - 5972239f46f24978ba8eb4b98f537f4f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODU0M2JmZDEtYTMy
-        OC00ODk2LWI2ZmEtNTUxMjQyMmM5YjFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNDcyODM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDkwYmNkYmEtZjI3
+        Yi00MGE1LTg1N2QtMjA1NTAyZWU5YTFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNTc2OTQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZGM2M2U2YjI3OGQ0YTFlYTMy
-        Njk4Mzg1MzE0YTAzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjYyOTQ0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuNzYxNjcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmMzExNTg3NDg5MTc0ZmE2YmY0
+        YmVmMzkxYmU0ZDk2MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjUxLjk3NjE3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NTIuMjgwNzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iYTUxZjU2OC00NzM0LTQxOTMtYjY5Mi1hN2VhZjg4YzUwMjIvdmVyc2lv
+        bS8yYWQ3ZGUyMC0xNDA2LTRlOWUtOTM2Zi01NGIzMTgwZTFjMDEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDczNC00MTkz
-        LWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQwNi00ZTll
+        LTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/119c6bd3-395f-4e7c-b50f-16c6953d603e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f21c927e-8570-46a0-b04c-73a20ed8e620/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3995,53 +4355,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da75446b1df8415ba068c32f274019ee
+      - eaf1bc0f25d141989616ba7eb0e63a4e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTE5YzZiZDMtMzk1
-        Zi00ZTdjLWI1MGYtMTZjNjk1M2Q2MDNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNTI1NDE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjIxYzkyN2UtODU3
+        MC00NmEwLWIwNGMtNzNhMjBlZDhlNjIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNjYyMDI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYTIwYjBmMWFiZTU0Y2VlOTVi
-        NGE3M2M5ZmE0N2QwMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjc5MTQ1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuOTI0NTMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3YWI0ODA4MjFhNTI0ZjA5OTA3
+        MTZiNzQ2YTZlNTFlYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjUyLjM1MDAzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NTIuNjU5MzI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iYTUxZjU2OC00NzM0LTQxOTMtYjY5Mi1hN2VhZjg4YzUwMjIvdmVyc2lv
+        bS8yYWQ3ZGUyMC0xNDA2LTRlOWUtOTM2Zi01NGIzMTgwZTFjMDEvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDczNC00MTkz
-        LWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQwNi00ZTll
+        LTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dcc5b652-9430-4f66-9d7c-92b230d3124d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/36ad983b-fb04-4dfb-82cb-b94c7f0cb2b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4062,51 +4422,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 817c1456a6934c459cf50e6263aec78d
+      - 81db21318a5147479a3c574b4cc626ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNjNWI2NTItOTQz
-        MC00ZjY2LTlkN2MtOTJiMjMwZDMxMjRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNDE2NzU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzZhZDk4M2ItZmIw
+        NC00ZGZiLTgyY2ItYjk0YzdmMGNiMmI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNDg2Nzk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4NmY5NDRlM2Q4NWM0NmM3Yjg1
-        NDBmYjRiZTk4MDVjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjQ0NzQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuNTk3ODI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmN2RlMGNjZGVjNDc0YmY5YjYw
+        ZTYzMjQ5NzU1MDczZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjUxLjU1NzI3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NTEuOTIyNzQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDcz
-        NC00MTkzLWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQw
+        Ni00ZTllLTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8543bfd1-a328-4896-b6fa-5512422c9b1a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/490bcdba-f27b-40a5-857d-205502ee9a1b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4127,53 +4487,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9be4d50606cf40d1ae67c03c2eb6fbfa
+      - 2923beb5a94a483498af2587020523a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODU0M2JmZDEtYTMy
-        OC00ODk2LWI2ZmEtNTUxMjQyMmM5YjFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNDcyODM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDkwYmNkYmEtZjI3
+        Yi00MGE1LTg1N2QtMjA1NTAyZWU5YTFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNTc2OTQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZGM2M2U2YjI3OGQ0YTFlYTMy
-        Njk4Mzg1MzE0YTAzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjYyOTQ0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuNzYxNjcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmMzExNTg3NDg5MTc0ZmE2YmY0
+        YmVmMzkxYmU0ZDk2MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjUxLjk3NjE3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NTIuMjgwNzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iYTUxZjU2OC00NzM0LTQxOTMtYjY5Mi1hN2VhZjg4YzUwMjIvdmVyc2lv
+        bS8yYWQ3ZGUyMC0xNDA2LTRlOWUtOTM2Zi01NGIzMTgwZTFjMDEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDczNC00MTkz
-        LWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQwNi00ZTll
+        LTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/119c6bd3-395f-4e7c-b50f-16c6953d603e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f21c927e-8570-46a0-b04c-73a20ed8e620/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4194,53 +4554,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b43113a715e416d81c73225638be17f
+      - 603f1e7b0c8a4befa655d8c15567a8d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTE5YzZiZDMtMzk1
-        Zi00ZTdjLWI1MGYtMTZjNjk1M2Q2MDNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNTI1NDE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjIxYzkyN2UtODU3
+        MC00NmEwLWIwNGMtNzNhMjBlZDhlNjIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNjYyMDI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYTIwYjBmMWFiZTU0Y2VlOTVi
-        NGE3M2M5ZmE0N2QwMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjMxLjc5MTQ1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzEuOTI0NTMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3YWI0ODA4MjFhNTI0ZjA5OTA3
+        MTZiNzQ2YTZlNTFlYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjUyLjM1MDAzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        NTIuNjU5MzI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iYTUxZjU2OC00NzM0LTQxOTMtYjY5Mi1hN2VhZjg4YzUwMjIvdmVyc2lv
+        bS8yYWQ3ZGUyMC0xNDA2LTRlOWUtOTM2Zi01NGIzMTgwZTFjMDEvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDczNC00MTkz
-        LWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQwNi00ZTll
+        LTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7f6eabe9-7c52-4373-93d0-991155441c33/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5bf66856-dc6f-48e6-a7c0-0cfe80fd7c41/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4261,55 +4621,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db6f4313a8e44deaaf33b61d55e98fa2
+      - d38378c581ff467083b38cb77e17c25f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2Y2ZWFiZTktN2M1
-        Mi00MzczLTkzZDAtOTkxMTU1NDQxYzMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzEuNTc5MTQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWJmNjY4NTYtZGM2
+        Zi00OGU2LWE3YzAtMGNmZTgwZmQ3YzQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTEuNzcwMzY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiMmNlMzBiYTdjYzM0NGExOThhZjc0M2JiMTk5
-        OTNmNDYiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNzozMS45NTU0
-        MDFaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjMyLjQxNDYy
-        OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiNGEzMmM1NjY4ZmM0NDE1NDljMDE1N2E3YzMw
+        YWI0OTMiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMjo1Mi43MjM5
+        OTBaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjUzLjQ4MDA1
+        NVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1
-        NjgtNDczNC00MTkzLWI2OTItYTdlYWY4OGM1MDIyL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2Rl
+        MjAtMTQwNi00ZTllLTkzNmYtNTRiMzE4MGUxYzAxL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2JhNTFmNTY4LTQ3MzQtNDE5My1iNjkyLWE3
-        ZWFmODhjNTAyMi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzFkMGNkYWYyLTI0NzEtNDAxOS05OTE5LTdlYTNhOTE3MDFm
+        cG9zaXRvcmllcy9ycG0vcnBtLzJhZDdkZTIwLTE0MDYtNGU5ZS05MzZmLTU0
+        YjMxODBlMWMwMS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzY2YmM0OTg4LTAxMmMtNDA1Ny1hNDgyLWI1ZTVjNTdlNTNm
         Ny8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4317,7 +4677,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4330,76 +4690,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b04e37d153c44d4ca59a397944666779
+      - 6820085faeb44b7ab2f75ea7cffe38a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '566'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
-        NTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2Ji
-        Mzg0ODctOTY3Ny00YTQzLTgzZTMtNDM5MGIzZDIwNWI0LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhiMjUx
-        NzM4LTZhNDgtNDNjYi1iNzlhLWYwYWM5NjYyNWRmZi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQt
-        MmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThj
-        NWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZm
-        LTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00
-        NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTViNzEtNDE1
-        NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkw
-        YWMtZWVkNzQ2MGM1NjFiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YwNzc5MmMzLWE0MmQtNDcwYy1hMjYw
-        LWJlYmE2MjAwMzQ5Zi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00YjY2LWFlYWQtZmY4
-        NTBiOTI2ZTVjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4407,7 +4767,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4420,50 +4780,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66ec959213e44275bde6e144f11019f4
+      - b1328f8f54284851a1568a753eaeb9b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4471,7 +4831,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4484,37 +4844,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83a3c40cb8eb42d68569b43f9c3479c4
+      - '08c0800675f549558cc1b1cc0302b750'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4587,9 +4947,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -4605,8 +4965,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -4624,9 +4984,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -4648,9 +5008,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -4666,9 +5026,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -4677,9 +5037,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -4708,10 +5068,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4719,7 +5079,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4732,43 +5092,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5bad3b3996c48b194a0a59cde2ab245
+      - 8a700c19730b45b690f2ec1ba764fe1c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4776,7 +5136,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4789,41 +5149,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:32 GMT
+      - Fri, 29 Jul 2022 11:32:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 429011e9848a4846b52f1d8158f7cdd7
+      - 4b822a5421814c0e9608cb63fad7dc66
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4831,7 +5191,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4844,36 +5204,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:33 GMT
+      - Fri, 29 Jul 2022 11:32:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2435549975254f74a42c5bb8a06dbde3
+      - 6a7e07618d9b4afa9f1f6f4db6edc5ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4895,10 +5255,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4906,7 +5266,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4919,36 +5279,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:33 GMT
+      - Fri, 29 Jul 2022 11:32:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8dcff5aef1a641c1b37bda00cb25aa35
+      - 033c69af3b1d45afb55de9d2a228590b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4970,10 +5330,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4981,7 +5341,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4994,36 +5354,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:33 GMT
+      - Fri, 29 Jul 2022 11:32:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2098aad32f6a41ad8af865292c68c496
+      - f548cd9ed34b470393ce4339fefcd304
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5045,5 +5405,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:54 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_distribution_trees_repository/no_package_environments_are_copied_despite_whitelist_ids.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_distribution_trees_repository/no_package_environments_are_copied_despite_whitelist_ids.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:33 GMT
+      - Fri, 29 Jul 2022 11:32:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c3093f3bd1e4a58897583cc5095fd01
+      - e8c427c117a4421da22de6f5996c0642
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '313'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xZDBjZGFmMi0yNDcxLTQwMTktOTkxOS03ZWEzYTkxNzAxZjcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNzoyNy4xMjYyNDFa
+        cnBtL3JwbS84NTFhNWY1NC1iNjYzLTQxMTctYTRkZS0zZTg5ZTM2YTZkOTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjoxMS42NDg5MDJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xZDBjZGFmMi0yNDcxLTQwMTktOTkxOS03ZWEzYTkxNzAxZjcv
+        cnBtL3JwbS84NTFhNWY1NC1iNjYzLTQxMTctYTRkZS0zZTg5ZTM2YTZkOTEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzFkMGNk
-        YWYyLTI0NzEtNDAxOS05OTE5LTdlYTNhOTE3MDFmNy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzg1MWE1
+        ZjU0LWI2NjMtNDExNy1hNGRlLTNlODllMzZhNmQ5MS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:26 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/1d0cdaf2-2471-4019-9919-7ea3a91701f7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:33 GMT
+      - Fri, 29 Jul 2022 11:32:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 183e68f25128453a8a5cac0f5201a617
+      - 29830bcc37124b88b013ba80cff89ef6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc2ODI2Mzg3LWE2YzctNGRk
-        ZS04ZmMyLTEzM2JlMjk3M2NlZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5MDUwNWQzLWVhM2EtNDgx
+        ZC1hZTdkLTZlMjc4ZWNhMGE2Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bdd1e2c1cf124de0a050261f22a1d586
+      - 077fb40009e747fb9b0a0717fb8e14fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/76826387-a6c7-4dde-8fc2-133be2973ced/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/690505d3-ea3a-481d-ae7d-6e278eca0a62/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c73b267e468148fd8d91b129c3711691
+      - c3127d7e4265478da7b5444debfa3a64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzY4MjYzODctYTZj
-        Ny00ZGRlLThmYzItMTMzYmUyOTczY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzMuOTcxOTIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjkwNTA1ZDMtZWEz
+        YS00ODFkLWFlN2QtNmUyNzhlY2EwYTYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjYuMjQ5ODQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxODNlNjhmMjUxMjg0NTNhOGE1Y2FjMGY1
-        MjAxYTYxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjM0LjAy
-        MzY3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MzQuMTUw
-        ODIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyOTgzMGJjYzM3MTI0Yjg4YjAxM2JhODBj
+        ZmY4OWVmNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjI2LjQx
+        NjI5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MjYuNjgz
+        NTAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMWQwY2RhZjItMjQ3MS00MDE5
-        LTk5MTktN2VhM2E5MTcwMWY3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODUxYTVmNTQtYjY2My00MTE3
+        LWE0ZGUtM2U4OWUzNmE2ZDkxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b100a49e9f449a4b74fb1238d7d619f
+      - 71c591b43ac14d3f9c63a919355e8723
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1b884ae4889e4cb1bab08079ab3c6d54
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vY2ViM2VmZDEtOTQyZC00OTdkLTlmZjQtYzNmZDRlOTZlMTM5
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MTkuNjczMDY4
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:26 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/ceb3efd1-942d-497d-9ff4-c3fd4e96e139/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 60152010f7504b0db96c610fb837df38
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxODVjMTJmLWY4YmYtNDIz
+        MS1iZGZiLWU5MDg3NDliODgxMi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:27 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0185c12f-f8bf-4231-bdfb-e908749b8812/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d566ae4db15d41af968923301dd84d39
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4NWMxMmYtZjhi
+        Zi00MjMxLWJkZmItZTkwODc0OWI4ODEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjcuMDY3ODQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2MDE1MjAxMGY3NTA0YjBkYjk2YzYxMGZi
+        ODM3ZGYzOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjI3LjEz
+        MTEyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MjcuMTgz
+        MjE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:27 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9689cdecd7c74791a42d702aa5e7d1ba
+      - 67ea575fcdad49e98b4a70f4076f0af6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 367c992db4674bbd87346b695436b974
+      - 0f8a482c9a384c52833c6767d3a18c98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a077d50c797f48bd9b6e2c93925d5d75
+      - 4d07b807cda14085b50a743611a997cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b9af255953b44061857dc60afe7b4bb6
+      - 33ebc512c5c3460a97a520c18511b716
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:34 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d105641b21384f98aabdd6d7d7c3ee5a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:27 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/d785cc97-c9fc-446d-822b-7801e8472413/"
+      - "/pulp/api/v3/remotes/rpm/rpm/91e22ebb-0d3a-4524-942d-791ae3f27fa9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1db27d6b892490eacbb46e00803e21d
+      - 631acc18033a46d3a90ae7d9c35011c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q3
-        ODVjYzk3LWM5ZmMtNDQ2ZC04MjJiLTc4MDFlODQ3MjQxMy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI3OjM0LjU5NTM2NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkx
+        ZTIyZWJiLTBkM2EtNDUyNC05NDJkLTc5MWFlM2YyN2ZhOS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjI3LjU2NzgxNVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI3OjM0LjU5NTM4NVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjMyOjI3LjU2Nzg0MVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:27 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/"
+      - "/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5143f79e0ae443c4869bead69986f31d
+      - eb2f2562e2d447019d12609e290566ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmUzZjM2NDktMjUwZC00ZGJlLWEwNzctYmZmYmU1NTJiYWIwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MzQuNzg3MDUzWiIsInZl
+        cG0vNTYwNGVlM2UtZTIzYi00ZmI2LWE3MzktYmE4Mzg0ZTkxMmQxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MjcuNzYxNTgxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmUzZjM2NDktMjUwZC00ZGJlLWEwNzctYmZmYmU1NTJiYWIwL3ZlcnNp
+        cG0vNTYwNGVlM2UtZTIzYi00ZmI2LWE3MzktYmE4Mzg0ZTkxMmQxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZTNmMzY0OS0y
-        NTBkLTRkYmUtYTA3Ny1iZmZiZTU1MmJhYjAvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81NjA0ZWUzZS1l
+        MjNiLTRmYjYtYTczOS1iYTgzODRlOTEyZDEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:34 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf46f86f533744a0b5e0c19c5f382b40
+      - '097b25978eb54160b2cc3df74fe4387f'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iYTUxZjU2OC00NzM0LTQxOTMtYjY5Mi1hN2VhZjg4YzUwMjIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNzoyNy44Mjg3NjBa
+        cnBtL3JwbS9iNjE1ZTVhYi03ZDYzLTRhZTMtODE3Ni1jMTJmNzVmZThkYWYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjoxMy4wMTk4NjFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iYTUxZjU2OC00NzM0LTQxOTMtYjY5Mi1hN2VhZjg4YzUwMjIv
+        cnBtL3JwbS9iNjE1ZTVhYi03ZDYzLTRhZTMtODE3Ni1jMTJmNzVmZThkYWYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JhNTFm
-        NTY4LTQ3MzQtNDE5My1iNjkyLWE3ZWFmODhjNTAyMi92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I2MTVl
+        NWFiLTdkNjMtNGFlMy04MTc2LWMxMmY3NWZlOGRhZi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ba51f568-4734-4193-b692-a7eaf88c5022/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5d66694c0054e6fa3c9ecfcf59bdf60
+      - 04b2a7eb13be4cde8fcd96b55835ad28
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5YTEzMmIzLTkzMWYtNDM4
-        OC05ZjFkLWE4ZGMxZTJmYTE2Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4NjRmN2UzLWE4NmYtNDY3
+        OC1iNzE5LWIzNDM1NmI2MjI1NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8c546a3e362240ee9b5eaa37125d7e1f
+      - 3b2352b1c2cf4b43a9544bbb7770e480
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYTcwMzM5NjAtODc2OS00N2Q0LTg5YTgtZDU3MTg2ZTJkM2I0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MjcuMDE1MTMxWiIsIm5h
-        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
-        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
-        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
-        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyNzoyOC4xNjA2OTVaIiwiZG93bmxvYWRfY29uY3VycmVu
-        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
-        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
-        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
-        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
-        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+        cG0vOTQ4Y2FmZWQtNDNhOC00YjlmLWJkYmMtZTZiNDg5YWViOWM5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MTEuNDUyMTQwWiIsIm5h
+        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
+        ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
+        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
+        cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjoxMy41Nzc1MTVaIiwiZG93bmxv
+        YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
+        Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
+        Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
+        InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
+        dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a7033960-8769-47d4-89a8-d57186e2d3b4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/948cafed-43a8-4b9f-bdbc-e6b489aeb9c9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6aa3f0c26d364c9b8f291bc5104cab97
+      - 336b11b586b64483a093a3d74958d489
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExMmYwMjc5LWFjN2YtNDY5
-        NS05MjIyLTRlNDk1YmFiY2M5NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3OTE4OWYyLWExMzAtNDVl
+        ZC05NTY2LTAwNjIzMWYxMDAyZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b9a132b3-931f-4388-9f1d-a8dc1e2fa162/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1864f7e3-a86f-4678-b719-b34356b62255/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbca98e3c0934d96a57698bb5518ac6e
+      - 1f7aa1e51c8146faa63048dbcaa14094
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjlhMTMyYjMtOTMx
-        Zi00Mzg4LTlmMWQtYThkYzFlMmZhMTYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzQuOTk0MTE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTg2NGY3ZTMtYTg2
+        Zi00Njc4LWI3MTktYjM0MzU2YjYyMjU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjguMTM4NDM3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmNWQ2NjY5NGMwMDU0ZTZmYTNjOWVjZmNm
-        NTliZGY2MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjM1LjAy
-        NjQ5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MzUuMDk0
-        MzUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNGIyYTdlYjEzYmU0Y2RlOGZjZDk2YjU1
+        ODM1YWQyOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjI4LjIx
+        MDAyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MjguMzU0
+        MTU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmE1MWY1NjgtNDczNC00MTkz
-        LWI2OTItYTdlYWY4OGM1MDIyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjYxNWU1YWItN2Q2My00YWUz
+        LTgxNzYtYzEyZjc1ZmU4ZGFmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/112f0279-ac7f-4695-9222-4e495babcc94/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/079189f2-a130-45ed-9566-006231f1002e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 93bcc8e30105472eabf46ff2e85bb57d
+      - 9ce2ff3c381a4f8bb3b7344051b5cb7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTEyZjAyNzktYWM3
-        Zi00Njk1LTkyMjItNGU0OTViYWJjYzk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzUuMDg1MzA4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDc5MTg5ZjItYTEz
+        MC00NWVkLTk1NjYtMDA2MjMxZjEwMDJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjguMzQwNjU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2YWEzZjBjMjZkMzY0YzliOGYyOTFiYzUx
-        MDRjYWI5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjM1LjEy
-        NDI1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MzUuMTY5
-        NjYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzMzZiMTFiNTg2YjY0NDgzYTA5M2EzZDc0
+        OTU4ZDQ4OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjI4LjQx
+        MDg1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MjguNDky
+        MDI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E3MDMzOTYwLTg3NjktNDdkNC04OWE4
-        LWQ1NzE4NmUyZDNiNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk0OGNhZmVkLTQzYTgtNGI5Zi1iZGJj
+        LWU2YjQ4OWFlYjljOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c8fcf0809004b70aa21d48f0f3d2312
+      - 7e5945e84abb4fadbffe23cd52ecad8d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 47e39f21054943d8b266ddb9cb71042f
+      - 60d3250b9cc3410eaac6ae237d942270
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b09cfeec93834a528b6ab6a7cd4104de
+      - 17027b47b56746829ac71a4bcc5daec7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2fa4d7a590d4a7a9a88fa7a8cbb4bc5
+      - 7e6d349cfb064ea8a51d2d960a8bf149
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa3a509b3388486c9de87430e029ddda
+      - 201acb502037400283b83771b03462e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5fae0068fd84c29ac43f5974270ade8
+      - d499739e06104f23bbeeac0d6d3e9242
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:28 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/"
+      - "/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2061352e9464074919b124a46df1e86
+      - f28ea07864794a418572f253188e49a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjY3MmE2Y2UtY2JkZi00NzkxLWEyOWQtMzMyNmM4ODRiYzg2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MzUuNjA4MDM2WiIsInZl
+        cG0vMzg4NWUzN2YtZTA1NC00OWEyLWJlYTYtMjUzMzdiMzg2Y2JmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MjkuMTc1MjQyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjY3MmE2Y2UtY2JkZi00NzkxLWEyOWQtMzMyNmM4ODRiYzg2L3ZlcnNp
+        cG0vMzg4NWUzN2YtZTA1NC00OWEyLWJlYTYtMjUzMzdiMzg2Y2JmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iNjcyYTZjZS1j
-        YmRmLTQ3OTEtYTI5ZC0zMzI2Yzg4NGJjODYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zODg1ZTM3Zi1l
+        MDU0LTQ5YTItYmVhNi0yNTMzN2IzODZjYmYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:29 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/d785cc97-c9fc-446d-822b-7801e8472413/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/91e22ebb-0d3a-4524-942d-791ae3f27fa9/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:35 GMT
+      - Fri, 29 Jul 2022 11:32:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2dcd038ed394c5eb77bc32f940ab637
+      - db784875ef0d47d8a06b1d0a8f950e56
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4NTdiYmRiLWQxNWYtNDNi
-        Yy1hZjE3LTMxNjFmYzJiYTdkZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxY2Q1ODgzLTM1NTgtNGY4
+        OC04ODJlLTVlYjk0MDVmNGNjZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0857bbdb-d15f-43bc-af17-3161fc2ba7de/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f1cd5883-3558-4f88-882e-5eb9405f4ccd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:36 GMT
+      - Fri, 29 Jul 2022 11:32:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bdec24a652bb4da98c8b320f199b23ba
+      - ff4417494bb045079f25891e64f595dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDg1N2JiZGItZDE1
-        Zi00M2JjLWFmMTctMzE2MWZjMmJhN2RlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzUuOTEzNDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjFjZDU4ODMtMzU1
+        OC00Zjg4LTg4MmUtNWViOTQwNWY0Y2NkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjkuNjcxODE4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmMmRjZDAzOGVkMzk0YzVlYjc3YmMzMmY5
-        NDBhYjYzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjM1Ljk0
-        NDYxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MzUuOTY4
-        MjYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkYjc4NDg3NWVmMGQ0N2Q4YTA2YjFkMGE4
+        Zjk1MGU1NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjI5Ljcy
+        ODAwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MjkuNzY4
+        ODcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q3ODVjYzk3LWM5ZmMtNDQ2ZC04MjJi
-        LTc4MDFlODQ3MjQxMy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkxZTIyZWJiLTBkM2EtNDUyNC05NDJk
+        LTc5MWFlM2YyN2ZhOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:29 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q3ODVj
-        Yzk3LWM5ZmMtNDQ2ZC04MjJiLTc4MDFlODQ3MjQxMy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkxZTIy
+        ZWJiLTBkM2EtNDUyNC05NDJkLTc5MWFlM2YyN2ZhOS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:36 GMT
+      - Fri, 29 Jul 2022 11:32:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5b1f4c6ac9443f4af907c6d62f0578e
+      - c13db2ca381f4b84ac7a2d8678f0c893
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5YzFhNmYwLTNlODAtNDdm
-        ZC05MjA4LWRlYTEyNzA0ODkxZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4MTkxN2M5LTMwZTYtNDU5
+        ZC1iODkxLTY5MzJkNzVhMjQ4Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/29c1a6f0-3e80-47fd-9208-dea12704891f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/981917c9-30e6-459d-b891-6932d75a248b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:37 GMT
+      - Fri, 29 Jul 2022 11:32:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef7313acf4664f11af73957b6a817c2e
+      - 6385a15dddbb4a1d8ff1325559080edb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '652'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjljMWE2ZjAtM2U4
-        MC00N2ZkLTkyMDgtZGVhMTI3MDQ4OTFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzYuMDg5NjgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTgxOTE3YzktMzBl
+        Ni00NTlkLWI4OTEtNjkzMmQ3NWEyNDhiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjkuOTIyMjA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmNWIxZjRjNmFjOTQ0M2Y0YWY5
-        MDdjNmQ2MmYwNTc4ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM2LjExOTM0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzYuOTI5MDcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJjMTNkYjJjYTM4MWY0Yjg0YWM3
+        YTJkODY3OGYwYzg5MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjMwLjAwNDEwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzEuNjA2MjI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2JlM2YzNjQ5LTI1MGQtNGRiZS1hMDc3LWJmZmJl
-        NTUyYmFiMC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZTNm
-        MzY0OS0yNTBkLTRkYmUtYTA3Ny1iZmZiZTU1MmJhYjAvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZDc4NWNjOTctYzlmYy00NDZk
-        LTgyMmItNzgwMWU4NDcyNDEzLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS81NjA0ZWUzZS1lMjNiLTRmYjYtYTczOS1iYTgzODRl
+        OTEyZDEvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTYwNGVl
+        M2UtZTIzYi00ZmI2LWE3MzktYmE4Mzg0ZTkxMmQxLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkxZTIyZWJiLTBkM2EtNDUyNC05
+        NDJkLTc5MWFlM2YyN2ZhOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYmUzZjM2NDktMjUwZC00ZGJlLWEwNzctYmZmYmU1NTJi
-        YWIwL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNTYwNGVlM2UtZTIzYi00ZmI2LWE3MzktYmE4Mzg0ZTkx
+        MmQxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:37 GMT
+      - Fri, 29 Jul 2022 11:32:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb686b868ffc4340bbe803c33dd7c3db
+      - 34d6ca27729b479694d13a97f8d76811
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2NGViN2YyLWY5MmItNDY0
-        YS1iZWFhLWY5YmMwMjJhZjM5Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExZWQ1NmVjLWFmODgtNDI2
+        ZC05NGIyLTk5ZGMzNWQ3MGJjOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e64eb7f2-f92b-464a-beaa-f9bc022af39c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a1ed56ec-af88-426d-94b2-99dc35d70bc8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:37 GMT
+      - Fri, 29 Jul 2022 11:32:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f8bc237d67124652a1abd52b3b1ebe4a
+      - c8df596859cd442c997d797a28c51896
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '472'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTY0ZWI3ZjItZjky
-        Yi00NjRhLWJlYWEtZjliYzAyMmFmMzljLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzcuMjM3OTExWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTFlZDU2ZWMtYWY4
+        OC00MjZkLTk0YjItOTlkYzM1ZDcwYmM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzIuMjUwNzE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImJiNjg2Yjg2OGZmYzQzNDBiYmU4MDNjMzNk
-        ZDdjM2RiIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MzcuMjc3
-        NTQxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNzozNy42MjEw
-        NzZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjM0ZDZjYTI3NzI5YjQ3OTY5NGQxM2E5N2Y4
+        ZDc2ODExIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MzIuMzA1
+        MjI4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMjozMi44NTI3
+        MjhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZmZhNDQ4
-        MGQtNmUwNS00ZGNjLWEyODgtOWZmZDJjYzhmYzBhLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNGMxOGMy
+        MzMtYmQ1YS00Njg0LWEyMDQtZTYyZDA2NDFhYTZkLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYmUzZjM2NDktMjUwZC00ZGJlLWEwNzctYmZmYmU1
-        NTJiYWIwLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNTYwNGVlM2UtZTIzYi00ZmI2LWE3MzktYmE4Mzg0
+        ZTkxMmQxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:37 GMT
+      - Fri, 29 Jul 2022 11:32:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33045d934a4542a18bfef31592c544b6
+      - 3dedd9175dac4487a31aa42db3f8baaa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/4c18c233-bd5a-4684-a204-e62d0641aa6d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 26b2896dbdb549f9b9fb8697334a23e2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNGMxOGMyMzMtYmQ1YS00Njg0LWEyMDQtZTYyZDA2NDFhYTZkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MzIuMzM1OTQ1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS81NjA0ZWUzZS1lMjNiLTRmYjYtYTczOS1iYTgzODRlOTEyZDEv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzU2MDRlZTNlLWUyM2ItNGZiNi1hNzM5LWJhODM4
+        NGU5MTJkMS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:33 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS80YzE4YzIzMy1iZDVhLTQ2ODQtYTIwNC1lNjJkMDY0MWFhNmQv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6f97d580776943c6aee5422862e85ec1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlOTM2YWJkLTQwNjAtNGE0
+        Mi04YWEyLTgxNjZlNGM5NzQ4OC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1e936abd-4060-4a42-8aa2-8166e4c97488/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0607d271693d4d169e4b570a5a18903b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWU5MzZhYmQtNDA2
+        MC00YTQyLThhYTItODE2NmU0Yzk3NDg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzMuMjM2OTk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2Zjk3ZDU4MDc3Njk0M2M2YWVlNTQyMjg2
+        MmU4NWVjMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjMzLjI5
+        MTU5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MzMuNTk4
+        MDA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYWE4
+        MjgxNzUtYmFjMS00MWY3LWEwYjYtZDFlOTI0ODhiMjI2LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/aa828175-bac1-41f7-a0b6-d1e92488b226/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e05bfa77dc31465097f31422c41dacc2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2FhODI4MTc1LWJhYzEtNDFmNy1hMGI2LWQxZTkyNDg4YjIyNi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjMzLjU3MjEzMloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNGMxOGMyMzMtYmQ1YS00Njg0LWEyMDQt
+        ZTYyZDA2NDFhYTZkLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d29b4acabbe94fc4951d94ae63d93d44
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0bc748017c4f4de5b112244146ffab2f
+      - e7e2be44f40d45ddb5058a1862375223
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39db795c4ec44562a5277b1df0730ed4
+      - 8ae50083d9c74db69e55be3041a84ae6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb8848a004254693a47df44c039a5a55
+      - b81471cefdac4eb881b7d83b2f8e9a9e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '09b3b1e505f445da9ec4104eecc791af'
+      - aeb86d3ba17440e2931dc800c5a53a77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbb54b6c540e43d69a16c2f79b33b89c
+      - 9c3c63572d3c4b6fa2b01f17806b98c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1fb2e23174940dabc72d6f15919686f
+      - 4b7f2b9b714747b88d1ca97e86a6553b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 508851169bdd4fbca2a8897a7ec73913
+      - f0a53f9dfbd34fcd929ca26400429b7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5d85914a3694ea3b8087c08564a81bd
+      - 5ee0fa89cdcb4b2c829deed1260bd4c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f82617d3889a4c24ae09a1cbcf5ac943
+      - 1c822152c00a4d7dab023bfa95fc89bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fec83eedb2f24d63a3c1b5653445a9d1
+      - 6f0be959c4a44d66be03341c4b5f99f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5596ccec864f47919b26fc02eb8479b7
+      - 24bb8e0f58e04abebe5bce22acce5872
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:38 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e00d1b011b8743efa1a01d36a578f1ce
+      - b47479d2648f488b9c774913eb08c5fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:38 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ace3f5b583b4a41aba6feda9839561c
+      - 8c313b8094d44ec58acc4e963d1d829d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae64898b6a66463ab236d8fe6a2ed651
+      - a00f833fd6254d7e813ac374cf8066fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3ODE5ODhlLTY4NjAtNDk2
-        Yi1iYjY0LTdhOWVhOTBkN2M5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyYzNmN2M1LTIzYWEtNGI1
+        Yi05MGNiLTMxOGNhYWIxZDJkZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8cef7db3429e4122a9a84ae5e0d1a30c
+      - d69d3493d2ac4ed4bb1e510d7ed44d24
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y1ZjIyZGMzLWI5NTUtNGY3
-        ZS1hNjg4LTkxZjQyNmFlOTBmZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3ZTUzZmY4LTM4NjctNGRi
+        OC1hZDZlLTBmN2VkODU1OWE4NC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,72 +3935,72 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c6959ef1e2646219e9ed20418e938ab
+      - 320cb8589a8940b5a99ce50ac8abe01e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2NjVhMDNmLTcyNDktNGRj
-        Zi1iNmVkLTliNzllMThkYjdjMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjYWM3MmQ3LWFhNzctNGQ1
+        Ny04OTc4LTUwZDVkOTc2N2Y3Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmUzZjM2NDktMjUwZC00ZGJlLWEw
-        NzctYmZmYmU1NTJiYWIwL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I2NzJhNmNlLWNiZGYt
-        NDc5MS1hMjlkLTMzMjZjODg0YmM4Ni8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NjNmYmYwMmEtNDI1OS00M2FlLTlhNzYtMTJiZmI4Nzg5NTZmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2Qt
-        NDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1ZC1i
-        ODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRkNGFh
-        Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRlNTYx
-        MGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04
-        Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNlYzY5
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5YTY1
-        ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05
-        M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZh
-        ZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01Yjcx
-        LTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlm
-        OGU2NWMwZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        M2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1
-        ZDItODU2MC1jNzBhZjkxMzdjY2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTli
-        ZDQ4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIy
-        NTE3MzgtNmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQzZC03NDg3LTRhNzYt
-        ODUzMi03ZDdjZDlkZTg5OGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZmODUwYjkyNmU1
-        Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9m
-        aWxlcy9mNDdhM2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTYwNGVlM2UtZTIzYi00ZmI2LWE3
+        MzktYmE4Mzg0ZTkxMmQxL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM4ODVlMzdmLWUwNTQt
+        NDlhMi1iZWE2LTI1MzM3YjM4NmNiZi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8zOWI0ZTRmNy1kNzdjLTQwNjYtOTJkMC05NTBmZjBl
+        MmJlNjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        YWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYyYWIt
+        NGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdhYi1h
+        NTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQyOTI5
+        My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1ZWE3
+        ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1h
+        ZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFkMTkx
+        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1
+        ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgxNS04
+        OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFj
+        YmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMtNGFjYy05ZTE5LTg0Yjlj
+        NDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUzNC0wZjE0LTRl
+        NDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAxYy1hZmU1LTU4NWIyOTkz
+        N2M1Ni8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTcy
+        MjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAt
+        YmQyYi05MDMzNmRkMzBjNGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2E3MjQwZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIw
+        ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9m
+        aWxlcy80YWJmNTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19
         XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3588,7 +4013,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3606,21 +4031,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41ff3ed3a8e34b8ca5b93d4f29125923
+      - a08d86f3809d48718c43f9fee595d35e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJlZjY2OGMwLWU4YzgtNDgy
-        Zi1hYWI2LTU0OGRkYzdjZjYzNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwODliNWFiLTNiM2QtNDc5
+        ZS04MmNiLWI3NDQ2MDM2YThmMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3781988e-6860-496b-bb64-7a9ea90d7c99/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2c3f7c5-23aa-4b5b-90cb-318caab1d2de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3641,51 +4066,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e9dcd5188ce345c78dab59298996b7e9
+      - f9bb4b1b623f41859ba9909007176a0f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzc4MTk4OGUtNjg2
-        MC00OTZiLWJiNjQtN2E5ZWE5MGQ3Yzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMDM0NjU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJjM2Y3YzUtMjNh
+        YS00YjViLTkwY2ItMzE4Y2FhYjFkMmRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNTA3MDI3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZTY0ODk4YjZhNjY0NjNhYjIz
-        NmQ4ZmU2YTJlZDY1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjA2NTQ5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuMjEwMDg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhMDBmODMzZmQ2MjU0ZDdlODEz
+        YWMzNzRjZjgwNjZmYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM2LjU3Mzc0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzYuODYxODA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2Jk
-        Zi00NzkxLWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1
+        NC00OWEyLWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3781988e-6860-496b-bb64-7a9ea90d7c99/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2c3f7c5-23aa-4b5b-90cb-318caab1d2de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3706,51 +4131,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8964f59a07349ef9c0cebb182303ef3
+      - 68eabc8d15f5450aadf88dd1b785ba28
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzc4MTk4OGUtNjg2
-        MC00OTZiLWJiNjQtN2E5ZWE5MGQ3Yzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMDM0NjU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJjM2Y3YzUtMjNh
+        YS00YjViLTkwY2ItMzE4Y2FhYjFkMmRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNTA3MDI3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZTY0ODk4YjZhNjY0NjNhYjIz
-        NmQ4ZmU2YTJlZDY1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjA2NTQ5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuMjEwMDg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhMDBmODMzZmQ2MjU0ZDdlODEz
+        YWMzNzRjZjgwNjZmYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM2LjU3Mzc0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzYuODYxODA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2Jk
-        Zi00NzkxLWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1
+        NC00OWEyLWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f5f22dc3-b955-4f7e-a688-91f426ae90fd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a7e53ff8-3867-4db8-ad6e-0f7ed8559a84/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3771,53 +4196,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9dad19532f5841e3b241ebe0b1bb8317
+      - 1b576676164a480a96ae75c01a0cc640
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjVmMjJkYzMtYjk1
-        NS00ZjdlLWE2ODgtOTFmNDI2YWU5MGZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMDg1NTMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTdlNTNmZjgtMzg2
+        Ny00ZGI4LWFkNmUtMGY3ZWQ4NTU5YTg0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNjE2NDM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4Y2VmN2RiMzQyOWU0MTIyYTlh
-        ODRhZTVlMGQxYTMwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjI0MjE4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuMzczNjcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkNjlkMzQ5M2QyYWM0ZWQ0YmIx
+        ZTUxMGQ3ZWQ0NGQyNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM2LjkwODQ2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzcuMjA4OTg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iNjcyYTZjZS1jYmRmLTQ3OTEtYTI5ZC0zMzI2Yzg4NGJjODYvdmVyc2lv
+        bS8zODg1ZTM3Zi1lMDU0LTQ5YTItYmVhNi0yNTMzN2IzODZjYmYvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2JkZi00Nzkx
-        LWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1NC00OWEy
+        LWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3781988e-6860-496b-bb64-7a9ea90d7c99/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2c3f7c5-23aa-4b5b-90cb-318caab1d2de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3838,51 +4263,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 916dad2aa3e847c1a2e3fc5672b1d3b2
+      - d0453394b9f34b318acafb1b8ec8ae41
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzc4MTk4OGUtNjg2
-        MC00OTZiLWJiNjQtN2E5ZWE5MGQ3Yzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMDM0NjU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJjM2Y3YzUtMjNh
+        YS00YjViLTkwY2ItMzE4Y2FhYjFkMmRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNTA3MDI3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZTY0ODk4YjZhNjY0NjNhYjIz
-        NmQ4ZmU2YTJlZDY1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjA2NTQ5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuMjEwMDg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhMDBmODMzZmQ2MjU0ZDdlODEz
+        YWMzNzRjZjgwNjZmYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM2LjU3Mzc0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzYuODYxODA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2Jk
-        Zi00NzkxLWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1
+        NC00OWEyLWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f5f22dc3-b955-4f7e-a688-91f426ae90fd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a7e53ff8-3867-4db8-ad6e-0f7ed8559a84/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3903,53 +4328,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e3cf06a698734715856d463c28f3d728
+      - 69fd59bd6dbd4f24a9cc0fddabe353be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjVmMjJkYzMtYjk1
-        NS00ZjdlLWE2ODgtOTFmNDI2YWU5MGZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMDg1NTMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTdlNTNmZjgtMzg2
+        Ny00ZGI4LWFkNmUtMGY3ZWQ4NTU5YTg0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNjE2NDM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4Y2VmN2RiMzQyOWU0MTIyYTlh
-        ODRhZTVlMGQxYTMwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjI0MjE4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuMzczNjcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkNjlkMzQ5M2QyYWM0ZWQ0YmIx
+        ZTUxMGQ3ZWQ0NGQyNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM2LjkwODQ2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzcuMjA4OTg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iNjcyYTZjZS1jYmRmLTQ3OTEtYTI5ZC0zMzI2Yzg4NGJjODYvdmVyc2lv
+        bS8zODg1ZTM3Zi1lMDU0LTQ5YTItYmVhNi0yNTMzN2IzODZjYmYvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2JkZi00Nzkx
-        LWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1NC00OWEy
+        LWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1665a03f-7249-4dcf-b6ed-9b79e18db7c3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/acac72d7-aa77-4d57-8978-50d5d9767f7b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3970,53 +4395,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd4c8879fb7640d3a6b791921a8ec648
+      - 90583ce4dd9c454caf2c9e1c837723cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTY2NWEwM2YtNzI0
-        OS00ZGNmLWI2ZWQtOWI3OWUxOGRiN2MzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMTM2MzYwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNhYzcyZDctYWE3
+        Ny00ZDU3LTg5NzgtNTBkNWQ5NzY3ZjdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNzA5MjQ3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5YzY5NTllZjFlMjY0NjIxOWU5
-        ZWQyMDQxOGU5MzhhYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjQwNDExNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuNTM3Mzg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMjBjYjg1ODlhODk0MGI1YTk5
+        Y2U1MGFjOGFiZTAxZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM3LjI1NzUyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzcuNTgyNzExWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iNjcyYTZjZS1jYmRmLTQ3OTEtYTI5ZC0zMzI2Yzg4NGJjODYvdmVyc2lv
+        bS8zODg1ZTM3Zi1lMDU0LTQ5YTItYmVhNi0yNTMzN2IzODZjYmYvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2JkZi00Nzkx
-        LWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1NC00OWEy
+        LWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3781988e-6860-496b-bb64-7a9ea90d7c99/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2c3f7c5-23aa-4b5b-90cb-318caab1d2de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4037,51 +4462,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbd0d4971d2746e3a149be192d63600a
+      - 9f3c1ab525da4bf496e50c57eee2f3fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzc4MTk4OGUtNjg2
-        MC00OTZiLWJiNjQtN2E5ZWE5MGQ3Yzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMDM0NjU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJjM2Y3YzUtMjNh
+        YS00YjViLTkwY2ItMzE4Y2FhYjFkMmRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNTA3MDI3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZTY0ODk4YjZhNjY0NjNhYjIz
-        NmQ4ZmU2YTJlZDY1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjA2NTQ5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuMjEwMDg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhMDBmODMzZmQ2MjU0ZDdlODEz
+        YWMzNzRjZjgwNjZmYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM2LjU3Mzc0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzYuODYxODA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2Jk
-        Zi00NzkxLWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1
+        NC00OWEyLWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f5f22dc3-b955-4f7e-a688-91f426ae90fd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a7e53ff8-3867-4db8-ad6e-0f7ed8559a84/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4102,53 +4527,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:39 GMT
+      - Fri, 29 Jul 2022 11:32:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 823cee15e1ef45fdafd2414e386c642a
+      - 140d0f045e754660bb4a7bc015ed5973
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjVmMjJkYzMtYjk1
-        NS00ZjdlLWE2ODgtOTFmNDI2YWU5MGZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMDg1NTMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTdlNTNmZjgtMzg2
+        Ny00ZGI4LWFkNmUtMGY3ZWQ4NTU5YTg0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNjE2NDM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4Y2VmN2RiMzQyOWU0MTIyYTlh
-        ODRhZTVlMGQxYTMwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjI0MjE4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuMzczNjcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkNjlkMzQ5M2QyYWM0ZWQ0YmIx
+        ZTUxMGQ3ZWQ0NGQyNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM2LjkwODQ2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzcuMjA4OTg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iNjcyYTZjZS1jYmRmLTQ3OTEtYTI5ZC0zMzI2Yzg4NGJjODYvdmVyc2lv
+        bS8zODg1ZTM3Zi1lMDU0LTQ5YTItYmVhNi0yNTMzN2IzODZjYmYvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2JkZi00Nzkx
-        LWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1NC00OWEy
+        LWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1665a03f-7249-4dcf-b6ed-9b79e18db7c3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/acac72d7-aa77-4d57-8978-50d5d9767f7b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4169,53 +4594,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8cd8d147fd594c5396d8e19ae8adebde
+      - dc8e90b6cf974fbcaab7c2c87fea0a7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTY2NWEwM2YtNzI0
-        OS00ZGNmLWI2ZWQtOWI3OWUxOGRiN2MzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMTM2MzYwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNhYzcyZDctYWE3
+        Ny00ZDU3LTg5NzgtNTBkNWQ5NzY3ZjdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuNzA5MjQ3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5YzY5NTllZjFlMjY0NjIxOWU5
-        ZWQyMDQxOGU5MzhhYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjM5LjQwNDExNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MzkuNTM3Mzg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMjBjYjg1ODlhODk0MGI1YTk5
+        Y2U1MGFjOGFiZTAxZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjM3LjI1NzUyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MzcuNTgyNzExWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iNjcyYTZjZS1jYmRmLTQ3OTEtYTI5ZC0zMzI2Yzg4NGJjODYvdmVyc2lv
+        bS8zODg1ZTM3Zi1lMDU0LTQ5YTItYmVhNi0yNTMzN2IzODZjYmYvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2JkZi00Nzkx
-        LWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUzN2YtZTA1NC00OWEy
+        LWJlYTYtMjUzMzdiMzg2Y2JmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2ef668c0-e8c8-482f-aab6-548ddc7cf635/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5089b5ab-3b3d-479e-82cb-b7446036a8f0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4236,55 +4661,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fcff9764d25c459c9c322dd8f16a0a8f
+      - ecb25843cbed42db8ce1526be567ecd3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmVmNjY4YzAtZThj
-        OC00ODJmLWFhYjYtNTQ4ZGRjN2NmNjM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MzkuMTg2NjgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTA4OWI1YWItM2Iz
+        ZC00NzllLTgyY2ItYjc0NDYwMzZhOGYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MzYuODM4MTY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiNDFmZjNlZDNhOGUzNGI4Y2E1YjkzZDRmMjkx
-        MjU5MjMiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNzozOS41NjU2
-        NzRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjM5Ljk5MDA1
-        OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvMGRmMThhZmYtNjRiOC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiYTA4ZDg2ZjM4MDlkNDg3MThjNDNmOWZlZTU5
+        NWQzNWUiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMjozNy42NDE2
+        MTRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjM4LjU3ODg1
+        MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2
-        Y2UtY2JkZi00NzkxLWEyOWQtMzMyNmM4ODRiYzg2L3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzg4NWUz
+        N2YtZTA1NC00OWEyLWJlYTYtMjUzMzdiMzg2Y2JmL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2I2NzJhNmNlLWNiZGYtNDc5MS1hMjlkLTMz
-        MjZjODg0YmM4Ni8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2JlM2YzNjQ5LTI1MGQtNGRiZS1hMDc3LWJmZmJlNTUyYmFi
-        MC8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzM4ODVlMzdmLWUwNTQtNDlhMi1iZWE2LTI1
+        MzM3YjM4NmNiZi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzU2MDRlZTNlLWUyM2ItNGZiNi1hNzM5LWJhODM4NGU5MTJk
+        MS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4292,7 +4717,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4305,64 +4730,64 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1196'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 855f346be1104bb3a119c0b0f4b0bf8b
+      - 12af7c494c124ed3bfeb801d389b8caa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '428'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTMsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8wYTc1Y2I2NS04NzMxLTRhYzMtYjRkNy02ZTY3ZTU5M2VkMzMvIn0s
+        YWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQyYi05MDMzNmRkMzBjNGMvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyJ9LHsi
+        ZXMvOWVjYTM4YTItNzhkZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFjOTY2MjVkZmYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGY0
-        YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5ZGU4OThmLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI5ZTZh
-        MjFkLTJmNjktNGNkMi1iNzExLTYxY2M4OWNmNzBjZS8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NjUyMjg4
-        MC04YzVhLTQ4MDEtYjU2Ny0xZjJiMWRiNzNkZWMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEt
-        ZmFlMi00NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTVi
-        NzEtNDE1NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2Ex
-        LTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00
-        YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyJ9XX0=
+        L2QxYzc5OWE2LWY3NjYtNDU4Ni1hMTliLTI0YzJmYmUzNzFmYy8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJh
+        NDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVhMzI4
+        NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVjMTBkNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhj
+        MS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVmMmUt
+        YjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEw
+        ZmMtNDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEz
+        LTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00
+        MWQxLWE4ZGYtZmQ4NDNhN2VkNWE4LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4370,7 +4795,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4383,50 +4808,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7e92f72ef5ad479e9911c16124c73c46
+      - e2d7f79140154a6a9ad12f24797e7eec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4434,7 +4859,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4447,37 +4872,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6131'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce512339d992450c8823241162d4e860
+      - c9818aa866b044d2bcc3eb1ed6343074
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1830'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4550,9 +4975,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -4569,9 +4994,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -4580,9 +5005,9 @@ http_interactions:
         c29sdXRpb24iOiIiLCJyZWxlYXNlIjoiMSIsInJpZ2h0cyI6IiIsInB1c2hj
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvNjNmYmYwMmEtNDI1OS00M2FlLTlh
-        NzYtMTJiZmI4Nzg5NTZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNU
-        MjM6MjY6NTguMjM4MjM3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
+        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvZWE1ZjA0NjItNjJhYi00YzFmLWE2
+        NGQtYjkxZDA2YzQ1YjZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhU
+        MTU6MDQ6MzQuMjcyMTg0WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
         OSIsInVwZGF0ZWRfZGF0ZSI6IjIwMTgtMDctMjAgMDY6MDA6MDEiLCJkZXNj
         cmlwdGlvbiI6IkR1Y2tfS2FuZ2Fyb19FcnJhdHVtIGRlc2NyaXB0aW9uIiwi
         aXNzdWVkX2RhdGUiOiIyMDE4LTAxLTI3IDE2OjA4OjA5IiwiZnJvbXN0ciI6
@@ -4611,10 +5036,10 @@ http_interactions:
         biI6IjAuNyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3Rl
         ZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4622,7 +5047,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4635,43 +5060,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a712c99cd1c1434690b29d46ade62918
+      - ec9bc8d22ec9456c8600b6f721f58941
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4679,7 +5104,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4692,41 +5117,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5c31053ebb94c4cafeb9c6e47323177
+      - a2118241e8e44232a5482cb2c14c384a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4734,7 +5159,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4747,36 +5172,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1d50f770fc28427fbe223ac8f787cba5
+      - 462f7def76184a2d9d9b53dd688e8728
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4798,10 +5223,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5604ee3e-e23b-4fb6-a739-ba8384e912d1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4809,7 +5234,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4822,36 +5247,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 377efb91a0a94fc9bca7cc5c1f7cf6a1
+      - 5b4718d0e5f2462a872c522e7b1d878a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4873,10 +5298,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3885e37f-e054-49a2-bea6-25337b386cbf/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4884,7 +5309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4897,36 +5322,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:40 GMT
+      - Fri, 29 Jul 2022 11:32:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95f5facc0d4b4a32a964da04a2e87079
+      - 8760328a82754861a2ae292358fa00c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4948,5 +5373,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:39 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_errata_repository/all_errata_copied_if_no_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_errata_repository/all_errata_copied_if_no_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7eab2236ab7a47bca5ce23fe96fda1d4
+      - 4cede700a1704af5a369e671984234cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '314'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85ZjBlYTBkNi1jYWJlLTQ1ZDAtYTI2NS04MGY3ZmY3MmRkMzYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyODowNS4zMjg1Nzha
+        cnBtL3JwbS9iMWU5NTkxNC1jZTVmLTQzNDgtYmFjMi02MWM1MjA5ODliMjUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDoyOS4yNDcwOTNa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85ZjBlYTBkNi1jYWJlLTQ1ZDAtYTI2NS04MGY3ZmY3MmRkMzYv
+        cnBtL3JwbS9iMWU5NTkxNC1jZTVmLTQzNDgtYmFjMi02MWM1MjA5ODliMjUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzlmMGVh
-        MGQ2LWNhYmUtNDVkMC1hMjY1LTgwZjdmZjcyZGQzNi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IxZTk1
+        OTE0LWNlNWYtNDM0OC1iYWMyLTYxYzUyMDk4OWIyNS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:40 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd98fcf2185f4ec680da21eb91a5d0b1
+      - 3f23d9e850c74e5292f3c0e30b748da2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiODA2ZGRkLTc4OGQtNGFk
-        NS05Y2I1LWZjMGMwMGFiZTJmMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiZmQ2NzVhLTBjYzMtNDQ5
+        ZS04ZGNjLWU0NTJkOTliYTQxMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c62ff0b12cc415faaf029e8e5585220
+      - 8c8cdff7fa3443e9836921d2e0618efc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b806ddd-788d-4ad5-9cb5-fc0c00abe2f3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fbfd675a-0cc3-449e-8dcc-e452d99ba411/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 76eeb016ed624b9c91cea7aec271fb62
+      - '086566113ece4d99b9af42664418581f'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmI4MDZkZGQtNzg4
-        ZC00YWQ1LTljYjUtZmMwYzAwYWJlMmYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MTIuMjg1MDk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmJmZDY3NWEtMGNj
+        My00NDllLThkY2MtZTQ1MmQ5OWJhNDExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDAuNjI2ODQ3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZDk4ZmNmMjE4NWY0ZWM2ODBkYTIxZWI5
-        MWE1ZDBiMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjEyLjMx
-        OTQ2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MTIuNTM3
-        NDc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzZjIzZDllODUwYzc0ZTUyOTJmM2MwZTMw
+        Yjc0OGRhMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjQwLjY2
+        OTI4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NDAuODY5
+        MzQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWYwZWEwZDYtY2FiZS00NWQw
-        LWEyNjUtODBmN2ZmNzJkZDM2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjFlOTU5MTQtY2U1Zi00MzQ4
+        LWJhYzItNjFjNTIwOTg5YjI1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2021035e684840e3a4b88f37f20423a7
+      - f3b53eb873334c1b9e908625f6d0b201
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e465225734504d2086cba63674bbeb92
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMzkzNzJkN2MtZDQ3My00N2RkLTlmMmMtOTBmMTQ1NDhmMzZk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MzMuODk2MDYy
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/39372d7c-d473-47dd-9f2c-90f14548f36d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e54521fe93634d06b94236391ba1da3f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3MTM1YTBjLTJiODEtNGI0
+        NS1iYjk4LWJkMzRhODg4N2RjZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/47135a0c-2b81-4b45-bb98-bd34a8887dce/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 671c7c72d1db42ad96c5495dc3a14679
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDcxMzVhMGMtMmI4
+        MS00YjQ1LWJiOTgtYmQzNGE4ODg3ZGNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDEuMDQwNjA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNTQ1MjFmZTkzNjM0ZDA2Yjk0MjM2Mzkx
+        YmExZGEzZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjQxLjA3
+        ODgzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NDEuMTE0
+        NTU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 32ee1c5f22ee4db290cb2afb1f005a34
+      - b92ed767382f4acbaddf8b911e954689
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66f04dcd83df4540864778afea2fb147
+      - f42d7ce0f2a54a8b8876a869990899e0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d3b994c0f0b4ad9b3e6a5bf199b3d6d
+      - 731f3d5d9c204f1790f58321c0d2ec24
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:12 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 004bf50ba2154a2182d589249370501f
+      - b1882fed1ea94e17baab2471638cb5d8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:28:12 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - be6ad790ded9406bbee8f665c96f046e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/a835c9ef-e0d0-4bba-bcd9-be6621285ab9/"
+      - "/pulp/api/v3/remotes/rpm/rpm/9b2e25d2-5ab5-4217-b855-411517c1b328/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a99bb85dc774ad58cb22b91e7189cfa
+      - 9e04f350bbfc41759790aaad4f6a9548
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E4
-        MzVjOWVmLWUwZDAtNGJiYS1iY2Q5LWJlNjYyMTI4NWFiOS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjEzLjA2MjY5OVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzli
+        MmUyNWQyLTVhYjUtNDIxNy1iODU1LTQxMTUxN2MxYjMyOC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjQxLjQwNzA1NloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI4OjEzLjA2MjcyMFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjM0OjQxLjQwNzA3OVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/"
+      - "/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a337dfad7ef4e92bd08c0556b685134
+      - 5ade2f2860504d84a836353b4500108e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTg4ZjZjMzUtNzEzZC00YWFiLWJjNDYtNTNmYTZkM2Q4ZDhiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MTMuMTc5ODkzWiIsInZl
+        cG0vYjJiNTMzMDAtOWNjOC00YWVlLWI3MjQtMDA3NzlhMTYyYTg2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NDEuNTQ4NzQ1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTg4ZjZjMzUtNzEzZC00YWFiLWJjNDYtNTNmYTZkM2Q4ZDhiL3ZlcnNp
+        cG0vYjJiNTMzMDAtOWNjOC00YWVlLWI3MjQtMDA3NzlhMTYyYTg2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ODhmNmMzNS03
-        MTNkLTRhYWItYmM0Ni01M2ZhNmQzZDhkOGIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMmI1MzMwMC05
+        Y2M4LTRhZWUtYjcyNC0wMDc3OWExNjJhODYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e7e9e0564cc841a98b48eb9ee5ec8a78
+      - 842bf8f0531a4b8db22385e794c04628
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82ZThmMjBiOS04ZTIxLTRlMzktYTBiZC02MmM0ZGRhODliNDkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyODowNi4wMzQ3MzRa
+        cnBtL3JwbS9iYTNlZTExZC1lY2Y5LTQ5YTAtYjViYS1jZmQxNGNmNTg3ZjQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDozMC4yMTk3NjRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82ZThmMjBiOS04ZTIxLTRlMzktYTBiZC02MmM0ZGRhODliNDkv
+        cnBtL3JwbS9iYTNlZTExZC1lY2Y5LTQ5YTAtYjViYS1jZmQxNGNmNTg3ZjQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZlOGYy
-        MGI5LThlMjEtNGUzOS1hMGJkLTYyYzRkZGE4OWI0OS92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JhM2Vl
+        MTFkLWVjZjktNDlhMC1iNWJhLWNmZDE0Y2Y1ODdmNC92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49502cce581f4c50892f2b1b61f93ffe
+      - b5696f2408ab49fdb854b0598aeb4ac8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1ZGFmMzdiLTUzMTItNDVm
-        NS05Y2I2LTkzNWYzMzJmMjljYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUyZmQ4N2ZkLWRlNjctNDIw
+        My04ZTljLTQ1YTRkMTQwNDc1MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3be924d54b28447492d75fcb61ae2ba1
+      - a61f8cae707a47148adf364a9c137775
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNzQzM2Y3NDItMjc2Ny00NGIzLTg2MWItODcyYjA5ODRjZGQ0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MDUuMjEyOTQ1WiIsIm5h
+        cG0vNzgwM2I4MWYtNzNkOC00OTcxLWE1YmYtNjQ0MWYyMmU5ZWYzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MjkuMTA3NzE4WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyODowNi4zNjIwNjlaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozNDozMC42NTAwMTVaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/7433f742-2767-44b3-861b-872b0984cdd4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/7803b81f-73d8-4971-a5bf-6441f22e9ef3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 378d268cd47942c8acc7962eceec0ff2
+      - 69bae3f39679472c82dc16895682aa33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiODFmMmViLWJmYWEtNDQz
-        Mi05Y2IxLTVlYjIzZTFjYzg0ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlMGY1NTYxLTczNTAtNDI1
+        MS05ODk0LTM4NjViMDczYzYxMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/95daf37b-5312-45f5-9cb6-935f332f29cb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/52fd87fd-de67-4203-8e9c-45a4d1404751/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5827efab35504a7f82ff3eaa11db2781
+      - 0264cea8291249a6a2bb621c6bad130b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTVkYWYzN2ItNTMx
-        Mi00NWY1LTljYjYtOTM1ZjMzMmYyOWNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MTMuMzcwMDQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTJmZDg3ZmQtZGU2
+        Ny00MjAzLThlOWMtNDVhNGQxNDA0NzUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDEuNzcwMzk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0OTUwMmNjZTU4MWY0YzUwODkyZjJiMWI2
-        MWY5M2ZmZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjEzLjQw
-        MTI0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MTMuNDY4
-        NzUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiNTY5NmYyNDA4YWI0OWZkYjg1NGIwNTk4
+        YWViNGFjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjQxLjgx
+        MTI5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NDEuOTA0
+        MDQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUyMS00ZTM5
-        LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNmOS00OWEw
+        LWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2b81f2eb-bfaa-4432-9cb1-5eb23e1cc84d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8e0f5561-7350-4251-9894-3865b073c611/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c2fc42db7404d61a710a198c973c70c
+      - f7ee02b6f6ba44499cef57c5efe568e2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI4MWYyZWItYmZh
-        YS00NDMyLTljYjEtNWViMjNlMWNjODRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MTMuNDcwOTUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGUwZjU1NjEtNzM1
+        MC00MjUxLTk4OTQtMzg2NWIwNzNjNjExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDEuOTAxMzYzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNzhkMjY4Y2Q0Nzk0MmM4YWNjNzk2MmVj
-        ZWVjMGZmMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjEzLjUw
-        MTcwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MTMuNTQ0
-        NTQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2OWJhZTNmMzk2Nzk0NzJjODJkYzE2ODk1
+        NjgyYWEzMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjQxLjk0
+        MDA5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NDIuMDAw
+        NTg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc0MzNmNzQyLTI3NjctNDRiMy04NjFi
-        LTg3MmIwOTg0Y2RkNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc4MDNiODFmLTczZDgtNDk3MS1hNWJm
+        LTY0NDFmMjJlOWVmMy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ee1ba3f9ce9442e693f343432e4aa582
+      - 8bb8bba40494434d98463d0b2dca2a20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c97fbac4f9684c189a37960a3458dd34
+      - ae810c859e8840c3b0cf4f9c2c4242c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 93f9f6db7b7b44869e46e15715cca176
+      - dec3a1aa269b4567ac2784388e137a0d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 16ac3f985074472a97d20bc015cf07ef
+      - 8745cb647ff5404e8c528f803246b5c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49aa4c4d8df045d98d4739d6d1246340
+      - 322a126ed2f04c7ba60395907f8774dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5026ac56d3e144b49663c1ad9c0de451
+      - 101d54bca2744b91a12af216fce655db
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:13 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/"
+      - "/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b7f0124c30c34e56939de3c4e5415b2b
+      - afca2e1689df4cc4835f8b3c049e0246
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTZlNGQ0MTktNDcxNi00ZTM5LWFkNzEtMmFhNTNkZWY3ZGU4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MTMuOTMzNDI0WiIsInZl
+        cG0vZWI3MDU2NDYtMjA1Mi00MWU5LWI2ZDEtYzg2NmQxZjhiZGUyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NDIuNDUzODczWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTZlNGQ0MTktNDcxNi00ZTM5LWFkNzEtMmFhNTNkZWY3ZGU4L3ZlcnNp
+        cG0vZWI3MDU2NDYtMjA1Mi00MWU5LWI2ZDEtYzg2NmQxZjhiZGUyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85NmU0ZDQxOS00
-        NzE2LTRlMzktYWQ3MS0yYWE1M2RlZjdkZTgvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lYjcwNTY0Ni0y
+        MDUyLTQxZTktYjZkMS1jODY2ZDFmOGJkZTIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a835c9ef-e0d0-4bba-bcd9-be6621285ab9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/9b2e25d2-5ab5-4217-b855-411517c1b328/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:14 GMT
+      - Fri, 29 Jul 2022 11:34:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2550b34e0a72418bbdaa4a94ad76caa9
+      - cd67d29320c04bb1bf523106accf80b2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiYjVmNWVjLTg0YmUtNGJk
-        My04Y2JkLWNiM2VjYjNlZmI3YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyM2I0NGFmLTViNjItNDg5
+        Yy1iYmQzLTE5Y2ZmMTc4NjU5OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6bb5f5ec-84be-4bd3-8cbd-cb3ecb3efb7a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/923b44af-5b62-489c-bbd3-19cff1786598/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:14 GMT
+      - Fri, 29 Jul 2022 11:34:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c9988233d3d415685b5e3cf1f1074b9
+      - 41c10d1a278f48e1ad739e0a8c25ae38
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmJiNWY1ZWMtODRi
-        ZS00YmQzLThjYmQtY2IzZWNiM2VmYjdhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MTQuMjAxMjk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTIzYjQ0YWYtNWI2
+        Mi00ODljLWJiZDMtMTljZmYxNzg2NTk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDIuODQ2MTA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIyNTUwYjM0ZTBhNzI0MThiYmRhYTRhOTRh
-        ZDc2Y2FhOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjE0LjIz
-        MTU0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MTQuMjU3
-        MjMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJjZDY3ZDI5MzIwYzA0YmIxYmY1MjMxMDZh
+        Y2NmODBiMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjQyLjky
+        MTk4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NDIuOTQ5
+        NzQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E4MzVjOWVmLWUwZDAtNGJiYS1iY2Q5
-        LWJlNjYyMTI4NWFiOS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzliMmUyNWQyLTVhYjUtNDIxNy1iODU1
+        LTQxMTUxN2MxYjMyOC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:43 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E4MzVj
-        OWVmLWUwZDAtNGJiYS1iY2Q5LWJlNjYyMTI4NWFiOS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzliMmUy
+        NWQyLTVhYjUtNDIxNy1iODU1LTQxMTUxN2MxYjMyOC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:14 GMT
+      - Fri, 29 Jul 2022 11:34:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 12bf7e12d1f1487e8f63b4affbf661ba
+      - 467a90da4c284632b93f49470d10c094
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1M2U2ZDgxLWNjNTgtNDE5
-        Mi05NzQwLTdiYjA5ZGE0YjE1ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlNGE2YWYwLWMwMjAtNGUy
+        OC04MTgyLTNlN2QzOGQ0MGRiMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/653e6d81-cc58-4192-9740-7bb09da4b15e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ce4a6af0-c020-4e28-8182-3e7d38d40db1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:15 GMT
+      - Fri, 29 Jul 2022 11:34:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6bcb59d999a1465dab4da69646b9aac2
+      - 47a8c8d7d1434a6cb25a5026861743a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjUzZTZkODEtY2M1
-        OC00MTkyLTk3NDAtN2JiMDlkYTRiMTVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MTQuMzc0NjkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2U0YTZhZjAtYzAy
+        MC00ZTI4LTgxODItM2U3ZDM4ZDQwZGIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDMuMTI4MTExWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxMmJmN2UxMmQxZjE0ODdlOGY2
-        M2I0YWZmYmY2NjFiYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjE0LjQxMTgwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MTUuMTgyNzQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI0NjdhOTBkYTRjMjg0NjMyYjkz
+        ZjQ5NDcwZDEwYzA5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjQzLjE5MDY0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NDQuMzMyOTAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzU4OGY2YzM1LTcxM2QtNGFhYi1iYzQ2LTUzZmE2
-        ZDNkOGQ4Yi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ODhm
-        NmMzNS03MTNkLTRhYWItYmM0Ni01M2ZhNmQzZDhkOGIvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYTgzNWM5ZWYtZTBkMC00YmJh
-        LWJjZDktYmU2NjIxMjg1YWI5LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9iMmI1MzMwMC05Y2M4LTRhZWUtYjcyNC0wMDc3OWEx
+        NjJhODYvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjJiNTMz
+        MDAtOWNjOC00YWVlLWI3MjQtMDA3NzlhMTYyYTg2LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzliMmUyNWQyLTVhYjUtNDIxNy1i
+        ODU1LTQxMTUxN2MxYjMyOC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:44 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNTg4ZjZjMzUtNzEzZC00YWFiLWJjNDYtNTNmYTZkM2Q4
-        ZDhiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYjJiNTMzMDAtOWNjOC00YWVlLWI3MjQtMDA3NzlhMTYy
+        YTg2L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:15 GMT
+      - Fri, 29 Jul 2022 11:34:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bafc7d0e6fdf46d7a951967eb2a187c4
+      - 9104e9ff22cf40b9b0f429829eb80ef5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiNDg0OTk2LTBiNWQtNDFk
-        ZC1iOGZiLWJkOWRkMDFlNDAyMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyZTg5NDlmLTQyZGMtNDIz
+        Zi05NjBkLTIzOTdjMjg2MmM0OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b484996-0b5d-41dd-b8fb-bd9dd01e4020/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/32e8949f-42dc-423f-960d-2397c2862c48/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:15 GMT
+      - Fri, 29 Jul 2022 11:34:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a17b58a8bc6b43669b026401dca194d2
+      - 17afb3265e3548208ffdfc7c24347334
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmI0ODQ5OTYtMGI1
-        ZC00MWRkLWI4ZmItYmQ5ZGQwMWU0MDIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MTUuNDQ0MDA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzJlODk0OWYtNDJk
+        Yy00MjNmLTk2MGQtMjM5N2MyODYyYzQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDQuNzgwMzMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImJhZmM3ZDBlNmZkZjQ2ZDdhOTUxOTY3ZWIy
-        YTE4N2M0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MTUuNDcz
-        MTI4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODoxNS44MjIw
-        NTZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjkxMDRlOWZmMjJjZjQwYjliMGY0Mjk4Mjll
+        YjgwZWY1Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NDQuODI1
+        ODg2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDo0NS4yNjIw
+        MTRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZjlhNmYy
-        ZGQtZmU0MC00MWEwLTk4NzUtMmU4MmJlMTU2NWYyLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzdhN2Zk
+        ZDAtMjU4Yy00MTM0LWJmZmEtMWQyNmUyNzliYTY4LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNTg4ZjZjMzUtNzEzZC00YWFiLWJjNDYtNTNmYTZk
-        M2Q4ZDhiLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYjJiNTMzMDAtOWNjOC00YWVlLWI3MjQtMDA3Nzlh
+        MTYyYTg2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7582a440de9840c790937694095dd064
+      - ad3298abfb4e49a196d4b41d1d311bee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/c7a7fdd0-258c-4134-bffa-1d26e279ba68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9d1336708d0e4acab85be89246099f85
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYzdhN2ZkZDAtMjU4Yy00MTM0LWJmZmEtMWQyNmUyNzliYTY4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NDQuODU1NTA1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9iMmI1MzMwMC05Y2M4LTRhZWUtYjcyNC0wMDc3OWExNjJhODYv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2IyYjUzMzAwLTljYzgtNGFlZS1iNzI0LTAwNzc5
+        YTE2MmE4Ni8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:45 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9jN2E3ZmRkMC0yNThjLTQxMzQtYmZmYS0xZDI2ZTI3OWJhNjgv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ae64232f386c43008375dc633e76e3ae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4NjJmZjNhLWE3YWEtNGMw
+        Mi04OTZlLTcxNmY5MzY0ODhlZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f862ff3a-a7aa-4c02-896e-716f936488ef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4bef3b70a86b4e2682efbb78e575e274
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjg2MmZmM2EtYTdh
+        YS00YzAyLTg5NmUtNzE2ZjkzNjQ4OGVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDUuNTMzNzc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhZTY0MjMyZjM4NmM0MzAwODM3NWRjNjMz
+        ZTc2ZTNhZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjQ1LjU4
+        MzY4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NDUuNzk2
+        NzU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vOThi
+        NDY5OTctZDQ3Ny00OGQyLTk5NzUtNDk5MjcxOTYxNTJjLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/98b46997-d477-48d2-9975-49927196152c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 07c7b813ce9644b4a2f4956ccf508f50
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzk4YjQ2OTk3LWQ0NzctNDhkMi05OTc1LTQ5OTI3MTk2MTUyYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjQ1Ljc3NzM1MloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYzdhN2ZkZDAtMjU4Yy00MTM0LWJmZmEt
+        MWQyNmUyNzliYTY4LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1cd8b351f5b14777a5afb854034e42de
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b04cf1f71d9454f99a7ed0d2e0d55ae
+      - ad14795de50141b6a0c5828868c50439
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1cec2e1d42954383afb6edd741be6f51
+      - 7c4d3ee000334c1c9c2e27fe2ccf886a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 319fdbe3ef664742bc74f7ec7be622f0
+      - c2e238141b0a4989aca60f0759e799e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '093db101510140eb8e2170b02e86ff86'
+      - a69f501653fa40149ce6fd49cec293d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83582d7c2ea14c449ab75d47d6d88cd2
+      - 31fa9fea936c4eae8daa35fc1b7876dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a89ca967acec43e9960f01006fb1e53f
+      - c8e7643cc9944915b86620ef84dac175
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 76c2fc32df2f47339b6bee9351f8f26a
+      - 4c64a10cec604ff8a341896e40b8b7ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c61b7091588444e82b9143ee4be9613
+      - 5840bb045f794ae9a7712694294b8a93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c517afbded8248a5b00025bb8ba4ecf8
+      - 8dedcff14bb2470fb1bf8cbb39b02e2b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c63ac60fca2b4e4c8fd6bb7da72a0019
+      - 498b4594915b47a293fb9f97fe3864ed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:16 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c4a4fec668f46b3bf0138cf6296a70d
+      - 21f78ec897b4424fa677fffa719e0e9b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:17 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ab8483a2f974a53aa1a1f4cbe98a9e2
+      - 8d758b021077402a82db8cdf3415ea71
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,123 +3738,123 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:17 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 515dd43ec8c64554b1ccc8adbdfb866e
+      - c28afc78351040e5872b0d2b879c075a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTg4ZjZjMzUtNzEzZC00YWFiLWJj
-        NDYtNTNmYTZkM2Q4ZDhiL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk2ZTRkNDE5LTQ3MTYt
-        NGUzOS1hZDcxLTJhYTUzZGVmN2RlOC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        Mjk2ZTUwNTQtODIyNS00MzNjLWEzY2QtNjQxYzEwMDk1MTEzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM4NTMwYWU2LTRiYzYt
-        NDE2Zi1iYmVlLTk2MTA2YTRjZjk1MC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQtZDcxNTNhZDc4NDIyLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQy
-        M2QtNDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1
-        ZC1iODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRk
-        NGFhYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRl
-        NTYxMGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhk
-        YS04Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNl
-        YzY5Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5
-        YTY1ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3
-        MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJj
-        ODZhZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
-        cm91cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01
-        YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3Yi1iY2MzLTQ2
-        MzNhMmM3OTkwZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNGI5ZTFkMS1mYWUy
-        LTQ0NWQtYTg3Ny05Mzk5ZjhlNjVjMGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzI5ZTZhMjFkLTJmNjktNGNkMi1iNzExLTYxY2M4
-        OWNmNzBjZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MzdjMzgwYTAtYWFmZi00M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQy
-        YzAtODhmMy0xNTI4OTBlZmE3ZWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzQ5NDNkMTlkLWM1NTItNDVkMi04NTYwLWM3MGFmOTEz
-        N2NjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNTBj
-        ODJlOWQtYWY4OS00MzEzLWJmZWQtZDRjNGE2YzgwZjllLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NjQ2NWZmYS05NTFlLTRlZDUt
-        YjNjMy1hODA2ZWVkZmM4NWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzc2MDhjZTM3LTFjNzEtNGFkMC05MGFjLWVlZDc0NjBjNTYx
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2EzYzU3
-        OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJkNDg4LyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5
-        YS1mMGFjOTY2MjVkZmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzhmNGMwNDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4Zi8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1MjI4ODAt
-        OGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0
-        NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJkLTQ3MGMtYTI2MC1iZWJh
-        NjIwMDM0OWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2ZjMmFlODJlLWI3YTEtNGQ2Zi1iNjNkLWNlNzFlZmU1NmM1YS8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9mNDdh
-        M2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19XSwiZGVwZW5k
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjJiNTMzMDAtOWNjOC00YWVlLWI3
+        MjQtMDA3NzlhMTYyYTg2L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ViNzA1NjQ2LTIwNTIt
+        NDFlOS1iNmQxLWM4NjZkMWY4YmRlMi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYy
+        YWItNGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQy
+        OTI5My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1
+        ZWE3ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBl
+        NS1hZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFk
+        MTkxOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYy
+        NTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgx
+        NS04OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJm
+        MjFjYmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
+        cm91cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0y
+        OTFhLTQzMzYtYWRiZC1kODliN2IwMWQ4NDYvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0YzgtNDU5Mi04Mzg0LWIy
+        NzZmZmE3ZTgyNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzViYmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0
+        NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0OTU0ZWVkLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81YTMyODQyNi0yYmFmLTQx
+        ODktOWNjNS02ZDhkYzM1YzEwZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQtNGU0Ni04ZmMzLTFiZmY3OTlm
+        YjYxZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjVm
+        YmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NmQwMjRjMi0xMGZjLTQwMWMt
+        YWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEy
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVm
+        MmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUtOTM2
+        Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMt
+        NTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0y
+        MmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkxLTM2ZWM4ZmMzNTA0OC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVh
+        Mi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2ZkYjk1N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJm
+        NTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19XSwiZGVwZW5k
         ZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3442,7 +3867,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:17 GMT
+      - Fri, 29 Jul 2022 11:34:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3460,21 +3885,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e8e88f357ee54db480cf9b73d3491b5f
+      - 22adb027b6344d1e80a48522b8ba2618
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmY2IwNjAwLWM2YzUtNDBm
-        Mi1iZmI0LTlhMjc0N2Q4NTg3ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5Yzg0MTRiLTM2MTktNDkx
+        ZC04NjdjLWQ1ZGRmZTcxNmU2OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5fcb0600-c6c5-40f2-bfb4-9a2747d8587e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/99c8414b-3619-491d-867c-d5ddfe716e68/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3495,55 +3920,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:17 GMT
+      - Fri, 29 Jul 2022 11:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9545b8e493994a76b1c1f5e5cac20530
+      - 9bf5005e00c14b1f92ef43b1101d703e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '415'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWZjYjA2MDAtYzZj
-        NS00MGYyLWJmYjQtOWEyNzQ3ZDg1ODdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MTcuMTY4MDA4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTljODQxNGItMzYx
+        OS00OTFkLTg2N2MtZDVkZGZlNzE2ZTY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NDcuNzM0OTk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiZThlODhmMzU3ZWU1NGRiNDgwY2Y5YjczZDM0
-        OTFiNWYiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODoxNy4xOTk0
-        MDlaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjE3LjY1OTYx
+        dCIsImxvZ2dpbmdfY2lkIjoiMjJhZGIwMjdiNjM0NGQxZTgwYTQ4NTIyYjhi
+        YTI2MTgiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDo0Ny43ODk4
+        NjFaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjQ4LjUwOTUy
         OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTZlNGQ0
-        MTktNDcxNi00ZTM5LWFkNzEtMmFhNTNkZWY3ZGU4L3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWI3MDU2
+        NDYtMjA1Mi00MWU5LWI2ZDEtYzg2NmQxZjhiZGUyL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzk2ZTRkNDE5LTQ3MTYtNGUzOS1hZDcxLTJh
-        YTUzZGVmN2RlOC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzU4OGY2YzM1LTcxM2QtNGFhYi1iYzQ2LTUzZmE2ZDNkOGQ4
-        Yi8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2ViNzA1NjQ2LTIwNTItNDFlOS1iNmQxLWM4
+        NjZkMWY4YmRlMi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2IyYjUzMzAwLTljYzgtNGFlZS1iNzI0LTAwNzc5YTE2MmE4
+        Ni8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3551,7 +3976,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3564,76 +3989,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:17 GMT
+      - Fri, 29 Jul 2022 11:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f9a669ae36f4091b84d4ebbd75c99ac
+      - 9594b6edefa245c889a96a8e732a78f5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '566'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
-        NTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2Ji
-        Mzg0ODctOTY3Ny00YTQzLTgzZTMtNDM5MGIzZDIwNWI0LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhiMjUx
-        NzM4LTZhNDgtNDNjYi1iNzlhLWYwYWM5NjYyNWRmZi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQt
-        MmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThj
-        NWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZm
-        LTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00
-        NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTViNzEtNDE1
-        NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkw
-        YWMtZWVkNzQ2MGM1NjFiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YwNzc5MmMzLWE0MmQtNDcwYy1hMjYw
-        LWJlYmE2MjAwMzQ5Zi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00YjY2LWFlYWQtZmY4
-        NTBiOTI2ZTVjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3641,7 +4066,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3654,50 +4079,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:17 GMT
+      - Fri, 29 Jul 2022 11:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 35feb1793fbb4849af49a3acc05d587b
+      - 2a79d0d7d497483a95bc8a251e8bbc82
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3705,7 +4130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3718,37 +4143,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:18 GMT
+      - Fri, 29 Jul 2022 11:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 36cae249f3954f1180af7b7e281894a4
+      - fd7ffefdcd514c7d93e25ae06e2521cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3821,9 +4246,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3839,8 +4264,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -3858,9 +4283,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -3882,9 +4307,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -3900,9 +4325,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -3911,9 +4336,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -3942,10 +4367,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3953,7 +4378,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3966,43 +4391,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:18 GMT
+      - Fri, 29 Jul 2022 11:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86b7ac204a554dbf8b3bed9a33566885
+      - d8518d95755e4abe9f7da53af4415332
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4010,7 +4435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4023,41 +4448,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:18 GMT
+      - Fri, 29 Jul 2022 11:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 678a0d7a40574a0fb00800c654339266
+      - 7ea2d004fa8d4b8fa43de5ab68f6f67f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4065,7 +4490,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4078,36 +4503,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:18 GMT
+      - Fri, 29 Jul 2022 11:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - de9042a50e064620a80566690d22522c
+      - 14de0e4da94d49039927827dc5b883a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4129,10 +4554,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4140,7 +4565,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4153,37 +4578,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:18 GMT
+      - Fri, 29 Jul 2022 11:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae404fc6608c45809f6f835c77712f33
+      - 5766fb07672b468f93067828272eb79d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4256,9 +4681,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -4274,8 +4699,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -4293,9 +4718,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -4317,9 +4742,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -4335,9 +4760,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -4346,9 +4771,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -4377,5 +4802,5 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:49 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_errata_repository/errata_copied_if_all_errata_packages_matches_included_packages.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_errata_repository/errata_copied_if_all_errata_packages_matches_included_packages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21011604858b4fd4a628570f8d7d71a3
+      - c60e009cf0924ead89153797c73dd581
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iZTNmMzY0OS0yNTBkLTRkYmUtYTA3Ny1iZmZiZTU1MmJhYjAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNzozNC43ODcwNTNa
+        cnBtL3JwbS82NWE2NDNiZS04NzFkLTQ1MzAtYWM0Ni0yYzk3MjQ3ZjQyZmUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDoxNi4yMTg5MjRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iZTNmMzY0OS0yNTBkLTRkYmUtYTA3Ny1iZmZiZTU1MmJhYjAv
+        cnBtL3JwbS82NWE2NDNiZS04NzFkLTQ1MzAtYWM0Ni0yYzk3MjQ3ZjQyZmUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JlM2Yz
-        NjQ5LTI1MGQtNGRiZS1hMDc3LWJmZmJlNTUyYmFiMC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY1YTY0
+        M2JlLTg3MWQtNDUzMC1hYzQ2LTJjOTcyNDdmNDJmZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/be3f3649-250d-4dbe-a077-bffbe552bab0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f0d0a6f7f404670a58f4bd8bc02cc82
+      - c5ef1d64504a4219a89aa26fd950ee8f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzMGE4YzkxLTExNWItNGI1
-        OC1hNzNlLThjZjBhMTNjZGJiMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5YWI1ZTM5LWM4NGYtNDY2
+        YS1iMTAxLTUyYWU4NmIwYzRlMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e389094c440a45189480169e75b74c36
+      - fb366c58be834e3f982c15c8f8e85266
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c30a8c91-115b-4b58-a73e-8cf0a13cdbb1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/69ab5e39-c84f-466a-b101-52ae86b0c4e3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf17deb0554d47f5a72e7ea5b28344af
+      - a98d3b57d5f843fb8f4f935a39a15154
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzMwYThjOTEtMTE1
-        Yi00YjU4LWE3M2UtOGNmMGExM2NkYmIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6NTcuMTIwODU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjlhYjVlMzktYzg0
+        Zi00NjZhLWIxMDEtNTJhZTg2YjBjNGUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjguMTQ3NTcwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1ZjBkMGE2ZjdmNDA0NjcwYTU4ZjRiZDhi
-        YzAyY2M4MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjU3LjE1
-        MjQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6NTcuMjgx
-        NjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjNWVmMWQ2NDUwNGE0MjE5YTg5YWEyNmZk
+        OTUwZWU4ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjI4LjE4
+        ODM1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MjguNDI3
+        MTk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmUzZjM2NDktMjUwZC00ZGJl
-        LWEwNzctYmZmYmU1NTJiYWIwLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjVhNjQzYmUtODcxZC00NTMw
+        LWFjNDYtMmM5NzI0N2Y0MmZlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e567201ee5e4749bb0e6c5f4912d4d1
+      - 87c6ba5b1af6452a9233ec58f2a7eb48
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d0c8f1e1b1174ed091e1169125670a62
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNzFkN2MwMDgtZjEwYy00NGZhLTlmOGItODlkZTczZWI2M2Qy
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MjEuMjIzMTc2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/71d7c008-f10c-44fa-9f8b-89de73eb63d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 737ffb7ae03d469092fe14c9b39adc96
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiMTQ2YTNhLWE3MWUtNGY3
+        Zi1iZWNjLTY5NDM5MDAzMTUyYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ab146a3a-a71e-4f7f-becc-69439003152b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6a7ef7cba64941629ab7a515efc1793f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWIxNDZhM2EtYTcx
+        ZS00ZjdmLWJlY2MtNjk0MzkwMDMxNTJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjguNTk1ODMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MzdmZmI3YWUwM2Q0NjkwOTJmZTE0Yzli
+        MzlhZGM5NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjI4LjYz
+        ODUxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MjguNjc5
+        ODE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 48623ab1693f4db1acab416ea46f933c
+      - dfd9f9a8dcdb43859f01f3888fd4a432
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39c45d9298a04715ade6fc5ead85fbf9
+      - 4a06fc735c0c40f596c8d3d8fc7f8851
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '098f4378e3574203b7e4b03c24193104'
+      - 3abedf35dbc64b6c972f76ab66f07a10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e64cd631753f4a4e9bb21ecb083f4774
+      - b50a1eb627324c47a5c1908bd5722844
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:57 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - eb38cde66ce14921beab79df10940f44
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/a6b0c813-82ae-433b-8839-65b6907faa93/"
+      - "/pulp/api/v3/remotes/rpm/rpm/7803b81f-73d8-4971-a5bf-6441f22e9ef3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - afc6f68a8efa438ebab45a52b87609fc
+      - b1de5aeacb5a4b038ecfe1b58c145063
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E2
-        YjBjODEzLTgyYWUtNDMzYi04ODM5LTY1YjY5MDdmYWE5My8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI3OjU3LjY1NDQ3N1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc4
+        MDNiODFmLTczZDgtNDk3MS1hNWJmLTY0NDFmMjJlOWVmMy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjI5LjEwNzcxOFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI3OjU3LjY1NDQ5NloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjM0OjI5LjEwNzc0M1oiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/"
+      - "/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9ccc0ec20a664d64bdbf5cdd32541ce6
+      - 9f8f3e3788ab4e1481c924dcfdea4ac2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjA5NDJkMDYtM2UzYi00NTdlLTg3OGItYmZmNjMzMDFlZjM3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6NTcuODEyMzgzWiIsInZl
+        cG0vYjFlOTU5MTQtY2U1Zi00MzQ4LWJhYzItNjFjNTIwOTg5YjI1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MjkuMjQ3MDkzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjA5NDJkMDYtM2UzYi00NTdlLTg3OGItYmZmNjMzMDFlZjM3L3ZlcnNp
+        cG0vYjFlOTU5MTQtY2U1Zi00MzQ4LWJhYzItNjFjNTIwOTg5YjI1L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMDk0MmQwNi0z
-        ZTNiLTQ1N2UtODc4Yi1iZmY2MzMwMWVmMzcvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMWU5NTkxNC1j
+        ZTVmLTQzNDgtYmFjMi02MWM1MjA5ODliMjUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fe0b9b19f62b4347a36772e64b67b0e5
+      - b9b3cb6364e64480bddc7302798847ed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iNjcyYTZjZS1jYmRmLTQ3OTEtYTI5ZC0zMzI2Yzg4NGJjODYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNzozNS42MDgwMzZa
+        cnBtL3JwbS83MWIzMjQ0Ni03Y2QxLTQxZTAtYjUwZS1hNWIyNDNmZmUwZGUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDoxNy4zOTU3ODVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iNjcyYTZjZS1jYmRmLTQ3OTEtYTI5ZC0zMzI2Yzg4NGJjODYv
+        cnBtL3JwbS83MWIzMjQ0Ni03Y2QxLTQxZTAtYjUwZS1hNWIyNDNmZmUwZGUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I2NzJh
-        NmNlLWNiZGYtNDc5MS1hMjlkLTMzMjZjODg0YmM4Ni92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcxYjMy
+        NDQ2LTdjZDEtNDFlMC1iNTBlLWE1YjI0M2ZmZTBkZS92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b672a6ce-cbdf-4791-a29d-3326c884bc86/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:57 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 902ecad0705449e49f69eecad1034fb1
+      - 1571cbcc3e174f408cb03522f727180b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjY2Q5OWU4LTY2MzMtNGY2
-        Ni05M2U5LThiZWE3YzgwYzEyNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4MTdlN2IwLTU3OGMtNDE2
+        NS04MTMxLWY5NDU1OWE3OGUwOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 669d8861bccc44c6befce2efdf16f960
+      - 78e79c70eeec4c5ea1cdf515c8c206c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZDc4NWNjOTctYzlmYy00NDZkLTgyMmItNzgwMWU4NDcyNDEzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MzQuNTk1MzY2WiIsIm5h
+        cG0vZDQwODA4ZWMtY2I3NS00MmNhLTg2MTEtMDk0MjE3MjRjODUzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MTYuMDUzNDg4WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyNzozNS45NjI5OTRaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozNDoxNy44NjU5NzNaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/d785cc97-c9fc-446d-822b-7801e8472413/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/d40808ec-cb75-42ca-8611-09421724c853/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b2d23816ade54b77b5a510a2150d7ed2
+      - 35a1c5147200400082ce622f34406f28
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjYjEyNjY0LTdlOGItNGRl
-        ZS1hNzdmLTYxMzhmZjQyODkwMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzOGJjMzkyLWYzMmItNGVi
+        OS1hY2M1LTA0MzY0OGMyZjg4Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fccd99e8-6633-4f66-93e9-8bea7c80c124/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b817e7b0-578c-4165-8131-f94559a78e08/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ba7a0b5f2a1b42d9b6ffdc663d7ce880
+      - 0371072f11da460e9f7df59765db794f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmNjZDk5ZTgtNjYz
-        My00ZjY2LTkzZTktOGJlYTdjODBjMTI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6NTcuOTc3MzI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjgxN2U3YjAtNTc4
+        Yy00MTY1LTgxMzEtZjk0NTU5YTc4ZTA4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjkuNDkwNDI3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5MDJlY2FkMDcwNTQ0OWU0OWY2OWVlY2Fk
-        MTAzNGZiMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjU4LjAw
-        ODU0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6NTguMDcy
-        ODYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxNTcxY2JjYzNlMTc0ZjQwOGNiMDM1MjJm
+        NzI3MTgwYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjI5LjUz
+        NjA5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MjkuNjMz
+        NDIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjY3MmE2Y2UtY2JkZi00Nzkx
-        LWEyOWQtMzMyNmM4ODRiYzg2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2NkMS00MWUw
+        LWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8cb12664-7e8b-4dee-a77f-6138ff428902/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d38bc392-f32b-4eb9-acc5-043648c2f88b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 65c6a1f227c9440eb0ccc1407147d6f8
+      - 666a990b8c004def85cdb0ca40a71a09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGNiMTI2NjQtN2U4
-        Yi00ZGVlLWE3N2YtNjEzOGZmNDI4OTAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6NTguMDY3OTMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDM4YmMzOTItZjMy
+        Yi00ZWI5LWFjYzUtMDQzNjQ4YzJmODhiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjkuNjE1NzUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiMmQyMzgxNmFkZTU0Yjc3YjVhNTEwYTIx
-        NTBkN2VkMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjU4LjEw
-        MjMxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6NTguMTUy
-        NjM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNWExYzUxNDcyMDA0MDAwODJjZTYyMmYz
+        NDQwNmYyOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjI5LjY3
+        MTEyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MjkuNzM3
+        MjY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q3ODVjYzk3LWM5ZmMtNDQ2ZC04MjJi
-        LTc4MDFlODQ3MjQxMy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q0MDgwOGVjLWNiNzUtNDJjYS04NjEx
+        LTA5NDIxNzI0Yzg1My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 003fed85bbd64b38ae6184f9d72dfe5c
+      - a37d7c781c2d43fa85e55b9835df3c92
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57801a5f730d422cbf0bfb91781a760b
+      - 1dfbda3344a241668d538f9415e67a4a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb3e75a0a0b1489ea8da73805d54604d
+      - 1910213e09e849a5b015e353bfe975ab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b110d0019dd74a7db8f155b908d2f6ea
+      - 356a22b7460b418db31d8484b28c6013
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e49b43cefc3b445ba7cb37db46d15266
+      - f64fe9afddc84ad7af5bb5e3a41768ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e29c56fd669461289942be1431c2144
+      - cc664fccb5c94aacbfa054667a8d64ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:30 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/"
+      - "/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d524ed373a154fe69797aa290c879877
+      - 4d9b296b67f14cde94c429f0e6686d2e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZWEwMTkyM2MtZWM0NS00NzVkLTg4NzQtODZmMjJkOTM0OTdjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6NTguNTE0Mzc0WiIsInZl
+        cG0vYmEzZWUxMWQtZWNmOS00OWEwLWI1YmEtY2ZkMTRjZjU4N2Y0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MzAuMjE5NzY0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZWEwMTkyM2MtZWM0NS00NzVkLTg4NzQtODZmMjJkOTM0OTdjL3ZlcnNp
+        cG0vYmEzZWUxMWQtZWNmOS00OWEwLWI1YmEtY2ZkMTRjZjU4N2Y0L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lYTAxOTIzYy1l
-        YzQ1LTQ3NWQtODg3NC04NmYyMmQ5MzQ5N2MvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iYTNlZTExZC1l
+        Y2Y5LTQ5YTAtYjViYS1jZmQxNGNmNTg3ZjQvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:30 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a6b0c813-82ae-433b-8839-65b6907faa93/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/7803b81f-73d8-4971-a5bf-6441f22e9ef3/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0674c2308e1c4afcacb51343be9eacc6
+      - 0f179383a4584812bcef285ef35b2144
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0MTg5OTBkLTE0MmMtNDFm
-        NC04ZThkLWZhMWZiNDA4MDkwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3NTM4ZGY5LTNiZjUtNGNj
+        ZC1iOGNlLTIzOTEwMmMxN2JmZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9418990d-142c-41f4-8e8d-fa1fb4080901/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d7538df9-3bf5-4ccd-b8ce-239102c17bff/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5dbb08ce9b945f2b077bfe9f9017a2c
+      - d1f04d6a0a804ba68e4f30be87e7c08d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQxODk5MGQtMTQy
-        Yy00MWY0LThlOGQtZmExZmI0MDgwOTAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6NTguNzk3NzU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDc1MzhkZjktM2Jm
+        NS00Y2NkLWI4Y2UtMjM5MTAyYzE3YmZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzAuNTgyNTM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwNjc0YzIzMDhlMWM0YWZjYWNiNTEzNDNi
-        ZTllYWNjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjU4Ljgy
-        OTAzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6NTguODUz
-        Mzk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwZjE3OTM4M2E0NTg0ODEyYmNlZjI4NWVm
+        MzViMjE0NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjMwLjYy
+        NzkzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MzAuNjU2
+        MjY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E2YjBjODEzLTgyYWUtNDMzYi04ODM5
-        LTY1YjY5MDdmYWE5My8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc4MDNiODFmLTczZDgtNDk3MS1hNWJm
+        LTY0NDFmMjJlOWVmMy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:30 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E2YjBj
-        ODEzLTgyYWUtNDMzYi04ODM5LTY1YjY5MDdmYWE5My8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc4MDNi
+        ODFmLTczZDgtNDk3MS1hNWJmLTY0NDFmMjJlOWVmMy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:58 GMT
+      - Fri, 29 Jul 2022 11:34:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96320a90d2154ec7991bc7f87c243667
+      - 2fdaddb29f7349038f56d3a1a85aea78
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYyNzM3ZmFhLWU3MDAtNDA0
-        Yy1iYjQ3LTg4YjM5OWNmMDlhMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YwYmJlZTY4LWJhMjQtNDI4
+        Yi1iMGFiLWI5MGRlY2RjNmI2Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/62737faa-e700-404c-bb47-88b399cf09a3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f0bbee68-ba24-428b-b0ab-b90decdc6b6b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:59 GMT
+      - Fri, 29 Jul 2022 11:34:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f04fb850144a47949cde9f2940e477f1
+      - eefe1178612a44b29f871c44c4e389e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '657'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjI3MzdmYWEtZTcw
-        MC00MDRjLWJiNDctODhiMzk5Y2YwOWEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6NTguOTczMzA1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjBiYmVlNjgtYmEy
+        NC00MjhiLWIwYWItYjkwZGVjZGM2YjZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzAuODE0MTcwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI5NjMyMGE5MGQyMTU0ZWM3OTkx
-        YmM3Zjg3YzI0MzY2NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjU5LjAwNTMwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        NTkuNzg5NDgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyZmRhZGRiMjlmNzM0OTAzOGY1
+        NmQzYTFhODVhZWE3OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjMwLjg2MDcxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzIuMDMyMDU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2IwOTQyZDA2LTNlM2ItNDU3ZS04NzhiLWJmZjYz
-        MzAxZWYzNy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMDk0
-        MmQwNi0zZTNiLTQ1N2UtODc4Yi1iZmY2MzMwMWVmMzcvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYTZiMGM4MTMtODJhZS00MzNi
-        LTg4MzktNjViNjkwN2ZhYTkzLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9iMWU5NTkxNC1jZTVmLTQzNDgtYmFjMi02MWM1MjA5
+        ODliMjUvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjFlOTU5
+        MTQtY2U1Zi00MzQ4LWJhYzItNjFjNTIwOTg5YjI1LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc4MDNiODFmLTczZDgtNDk3MS1h
+        NWJmLTY0NDFmMjJlOWVmMy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYjA5NDJkMDYtM2UzYi00NTdlLTg3OGItYmZmNjMzMDFl
-        ZjM3L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYjFlOTU5MTQtY2U1Zi00MzQ4LWJhYzItNjFjNTIwOTg5
+        YjI1L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:00 GMT
+      - Fri, 29 Jul 2022 11:34:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b63c2a27d244c2d8632977d1ea600eb
+      - a2c3a76832a647d6b3c04d18f50cae27
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjODk2Zjg0LTY2Y2ItNGZj
-        Ny05NmMxLTRhZjNlYjZkNzA5My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y3MGRlZDI1LWQwMzEtNDY2
+        ZS1hYTA2LWFlZmFiMGEyNTg1OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dc896f84-66cb-4fc7-96c1-4af3eb6d7093/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f70ded25-d031-466e-aa06-aefab0a25859/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:00 GMT
+      - Fri, 29 Jul 2022 11:34:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea61bc6b8e4143259143d8cc7a5f6176
+      - 2d88068b32204e9fb831b4830e4d3597
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGM4OTZmODQtNjZj
-        Yi00ZmM3LTk2YzEtNGFmM2ViNmQ3MDkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDAuMDYxMDg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjcwZGVkMjUtZDAz
+        MS00NjZlLWFhMDYtYWVmYWIwYTI1ODU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzIuNTc2MDczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjhiNjNjMmEyN2QyNDRjMmQ4NjMyOTc3ZDFl
-        YTYwMGViIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MDAuMTE2
-        NDE3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODowMC40NzAx
-        NThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImEyYzNhNzY4MzJhNjQ3ZDZiM2MwNGQxOGY1
+        MGNhZTI3Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MzIuNjQ1
+        MTY3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDozMy4xOTMy
+        NjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTRmNDcx
-        NDMtM2I3OS00ODgwLWJkOWQtOTU5OWYwMzBmYWY5LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjQ3MDI4
+        YjAtN2MwMS00MmJmLTliZDItNWVkYzdmZTE3NDhiLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYjA5NDJkMDYtM2UzYi00NTdlLTg3OGItYmZmNjMz
-        MDFlZjM3LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYjFlOTU5MTQtY2U1Zi00MzQ4LWJhYzItNjFjNTIw
+        OTg5YjI1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:00 GMT
+      - Fri, 29 Jul 2022 11:34:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 746b8f15061040a9ac6df601b457cef2
+      - f8a0527cf72d493aa75da20ad92d73c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/647028b0-7c01-42bf-9bd2-5edc7fe1748b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c217dd73d63c4bd589b1bc8c7f6bf44b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNjQ3MDI4YjAtN2MwMS00MmJmLTliZDItNWVkYzdmZTE3NDhiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MzIuNjg4ODIxWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9iMWU5NTkxNC1jZTVmLTQzNDgtYmFjMi02MWM1MjA5ODliMjUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2IxZTk1OTE0LWNlNWYtNDM0OC1iYWMyLTYxYzUy
+        MDk4OWIyNS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:33 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS82NDcwMjhiMC03YzAxLTQyYmYtOWJkMi01ZWRjN2ZlMTc0OGIv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 27f58a3e4da341e09f4c5577860160cd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhMmM2NjY0LTMxZWQtNDBm
+        Yi04MTE5LWM5ZjZhNWVhOTRlMy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0a2c6664-31ed-40fb-8119-c9f6a5ea94e3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2e3860a79030446787c42d8487c07883
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGEyYzY2NjQtMzFl
+        ZC00MGZiLTgxMTktYzlmNmE1ZWE5NGUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzMuNjAzNDE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyN2Y1OGEzZTRkYTM0MWUwOWY0YzU1Nzc4
+        NjAxNjBjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjMzLjY1
+        MjIwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MzMuOTE5
+        OTY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMzkz
+        NzJkN2MtZDQ3My00N2RkLTlmMmMtOTBmMTQ1NDhmMzZkLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/39372d7c-d473-47dd-9f2c-90f14548f36d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d76c6c1e7a474465bafb6cc91d47ac04
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzM5MzcyZDdjLWQ0NzMtNDdkZC05ZjJjLTkwZjE0NTQ4ZjM2ZC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjMzLjg5NjA2MloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNjQ3MDI4YjAtN2MwMS00MmJmLTliZDIt
+        NWVkYzdmZTE3NDhiLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4d82beaa91f84f4c9859fdcd91b0923f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:00 GMT
+      - Fri, 29 Jul 2022 11:34:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2566fecefb6a4eb1b5a08901fad00fb9
+      - 6ff9f8e8262a4da1ab2fe8dd17edb7ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 50753a5a8e8d42deaffd5935c895fe5c
+      - fe3c41338042499abf96481df2dfe752
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 790886ec90e14fedbd8322476e50043c
+      - babde0ce506a4afb984813e5306d98b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2cfd7212a2094f3d8023c53796ba73a3
+      - dc057f399f0241258b61e91adeb2be19
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a8e6a3cda2814bb8aed8572abebd92ef
+      - 2ec7724423f341979248fb239a2bc189
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d0c3ff737844a41a92ec5a1c1343982
+      - bc58586a84d6478e8a7d6aa5ae8d824c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 93ab068c6d0b4abfb6fa4bbc7ebd1fe5
+      - c7b2e8f3b8a44f67a2d98d6fdce630e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 799768cbbb58481286d77746e95c9fab
+      - 54e9d2101a11401a874b30a86a1bc7a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5129fdd858e94edd9ec635313c5b96c8
+      - aec0d917bf4f4933b59037b45bfa1ba2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 48485f998f294c4e840d3e9889664b5c
+      - 16cc17d815234049a891050152f2004c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f2c63ce80414770b9226ef77dc78a7a
+      - b72ff08a7e0e4416bf6f7f9f8d23cec9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b49733e322d4ab68c8950d0cd7503d5
+      - 8d8ed2e8d39c4c1197f37c4010359092
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b1e95914-ce5f-4348-bac2-61c520989b25/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 52495a28d8c54ba888ec8a56ea52ebbb
+      - 03f6e03c75354caba3d44cc37bb7cb10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cdee7eb114b54404a26ed0356168d4d3
+      - 9eca8d2a4cba48ef821d9e5660772222
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1NWEzZWE0LWU2MWYtNDE4
-        YS05NmRkLWZiMTU4NmQ0MzQzZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlmNzU0ZWYxLTk2ODItNDhk
+        ZC04NzBlLThjMWRlODg5NGViMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e72a3916217414c81255deef685ce48
+      - 4be8d855ebad408b92563b3418610a97
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RkYjc4YmVjLThjOTUtNDZl
-        ZC1iNDI0LTIyNGFkNTZhOTZhOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmMWNhMGQyLWJlNmQtNGNk
+        OS1iZTE4LTIxOTQ2NzkxOWExNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:01 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,55 +3935,55 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7707b68021646329a991e7264b0f941
+      - efe2dbd53c0d404c98d5f1f3fc8e4949
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0Mjc5YmY2LWRlYjUtNDI4
-        Zi04YjAyLWVjYzZlNGM5ZTk4Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0NGY1ZDlkLWZjZDItNGFj
+        MS1hODYzLWNkY2ZjZjdiYzc0ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjA5NDJkMDYtM2UzYi00NTdlLTg3
-        OGItYmZmNjMzMDFlZjM3L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2VhMDE5MjNjLWVjNDUt
-        NDc1ZC04ODc0LTg2ZjIyZDkzNDk3Yy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        Mjk2ZTUwNTQtODIyNS00MzNjLWEzY2QtNjQxYzEwMDk1MTEzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM4NTMwYWU2LTRiYzYt
-        NDE2Zi1iYmVlLTk2MTA2YTRjZjk1MC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9mMTc4OTMwOC1kMjNkLTQ0ODAtOGYyMS0yYzky
-        MDEwNzEzZjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3RyaWJ1
-        dGlvbl90cmVlcy81ODk3OTA5OS01NmNlLTQxNWQtYjg3My0yMTRhNzM1NmQx
-        MDAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
-        MGZjYTEwM2MtMmVjNi00NDdiLWFjNzEtNmIyYzg2YWQ4ZGJiLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZmLTQz
-        ZjItOWE2ZC03YTI1MmIwOWFhOTYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzQ5NDNkMTlkLWM1NTItNDVkMi04NTYwLWM3MGFmOTEz
-        N2NjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1
-        MjI4ODAtOGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jYmIzODQ4Ny05Njc3LTRhNDMt
-        ODNlMy00MzkwYjNkMjA1YjQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3JlcG9fbWV0YWRhdGFfZmlsZXMvZjQ3YTNmZTYtMmM0Ni00M2VkLWJlZjQt
-        ZDMxMjQ0MTFiZDI0LyJdfV0sImRlcGVuZGVuY3lfc29sdmluZyI6ZmFsc2V9
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjFlOTU5MTQtY2U1Zi00MzQ4LWJh
+        YzItNjFjNTIwOTg5YjI1L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JhM2VlMTFkLWVjZjkt
+        NDlhMC1iNWJhLWNmZDE0Y2Y1ODdmNC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8zOWI0ZTRmNy1kNzdjLTQwNjYtOTJkMC05NTBmZjBl
+        MmJlNjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NzExZjgzOTktNTQ2My00NWFjLWFlNjMtZjc5MzAwNWZkZjkyLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQt
+        NDkwYS04Njg5LTUxNGUzY2QwYWY0ZS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy9hZmEzNWE2MC05MTRjLTRkNzQtOTI2Ni1iMGUw
+        Nzg5NjM4ZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Rpc3RyaWJ1
+        dGlvbl90cmVlcy80ZjI1MmVjZS0zMTk1LTQ3YWItYTU2Ny1lOWNkZGRkNTBh
+        MjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
+        NWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OWU4M2FkNi0yNDI0LTRi
+        OTAtODFlOS0zYTViMWFkODRhMjQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzdjZjA1ZjJlLWIyYzEtNDhiMC04MTMzLTFiZjc1ZmRk
+        MjNlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTcy
+        NDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBlLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMjQ3NDI1NC0xNWEyLTQ0NjQt
+        OWQxMi0yNDFlZjZkNDUzYjAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00MjMxLTg3ZDIt
+        ZTEzMDNiZmRmYTVmLyJdfV0sImRlcGVuZGVuY3lfc29sdmluZyI6ZmFsc2V9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3571,7 +3996,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3589,21 +4014,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4c9f263d6e14f249962f3c4becf31bb
+      - 688778bf032f4bf4bcf7f0747d59b8c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0NTZhMzEyLWRiYjAtNDZj
-        Yy04NTI4LTkyNDlkM2NhMDFkNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiMjI3MjdlLWYxNjItNDdk
+        My1hYWNjLTEzOWI2YmE3NTJjNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b55a3ea4-e61f-418a-96dd-fb1586d4343f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9f754ef1-9682-48dd-870e-8c1de8894eb3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3624,51 +4049,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a112527561804c4886d9cda6f84675f1
+      - 440952e558fe4ce3a2bed32f43a79c6e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjU1YTNlYTQtZTYx
-        Zi00MThhLTk2ZGQtZmIxNTg2ZDQzNDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuODY4NDkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWY3NTRlZjEtOTY4
+        Mi00OGRkLTg3MGUtOGMxZGU4ODk0ZWIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuMjcwOTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjZGVlN2ViMTE0YjU0NDA0YTI2
-        ZWQwMzU2MTY4ZDRkMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAxLjkwMTk5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMDQ0NzU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ZWNhOGQyYTRjYmE0OGVmODIx
+        ZDllNTY2MDc3MjIyMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjM2LjMzNjg5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzYuNTg2Njk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0
-        NS00NzVkLTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNm
+        OS00OWEwLWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b55a3ea4-e61f-418a-96dd-fb1586d4343f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6f1ca0d2-be6d-4cd9-be18-219467919a15/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3689,118 +4114,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4f4d92349094ea390a47e1d464b2dea
+      - 7c605ef87e3149289565684f8f467788
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjU1YTNlYTQtZTYx
-        Zi00MThhLTk2ZGQtZmIxNTg2ZDQzNDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuODY4NDkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmYxY2EwZDItYmU2
+        ZC00Y2Q5LWJlMTgtMjE5NDY3OTE5YTE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuMzU1MTMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjZGVlN2ViMTE0YjU0NDA0YTI2
-        ZWQwMzU2MTY4ZDRkMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAxLjkwMTk5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMDQ0NzU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0
-        NS00NzVkLTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ddb78bec-8c95-46ed-b424-224ad56a96a9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:28:02 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1562fc24869c4122b3b30576b769ee28
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGRiNzhiZWMtOGM5
-        NS00NmVkLWI0MjQtMjI0YWQ1NmE5NmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuOTI1NDI4WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ZTcyYTM5MTYyMTc0MTRjODEy
-        NTVkZWVmNjg1Y2U0OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAyLjA3OTAwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMjE3NTI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0YmU4ZDg1NWViYWQ0MDhiOTI1
+        NjNiMzQxODYxMGE5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjM2LjYyNTMxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzYuODU5MzE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lYTAxOTIzYy1lYzQ1LTQ3NWQtODg3NC04NmYyMmQ5MzQ5N2MvdmVyc2lv
+        bS9iYTNlZTExZC1lY2Y5LTQ5YTAtYjViYS1jZmQxNGNmNTg3ZjQvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0NS00NzVk
-        LTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNmOS00OWEw
+        LWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b55a3ea4-e61f-418a-96dd-fb1586d4343f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9f754ef1-9682-48dd-870e-8c1de8894eb3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3821,51 +4181,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a13e48fd896243ecafcb4e341b5793e1
+      - 566a459ac67b41108dbf9294a5d450fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjU1YTNlYTQtZTYx
-        Zi00MThhLTk2ZGQtZmIxNTg2ZDQzNDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuODY4NDkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWY3NTRlZjEtOTY4
+        Mi00OGRkLTg3MGUtOGMxZGU4ODk0ZWIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuMjcwOTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjZGVlN2ViMTE0YjU0NDA0YTI2
-        ZWQwMzU2MTY4ZDRkMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAxLjkwMTk5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMDQ0NzU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ZWNhOGQyYTRjYmE0OGVmODIx
+        ZDllNTY2MDc3MjIyMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjM2LjMzNjg5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzYuNTg2Njk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0
-        NS00NzVkLTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNm
+        OS00OWEwLWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ddb78bec-8c95-46ed-b424-224ad56a96a9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6f1ca0d2-be6d-4cd9-be18-219467919a15/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3886,53 +4246,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d95c6543ed6e4053a553e1edbeecca33
+      - 73cbdfba110949feb115b099772b3f1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGRiNzhiZWMtOGM5
-        NS00NmVkLWI0MjQtMjI0YWQ1NmE5NmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuOTI1NDI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmYxY2EwZDItYmU2
+        ZC00Y2Q5LWJlMTgtMjE5NDY3OTE5YTE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuMzU1MTMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ZTcyYTM5MTYyMTc0MTRjODEy
-        NTVkZWVmNjg1Y2U0OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAyLjA3OTAwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMjE3NTI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0YmU4ZDg1NWViYWQ0MDhiOTI1
+        NjNiMzQxODYxMGE5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjM2LjYyNTMxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzYuODU5MzE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lYTAxOTIzYy1lYzQ1LTQ3NWQtODg3NC04NmYyMmQ5MzQ5N2MvdmVyc2lv
+        bS9iYTNlZTExZC1lY2Y5LTQ5YTAtYjViYS1jZmQxNGNmNTg3ZjQvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0NS00NzVk
-        LTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNmOS00OWEw
+        LWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/24279bf6-deb5-428f-8b02-ecc6e4c9e987/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/244f5d9d-fcd2-4ac1-a863-cdcfcf7bc74d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3953,53 +4313,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d3bada1382ab486e92bee508afdbd0b4
+      - 6f989bb16f6443908744eae1660b6482
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQyNzliZjYtZGVi
-        NS00MjhmLThiMDItZWNjNmU0YzllOTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuOTc1MzEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQ0ZjVkOWQtZmNk
+        Mi00YWMxLWE4NjMtY2RjZmNmN2JjNzRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuNDIxODA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkNzcwN2I2ODAyMTY0NjMyOWE5
-        OTFlNzI2NGIwZjk0MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAyLjI0OTQwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMzg3MDAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlZmUyZGJkNTNjMGQ0MDRjOThk
+        NWYxZjNmYzhlNDk0OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjM2Ljg5OTQ1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzcuMTU2MzkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lYTAxOTIzYy1lYzQ1LTQ3NWQtODg3NC04NmYyMmQ5MzQ5N2MvdmVyc2lv
+        bS9iYTNlZTExZC1lY2Y5LTQ5YTAtYjViYS1jZmQxNGNmNTg3ZjQvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0NS00NzVk
-        LTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNmOS00OWEw
+        LWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b55a3ea4-e61f-418a-96dd-fb1586d4343f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9f754ef1-9682-48dd-870e-8c1de8894eb3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4020,51 +4380,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e0f914617b034b6fba32c64a30860fd0
+      - 5ed951fb1cdd4dcf935b482d3c7413f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjU1YTNlYTQtZTYx
-        Zi00MThhLTk2ZGQtZmIxNTg2ZDQzNDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuODY4NDkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWY3NTRlZjEtOTY4
+        Mi00OGRkLTg3MGUtOGMxZGU4ODk0ZWIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuMjcwOTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjZGVlN2ViMTE0YjU0NDA0YTI2
-        ZWQwMzU2MTY4ZDRkMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAxLjkwMTk5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMDQ0NzU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ZWNhOGQyYTRjYmE0OGVmODIx
+        ZDllNTY2MDc3MjIyMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjM2LjMzNjg5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzYuNTg2Njk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0
-        NS00NzVkLTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNm
+        OS00OWEwLWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ddb78bec-8c95-46ed-b424-224ad56a96a9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6f1ca0d2-be6d-4cd9-be18-219467919a15/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4085,53 +4445,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bdd82f680c11402786a193cd01103aef
+      - ff6aa8cdf3fa485fa21ef5cde410f22b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGRiNzhiZWMtOGM5
-        NS00NmVkLWI0MjQtMjI0YWQ1NmE5NmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuOTI1NDI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmYxY2EwZDItYmU2
+        ZC00Y2Q5LWJlMTgtMjE5NDY3OTE5YTE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuMzU1MTMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ZTcyYTM5MTYyMTc0MTRjODEy
-        NTVkZWVmNjg1Y2U0OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAyLjA3OTAwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMjE3NTI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0YmU4ZDg1NWViYWQ0MDhiOTI1
+        NjNiMzQxODYxMGE5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjM2LjYyNTMxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzYuODU5MzE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lYTAxOTIzYy1lYzQ1LTQ3NWQtODg3NC04NmYyMmQ5MzQ5N2MvdmVyc2lv
+        bS9iYTNlZTExZC1lY2Y5LTQ5YTAtYjViYS1jZmQxNGNmNTg3ZjQvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0NS00NzVk
-        LTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNmOS00OWEw
+        LWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/24279bf6-deb5-428f-8b02-ecc6e4c9e987/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/244f5d9d-fcd2-4ac1-a863-cdcfcf7bc74d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4152,53 +4512,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:02 GMT
+      - Fri, 29 Jul 2022 11:34:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c5042faf91f941119e7f533344a93eb4
+      - d212446505bc49f4a69712edcee0bd54
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQyNzliZjYtZGVi
-        NS00MjhmLThiMDItZWNjNmU0YzllOTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDEuOTc1MzEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQ0ZjVkOWQtZmNk
+        Mi00YWMxLWE4NjMtY2RjZmNmN2JjNzRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuNDIxODA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkNzcwN2I2ODAyMTY0NjMyOWE5
-        OTFlNzI2NGIwZjk0MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjAyLjI0OTQwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDIuMzg3MDAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlZmUyZGJkNTNjMGQ0MDRjOThk
+        NWYxZjNmYzhlNDk0OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjM2Ljg5OTQ1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MzcuMTU2MzkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lYTAxOTIzYy1lYzQ1LTQ3NWQtODg3NC04NmYyMmQ5MzQ5N2MvdmVyc2lv
+        bS9iYTNlZTExZC1lY2Y5LTQ5YTAtYjViYS1jZmQxNGNmNTg3ZjQvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0NS00NzVk
-        LTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUxMWQtZWNmOS00OWEw
+        LWI1YmEtY2ZkMTRjZjU4N2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9456a312-dbb0-46cc-8528-9249d3ca01d4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8b22727e-f162-47d3-aacc-139b6ba752c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4219,55 +4579,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90cb09f86c8440a7a3c9841d03e37a5a
+      - f0f00031bf844c60b84f500863f983de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQ1NmEzMTItZGJi
-        MC00NmNjLTg1MjgtOTI0OWQzY2EwMWQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDIuMDI3NzMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGIyMjcyN2UtZjE2
+        Mi00N2QzLWFhY2MtMTM5YjZiYTc1MmM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MzYuNTAxOTQyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiZDRjOWYyNjNkNmUxNGYyNDk5NjJmM2M0YmVj
-        ZjMxYmIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODowMi40MTg1
-        ODhaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjAyLjgzMzcx
-        NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiNjg4Nzc4YmYwMzJmNGJmNGJjZjdmMDc0N2Q1
+        OWI4YzgiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDozNy4xOTI4
+        MjhaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjM3Ljc0NzM5
+        NVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTky
-        M2MtZWM0NS00NzVkLTg4NzQtODZmMjJkOTM0OTdjL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmEzZWUx
+        MWQtZWNmOS00OWEwLWI1YmEtY2ZkMTRjZjU4N2Y0L3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2VhMDE5MjNjLWVjNDUtNDc1ZC04ODc0LTg2
-        ZjIyZDkzNDk3Yy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2IwOTQyZDA2LTNlM2ItNDU3ZS04NzhiLWJmZjYzMzAxZWYz
-        Ny8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2JhM2VlMTFkLWVjZjktNDlhMC1iNWJhLWNm
+        ZDE0Y2Y1ODdmNC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2IxZTk1OTE0LWNlNWYtNDM0OC1iYWMyLTYxYzUyMDk4OWIy
+        NS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4275,7 +4635,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4288,54 +4648,54 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '755'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 017621db3dfc4b1db8bc7ce9186e4fa5
+      - 48a2f9d13c024f4381044d9e36ea9ea5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '314'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6OCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQyYzAtODhmMy0xNTI4OTBlZmE3ZWYv
+        YWNrYWdlcy80NjAxOTJmYy03ZWZmLTRlZGItYTA4YS1iYmFhNDgzNWFjNWEv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9
+        a2FnZXMvOWVjYTM4YTItNzhkZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8ifSx7
+        Z2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFjOTY2MjVkZmYvIn0seyJw
+        cy82MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MjllNmEyMWQtMmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2
-        NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2Mz
-        ODBhMC1hYWZmLTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmMyYWU4
-        MmUtYjdhMS00ZDZmLWI2M2QtY2U3MWVmZTU2YzVhLyJ9XX0=
+        NDgwNjA4YzEtYjZhYS00MDkwLTlhZmYtNzNhNDQ2Y2I2YjA0LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdj
+        ZjA1ZjJlLWIyYzEtNDhiMC04MTMzLTFiZjc1ZmRkMjNlMS8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMjQ3
+        NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3
+        YjEtYzkxMi00MWQxLWE4ZGYtZmQ4NDNhN2VkNWE4LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4343,7 +4703,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4356,7 +4716,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4374,21 +4734,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb61ae1b7a05403c8f34e350d713a2e6
+      - 27e6ae584e064cbeb0365ff4c76768c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4396,7 +4756,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4409,37 +4769,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6687'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a22ced3bd3da49b495b1782e39d4e604
+      - eedf53c59398411c8590809c8722614c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1785'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4512,9 +4872,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -4531,9 +4891,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM4NTMwYWU2LTRiYzYtNDE2
-        Zi1iYmVlLTk2MTA2YTRjZjk1MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0OTIyM1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMtNDVh
+        Yy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI5MzEwMFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAxMTEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRHVw
         bGljYXRlIE9uZSBwYWNrYWdlIGVycmF0YSIsImlzc3VlZF9kYXRlIjoiMjAx
         Mi0wMS0wMSAwMTowMTowMSIsImZyb21zdHIiOiJsemFwK3B1YkByZWRoYXQu
@@ -4555,9 +4915,9 @@ http_interactions:
         aHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90
         eXBlIjoiIiwidmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwi
         cmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjk2ZTUwNTQtODIyNS00
-        MzNjLWEzY2QtNjQxYzEwMDk1MTEzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjIt
-        MDUtMjNUMjM6MjY6NTguMjQ4MDU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIw
+        YXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvOWExY2RiNjgtZTdkZC00
+        OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjIt
+        MDctMjhUMTU6MDQ6MzQuMjkxMTg5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIw
         MTA6MDAwMiIsInVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJP
         bmUgcGFja2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEg
         MDE6MDE6MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0
@@ -4573,9 +4933,9 @@ http_interactions:
         cmMiOiJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwic3VtIjoiIiwi
         c3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4zIn1dfV0sInJlZmVyZW5jZXMi
         OltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy9mMTc4OTMwOC1k
-        MjNkLTQ0ODAtOGYyMS0yYzkyMDEwNzEzZjcvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMi0wNS0yM1QyMzoyNjo1OC4yNDA5OTZaIiwiaWQiOiJLQVRFTExPLVJI
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy9hZmEzNWE2MC05
+        MTRjLTRkNzQtOTI2Ni1iMGUwNzg5NjM4ZDQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNy0yOFQxNTowNDozNC4yNzcyMDdaIiwiaWQiOiJLQVRFTExPLVJI
         RUEtMjAxMDowMDAxIiwidXBkYXRlZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlv
         biI6IkVtcHR5IGVycmF0YSIsImlzc3VlZF9kYXRlIjoiMjAxMC0wMS0wMSAw
         MTowMTowMSIsImZyb21zdHIiOiJsemFwK3B1YkByZWRoYXQuY29tIiwic3Rh
@@ -4585,10 +4945,10 @@ http_interactions:
         LCJwdXNoY291bnQiOiIiLCJwa2dsaXN0IjpbXSwicmVmZXJlbmNlcyI6W10s
         InJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4596,7 +4956,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4609,41 +4969,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4afe891be3cb438b83df6ffd27284605
+      - b69db9fcbb584e7487c84e4dba3f42dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4651,7 +5011,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4664,41 +5024,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 812de589788c4c43afda422f313d71fa
+      - 327ddf2aaab14bedb9467b72421864fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4706,7 +5066,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4719,36 +5079,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e2f808a75d514877a4ef2c3fa20397dc
+      - eb8c24a95fb84212a5310d7c6eb3bd42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4770,10 +5130,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4781,7 +5141,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4794,54 +5154,54 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '755'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '07850463914146488abae338a3ec5d35'
+      - 954bdc1c20f848e8acba32874d1313c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '314'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6OCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQyYzAtODhmMy0xNTI4OTBlZmE3ZWYv
+        YWNrYWdlcy80NjAxOTJmYy03ZWZmLTRlZGItYTA4YS1iYmFhNDgzNWFjNWEv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9
+        a2FnZXMvOWVjYTM4YTItNzhkZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8ifSx7
+        Z2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFjOTY2MjVkZmYvIn0seyJw
+        cy82MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MjllNmEyMWQtMmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2
-        NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2Mz
-        ODBhMC1hYWZmLTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmMyYWU4
-        MmUtYjdhMS00ZDZmLWI2M2QtY2U3MWVmZTU2YzVhLyJ9XX0=
+        NDgwNjA4YzEtYjZhYS00MDkwLTlhZmYtNzNhNDQ2Y2I2YjA0LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdj
+        ZjA1ZjJlLWIyYzEtNDhiMC04MTMzLTFiZjc1ZmRkMjNlMS8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMjQ3
+        NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3
+        YjEtYzkxMi00MWQxLWE4ZGYtZmQ4NDNhN2VkNWE4LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4849,7 +5209,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4862,7 +5222,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4880,21 +5240,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9deb5a94cb4a430aa4c3b103e10e9cef
+      - 1cf295aa933e4df0beb96c2485752435
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4902,7 +5262,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4915,37 +5275,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6687'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c31e52190ee45448a32747528398f47
+      - 4b079d1ca4f94d9cbdf6e264895a16b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1785'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -5018,9 +5378,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -5037,9 +5397,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM4NTMwYWU2LTRiYzYtNDE2
-        Zi1iYmVlLTk2MTA2YTRjZjk1MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0OTIyM1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMtNDVh
+        Yy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI5MzEwMFoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAxMTEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRHVw
         bGljYXRlIE9uZSBwYWNrYWdlIGVycmF0YSIsImlzc3VlZF9kYXRlIjoiMjAx
         Mi0wMS0wMSAwMTowMTowMSIsImZyb21zdHIiOiJsemFwK3B1YkByZWRoYXQu
@@ -5061,9 +5421,9 @@ http_interactions:
         aHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90
         eXBlIjoiIiwidmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwi
         cmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjk2ZTUwNTQtODIyNS00
-        MzNjLWEzY2QtNjQxYzEwMDk1MTEzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjIt
-        MDUtMjNUMjM6MjY6NTguMjQ4MDU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIw
+        YXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvOWExY2RiNjgtZTdkZC00
+        OTBhLTg2ODktNTE0ZTNjZDBhZjRlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjIt
+        MDctMjhUMTU6MDQ6MzQuMjkxMTg5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIw
         MTA6MDAwMiIsInVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJP
         bmUgcGFja2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEg
         MDE6MDE6MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0
@@ -5079,9 +5439,9 @@ http_interactions:
         cmMiOiJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwic3VtIjoiIiwi
         c3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4zIn1dfV0sInJlZmVyZW5jZXMi
         OltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy9mMTc4OTMwOC1k
-        MjNkLTQ0ODAtOGYyMS0yYzkyMDEwNzEzZjcvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMi0wNS0yM1QyMzoyNjo1OC4yNDA5OTZaIiwiaWQiOiJLQVRFTExPLVJI
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy9hZmEzNWE2MC05
+        MTRjLTRkNzQtOTI2Ni1iMGUwNzg5NjM4ZDQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNy0yOFQxNTowNDozNC4yNzcyMDdaIiwiaWQiOiJLQVRFTExPLVJI
         RUEtMjAxMDowMDAxIiwidXBkYXRlZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlv
         biI6IkVtcHR5IGVycmF0YSIsImlzc3VlZF9kYXRlIjoiMjAxMC0wMS0wMSAw
         MTowMTowMSIsImZyb21zdHIiOiJsemFwK3B1YkByZWRoYXQuY29tIiwic3Rh
@@ -5091,10 +5451,10 @@ http_interactions:
         LCJwdXNoY291bnQiOiIiLCJwa2dsaXN0IjpbXSwicmVmZXJlbmNlcyI6W10s
         InJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5102,7 +5462,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5115,41 +5475,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 389de7eda49d4bbf8fb196e512ece877
+      - 4a6e3f1b1a4b4503a159d7f3b17cc8b5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5157,7 +5517,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5170,41 +5530,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9353160751ef4b0fad6c140e257688ac
+      - 1c9ac69383cd437a9f930b38c2c817e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ba3ee11d-ecf9-49a0-b5ba-cfd14cf587f4/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5212,7 +5572,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5225,36 +5585,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:03 GMT
+      - Fri, 29 Jul 2022 11:34:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - abb1da9c9ff14131b99a8955184d00f7
+      - f988776d6d3b4bfe958bd06455d5db0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5276,5 +5636,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:39 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_errata_repository/errata_is_not_copied_if_errata_packages_are_not_all_found_in_included_packages.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_errata_repository/errata_is_not_copied_if_errata_packages_are_not_all_found_in_included_packages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a63244480dd49f28c057f183fdd49f6
+      - d9d0ea74378f47bb928c26f8e9947a1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81ODhmNmMzNS03MTNkLTRhYWItYmM0Ni01M2ZhNmQzZDhkOGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyODoxMy4xNzk4OTNa
+        cnBtL3JwbS80MjlkOTNlYi0yNmRjLTQwNTYtOTQ5Ni0yMzlmNWNmZmFiOWYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDowMi44OTQ3NjFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81ODhmNmMzNS03MTNkLTRhYWItYmM0Ni01M2ZhNmQzZDhkOGIv
+        cnBtL3JwbS80MjlkOTNlYi0yNmRjLTQwNTYtOTQ5Ni0yMzlmNWNmZmFiOWYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU4OGY2
-        YzM1LTcxM2QtNGFhYi1iYzQ2LTUzZmE2ZDNkOGQ4Yi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQyOWQ5
+        M2ViLTI2ZGMtNDA1Ni05NDk2LTIzOWY1Y2ZmYWI5Zi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:14 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/588f6c35-713d-4aab-bc46-53fa6d3d8d8b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fee2959279834ccca17f794c714e80f5
+      - 9f0a8b23b3de451c92a161ef3e514b91
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwMzA3MjM5LTFiZTEtNDUy
-        MC05NjEzLWQxYjk2ODBjNzJkYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxMGUyNmFiLTdlNDQtNDc4
+        My04YmYzLTgxN2YyN2ViZmU4Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 15dcb6559a5a4c66a036832880b575d2
+      - 4f17b44342b94a28b21aa538cf45f8f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/30307239-1be1-4520-9613-d1b9680c72db/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/610e26ab-7e44-4783-8bf3-817f27ebfe86/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 070d1a08579b410c858809142121b79f
+      - 9accc2606d904dbda96fc888221acc4a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzAzMDcyMzktMWJl
-        MS00NTIwLTk2MTMtZDFiOTY4MGM3MmRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MTkuMjMxNjQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjEwZTI2YWItN2U0
+        NC00NzgzLThiZjMtODE3ZjI3ZWJmZTg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTQuOTU2NDcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmZWUyOTU5Mjc5ODM0Y2NjYTE3Zjc5NGM3
-        MTRlODBmNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjE5LjI2
-        MTA0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MTkuNDYx
-        MjQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5ZjBhOGIyM2IzZGU0NTFjOTJhMTYxZWYz
+        ZTUxNGI5MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjE1LjAy
+        MDczMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MTUuMjYz
+        MDc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTg4ZjZjMzUtNzEzZC00YWFi
-        LWJjNDYtNTNmYTZkM2Q4ZDhiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDI5ZDkzZWItMjZkYy00MDU2
+        LTk0OTYtMjM5ZjVjZmZhYjlmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 93ff6b36ab4941858ed2492d9d15ac0e
+      - d9d72db56ae749a2958761e9294f02e2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3f40b10e9783445aa072a2e0eb8b8ea4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZjZkNzA4NWQtZDk0YS00ZTQzLTg2NGItZjM0OTc5NDk5MWFk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MDcuOTUzNTk0
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/f6d7085d-d94a-4e43-864b-f349794991ad/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 00beff97d1964864a11fe0b48e8c48f5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkZTkyNmUwLTAyZGYtNDg2
+        Ny05YjVkLWM2Mzc4M2E0ZWU1Ny8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fde926e0-02df-4867-9b5d-c63783a4ee57/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f502bdbe3c9048b1bc4aa454533ea8ac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmRlOTI2ZTAtMDJk
+        Zi00ODY3LTliNWQtYzYzNzgzYTRlZTU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTUuNDQ3NDY5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMGJlZmY5N2QxOTY0ODY0YTExZmUwYjQ4
+        ZThjNDhmNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjE1LjQ5
+        ODMxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MTUuNTYy
+        NDIzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 306c69bbe6554e97a9e0e616e06cb45e
+      - b3e7d112ea4e4f5680b8732ac8088845
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f31551bceaf248a281c8dc563a8ff4de
+      - 418972f02b5c44d8b24f41f2ef670bb8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 59be351e9e2a4fdf854297241a30042e
+      - a2acfec23ecc49768b5cdb50c2e3fb2c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f794e568b2c541f98bd7fe93b999e000
+      - 021fe95a3bc94d31be86aff0af4e113c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:28:19 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - a7bfa94ac05a42a6b7cb64d3312fd0fb
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:19 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/88dd8413-c7d3-4f3a-9b18-94a9fa62c8a8/"
+      - "/pulp/api/v3/remotes/rpm/rpm/d40808ec-cb75-42ca-8611-09421724c853/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 728a45a5fd984080b6a71dd1016f8687
+      - 4a94711f5c1c4fc0afb2cba2c2a3afd9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg4
-        ZGQ4NDEzLWM3ZDMtNGYzYS05YjE4LTk0YTlmYTYyYzhhOC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjE5LjkxMTYwMFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q0
+        MDgwOGVjLWNiNzUtNDJjYS04NjExLTA5NDIxNzI0Yzg1My8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjE2LjA1MzQ4OFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI4OjE5LjkxMTYyOVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjM0OjE2LjA1MzUxMFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/"
+      - "/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c3537b56e6124f57b862f1cfec74ea3a
+      - 42eaea52ea19405084c75795f38a36c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjVjOWI3ZDYtMWRlZS00NzQ3LWJjZDYtMWU1YWRlYmZjNzhmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MjAuMDIwNTM5WiIsInZl
+        cG0vNjVhNjQzYmUtODcxZC00NTMwLWFjNDYtMmM5NzI0N2Y0MmZlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MTYuMjE4OTI0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjVjOWI3ZDYtMWRlZS00NzQ3LWJjZDYtMWU1YWRlYmZjNzhmL3ZlcnNp
+        cG0vNjVhNjQzYmUtODcxZC00NTMwLWFjNDYtMmM5NzI0N2Y0MmZlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iNWM5YjdkNi0x
-        ZGVlLTQ3NDctYmNkNi0xZTVhZGViZmM3OGYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82NWE2NDNiZS04
+        NzFkLTQ1MzAtYWM0Ni0yYzk3MjQ3ZjQyZmUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8aa5b939ecff446b8425efb41421ffb5
+      - 5f1c2e082e6c4df8bcea034c2257940e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85NmU0ZDQxOS00NzE2LTRlMzktYWQ3MS0yYWE1M2RlZjdkZTgv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyODoxMy45MzM0MjRa
+        cnBtL3JwbS81N2Y0YzY5MC0xM2EyLTRhOWEtYmI3My0xZjVjZGM1YTQ5MGMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDowMy45MzYzNTla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85NmU0ZDQxOS00NzE2LTRlMzktYWQ3MS0yYWE1M2RlZjdkZTgv
+        cnBtL3JwbS81N2Y0YzY5MC0xM2EyLTRhOWEtYmI3My0xZjVjZGM1YTQ5MGMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk2ZTRk
-        NDE5LTQ3MTYtNGUzOS1hZDcxLTJhYTUzZGVmN2RlOC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU3ZjRj
+        NjkwLTEzYTItNGE5YS1iYjczLTFmNWNkYzVhNDkwYy92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/96e4d419-4716-4e39-ad71-2aa53def7de8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ac57676ab03f4899a55f644f7a902fc9
+      - faa2e3715601467e86228a2f421df29b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViMGMxMTFiLTdkNmEtNGEz
-        MS04NjkzLTNmMmM2NjQyYjY0OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZhOTBkNjlhLTZjM2UtNGE3
+        Ni1hMDRmLWMzMTA0NTM4N2VkMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 532b1ee5f93943bda4b085fc72add384
+      - be1806743fb84a37a505b92bd4846f7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYTgzNWM5ZWYtZTBkMC00YmJhLWJjZDktYmU2NjIxMjg1YWI5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MTMuMDYyNjk5WiIsIm5h
+        cG0vYmI4MDhlYzctZDdhYy00NjJhLTg4YmQtOGI2MmMzOGM4YTg4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MDIuNzQzMjI3WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyODoxNC4yNTIxNzhaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozNDowNC40MDM0NjFaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a835c9ef-e0d0-4bba-bcd9-be6621285ab9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/bb808ec7-d7ac-462a-88bd-8b62c38c8a88/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 280328d02f284d4ba77b35f383fef139
+      - c6c208397fc0436bb06629f960eefaef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVkODk0ZWJlLTkxZjQtNGUz
-        ZS1iNjllLWI4MGRiYTMzNTFlMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlZDIyNGQyLWY2ZDEtNDc3
+        ZC1iMDJkLTkzMjc3MjI1OTE4Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5b0c111b-7d6a-4a31-8693-3f2c6642b648/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6a90d69a-6c3e-4a76-a04f-c31045387ed0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9d7e0c7282b46208552d4f260d7a17f
+      - 2844d6789e0345ee9d324618b02b4ba5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWIwYzExMWItN2Q2
-        YS00YTMxLTg2OTMtM2YyYzY2NDJiNjQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjAuMTc4NjU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmE5MGQ2OWEtNmMz
+        ZS00YTc2LWEwNGYtYzMxMDQ1Mzg3ZWQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTYuNTA5NTg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhYzU3Njc2YWIwM2Y0ODk5YTU1ZjY0NGY3
-        YTkwMmZjOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjIwLjIw
-        NzY1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MjAuMjYz
-        NDA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmYWEyZTM3MTU2MDE0NjdlODYyMjhhMmY0
+        MjFkZjI5YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjE2LjU3
+        NjgzOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MTYuNzI4
+        NjY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTZlNGQ0MTktNDcxNi00ZTM5
-        LWFkNzEtMmFhNTNkZWY3ZGU4LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNhMi00YTlh
+        LWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5d894ebe-91f4-4e3e-b69e-b80dba3351e3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fed224d2-f6d1-477d-b02d-93277225918f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4267431835054be7ba7072c880af63d5
+      - ad78d41d9053470c9ffab009735e1f79
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWQ4OTRlYmUtOTFm
-        NC00ZTNlLWI2OWUtYjgwZGJhMzM1MWUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjAuMjYzMzgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmVkMjI0ZDItZjZk
+        MS00NzdkLWIwMmQtOTMyNzcyMjU5MThmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTYuNjc1MTMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyODAzMjhkMDJmMjg0ZDRiYTc3YjM1ZjM4
-        M2ZlZjEzOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjIwLjI5
-        NTgyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MjAuMzM2
-        MTIzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjNmMyMDgzOTdmYzA0MzZiYjA2NjI5Zjk2
+        MGVlZmFlZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjE2Ljc0
+        NjEwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MTYuODI1
+        MjEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E4MzVjOWVmLWUwZDAtNGJiYS1iY2Q5
-        LWJlNjYyMTI4NWFiOS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JiODA4ZWM3LWQ3YWMtNDYyYS04OGJk
+        LThiNjJjMzhjOGE4OC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a8c8d014dc947e492d740c6c6f9e07e
+      - 6058a96157d1420f990cde9c196a1102
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 894cafb088f74d76b0e4caf534b4538f
+      - eaea84f06da84490ad7ce54318b93413
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 07e419617a814c7fb9ed74a1ea840c4b
+      - bccadf45abd848d3be037bee3789733d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25741391dc5e419c9f0e9f6fee58c923
+      - c3734d0b40c6422fa75dc9222bd8a3df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4a30b6e6ea24e759414bb43d6f8403b
+      - da9424e391b84d0b97b917cbd0659b67
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22e90be1727c4e55984cb69812b2ea3e
+      - 7598cbb99f9447699a882690d4d481a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:17 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/"
+      - "/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 67b69e03f09047bb87da76644825e992
+      - f8aa51bf31c241629a80036c81ba0f2f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmY5M2E3YTYtZWQ1Ni00YzVkLTk3ZDktODJkM2NkYmEyYWFiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MjAuNjkxMzU1WiIsInZl
+        cG0vNzFiMzI0NDYtN2NkMS00MWUwLWI1MGUtYTViMjQzZmZlMGRlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MTcuMzk1Nzg1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmY5M2E3YTYtZWQ1Ni00YzVkLTk3ZDktODJkM2NkYmEyYWFiL3ZlcnNp
+        cG0vNzFiMzI0NDYtN2NkMS00MWUwLWI1MGUtYTViMjQzZmZlMGRlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82ZjkzYTdhNi1l
-        ZDU2LTRjNWQtOTdkOS04MmQzY2RiYTJhYWIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MWIzMjQ0Ni03
+        Y2QxLTQxZTAtYjUwZS1hNWIyNDNmZmUwZGUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:17 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/88dd8413-c7d3-4f3a-9b18-94a9fa62c8a8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/d40808ec-cb75-42ca-8611-09421724c853/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:20 GMT
+      - Fri, 29 Jul 2022 11:34:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b2c449819b66429e8c3904009c4e6689
+      - d58913e414b649918c6174c1c0b74fd3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmYmQ3ODM0LTAyZGYtNDRk
-        ZC05MWMxLWU2ZGRhMTFlOGZlYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4ZGViZjRlLWUxMzktNDEx
+        Yy05ZTVmLWU5ZTY1YzA2NmRmMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6fbd7834-02df-44dd-91c1-e6dda11e8fea/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d8debf4e-e139-411c-9e5f-e9e65c066df2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:21 GMT
+      - Fri, 29 Jul 2022 11:34:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fc3ea21c5fa24d96b35d3eb7d72edcfa
+      - 3ac568e41f1c4d81b9fc4b06ddcedd6d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmZiZDc4MzQtMDJk
-        Zi00NGRkLTkxYzEtZTZkZGExMWU4ZmVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjAuOTY4MzQ4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDhkZWJmNGUtZTEz
+        OS00MTFjLTllNWYtZTllNjVjMDY2ZGYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTcuNzc3NjczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJiMmM0NDk4MTliNjY0MjllOGMzOTA0MDA5
-        YzRlNjY4OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjIxLjAw
-        NDY5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MjEuMDI5
-        MTkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkNTg5MTNlNDE0YjY0OTkxOGM2MTc0YzFj
+        MGI3NGZkMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjE3Ljgz
+        MjY5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MTcuODcx
+        NTE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg4ZGQ4NDEzLWM3ZDMtNGYzYS05YjE4
-        LTk0YTlmYTYyYzhhOC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q0MDgwOGVjLWNiNzUtNDJjYS04NjEx
+        LTA5NDIxNzI0Yzg1My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:17 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg4ZGQ4
-        NDEzLWM3ZDMtNGYzYS05YjE4LTk0YTlmYTYyYzhhOC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q0MDgw
+        OGVjLWNiNzUtNDJjYS04NjExLTA5NDIxNzI0Yzg1My8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:21 GMT
+      - Fri, 29 Jul 2022 11:34:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 23ef86e5af4c4d4880682d3eeba7ab10
+      - c0098c05aaef4584a4eb6a9cd8bd126a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxZTkyYzBhLWIyODItNGZl
-        NS04MjI0LTk0NGJkNTFhZDMxYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4MmViMDFmLWU4ZWEtNGYz
+        OC05ZTg5LWEwNGMzZjBiN2VkNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c1e92c0a-b282-4fe5-8224-944bd51ad31a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/382eb01f-e8ea-4f38-9e89-a04c3f0b7ed4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:22 GMT
+      - Fri, 29 Jul 2022 11:34:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c80d49ea265d4dca945e7e62557bce25
+      - 64ef58e032db4d49a1490445ecb6b6b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '652'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzFlOTJjMGEtYjI4
-        Mi00ZmU1LTgyMjQtOTQ0YmQ1MWFkMzFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjEuMTM5NTU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzgyZWIwMWYtZThl
+        YS00ZjM4LTllODktYTA0YzNmMGI3ZWQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTguMDQwODYwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyM2VmODZlNWFmNGM0ZDQ4ODA2
-        ODJkM2VlYmE3YWIxMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjIxLjE3NTQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjIuMDQ5MjQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJjMDA5OGMwNWFhZWY0NTg0YTRl
+        YjZhOWNkOGJkMTI2YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjE4LjExMTc4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTkuMzIwNTYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2I1YzliN2Q2LTFkZWUtNDc0Ny1iY2Q2LTFlNWFk
-        ZWJmYzc4Zi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iNWM5
-        YjdkNi0xZGVlLTQ3NDctYmNkNi0xZTVhZGViZmM3OGYvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vODhkZDg0MTMtYzdkMy00ZjNh
-        LTliMTgtOTRhOWZhNjJjOGE4LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS82NWE2NDNiZS04NzFkLTQ1MzAtYWM0Ni0yYzk3MjQ3
+        ZjQyZmUvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjVhNjQz
+        YmUtODcxZC00NTMwLWFjNDYtMmM5NzI0N2Y0MmZlLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q0MDgwOGVjLWNiNzUtNDJjYS04
+        NjExLTA5NDIxNzI0Yzg1My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYjVjOWI3ZDYtMWRlZS00NzQ3LWJjZDYtMWU1YWRlYmZj
-        NzhmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNjVhNjQzYmUtODcxZC00NTMwLWFjNDYtMmM5NzI0N2Y0
+        MmZlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:22 GMT
+      - Fri, 29 Jul 2022 11:34:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b31529a9b47b4c049794548e8e7538c2
+      - b9f0363123a5481fb8217f216594ef18
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2MmU1YmRhLTBlNjQtNDM5
-        NC04MGQ2LWZmYTcwOGUxOWFkOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2MTIwNDczLTA3YWEtNDEy
+        My1hNjg0LTA4ZGNhNjk4Njg3My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a62e5bda-0e64-4394-80d6-ffa708e19ad9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/36120473-07aa-4123-a684-08dca6986873/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:22 GMT
+      - Fri, 29 Jul 2022 11:34:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b7053fc2863749bcbbd8c4f249d63dd3
+      - 4d80d9ba7a3d4c729b758db5484ffcad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTYyZTViZGEtMGU2
-        NC00Mzk0LTgwZDYtZmZhNzA4ZTE5YWQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjIuMzQ3NTExWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzYxMjA0NzMtMDdh
+        YS00MTIzLWE2ODQtMDhkY2E2OTg2ODczLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTkuNzk3NjQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImIzMTUyOWE5YjQ3YjRjMDQ5Nzk0NTQ4ZThl
-        NzUzOGMyIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MjIuMzc5
-        NjM0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODoyMi43MTYx
-        MzhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImI5ZjAzNjMxMjNhNTQ4MWZiODIxN2YyMTY1
+        OTRlZjE4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MTkuODYy
+        MTg1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDoyMC41NDgy
+        MTRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vY2E3MjUy
-        MDItYTlkOC00Nzc4LTk3ZjktMmYzMGM2NGI0N2U0LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMGJkMTRl
+        Y2EtNGRhMS00YTcyLThmMjMtYzFhZmYyZDcwZjY1LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYjVjOWI3ZDYtMWRlZS00NzQ3LWJjZDYtMWU1YWRl
-        YmZjNzhmLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNjVhNjQzYmUtODcxZC00NTMwLWFjNDYtMmM5NzI0
+        N2Y0MmZlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d398d65ef6ec4142be4792cf68f243ec
+      - aec1f12ac60f4b98943d2c52c0c1a603
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:20 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/0bd14eca-4da1-4a72-8f23-c1aff2d70f65/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b550be43d0f84575a777598816dc7bfa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMGJkMTRlY2EtNGRhMS00YTcyLThmMjMtYzFhZmYyZDcwZjY1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MTkuODk3Mzg2WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82NWE2NDNiZS04NzFkLTQ1MzAtYWM0Ni0yYzk3MjQ3ZjQyZmUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzY1YTY0M2JlLTg3MWQtNDUzMC1hYzQ2LTJjOTcy
+        NDdmNDJmZS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:20 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8wYmQxNGVjYS00ZGExLTRhNzItOGYyMy1jMWFmZjJkNzBmNjUv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a308fa49f0f04c87884d4839f88c5826
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjNzExMmViLTFjYTQtNDUy
+        ZS04NGMyLTZkMzFhNWViZjQyOC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:20 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ac7112eb-1ca4-452e-84c2-6d31a5ebf428/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5d8f4cf1baf140a7b6c8fd83b720c202
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWM3MTEyZWItMWNh
+        NC00NTJlLTg0YzItNmQzMWE1ZWJmNDI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjAuODY0ODE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhMzA4ZmE0OWYwZjA0Yzg3ODg0ZDQ4Mzlm
+        ODhjNTgyNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjIwLjkx
+        NTY0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MjEuMjQ4
+        NTY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNzFk
+        N2MwMDgtZjEwYy00NGZhLTlmOGItODlkZTczZWI2M2QyLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:21 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/71d7c008-f10c-44fa-9f8b-89de73eb63d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a2c817d49df847f8898a32372ad5b8cb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzcxZDdjMDA4LWYxMGMtNDRmYS05ZjhiLTg5ZGU3M2ViNjNkMi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjIxLjIyMzE3NloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMGJkMTRlY2EtNGRhMS00YTcyLThmMjMt
+        YzFhZmYyZDcwZjY1LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:21 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - db8bf4faf1d440ba84472826299998d7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96aed97296524d5baec8bdabcc7be945
+      - a93ccf8ef3634605804e2ba5dd65336a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d6a74d030669402e88c160a4844d032b
+      - 6f40826d67a842f6989be5425ef65bcc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c64488781385461f969f9946bb52144a
+      - 1a7ffa9b1ee34c6a8c2676bde71d1c2f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bbde9fe5d29a4403a89fc4ead7043ebf
+      - 0a8f28b528434ebe8db8e944ce54772e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef416a3c6096464a9e74e106da822230
+      - 69d0beae36a14f55a63cb8e84eb92c33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9b59e456b3a04336a6f0863824b13869
+      - 785751c5f7144b35a2728d41b010400c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39640fada70b4ff5a62198c6dcb3b70c
+      - f073a3d3f250456aa4e6b93beb6e97ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1074adfb39e74e5f987337cebc92a2be
+      - d9185dfe4a794392ba6392e4c1b4b07d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:23 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3389c10acdab4756b7ea415e2ac4d207
+      - f9f7fc5c39c0427abfe3333fe90aa312
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0fc887d61ead4a48b883767751f04fb0
+      - 5b7d251bf7514579bbf2cf0830bfbafb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 29738cbb7a6742318738f836016204bf
+      - f030306b96694a5b9c863562ab8a51ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb7dc7bec21948989832e9265990a72a
+      - 4bf88a2a4fd44a2588bb84cf671d1044
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/65a643be-871d-4530-ac46-2c97247f42fe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 32a8c069eb3e40009e4b793f7823c0cd
+      - 5266bfdd643a448eb0e3d3c7a61c835d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f91a5dc5a44a46fb9519bfb7dc64a6d9
+      - ab2ded747220402e9888f071debaf6f8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2NzU1MDIxLWVmYjctNGYy
-        NC1iNDZiLTk2ZDUyM2E1YTIzMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjYWY5NzAyLTA5NGQtNDg4
+        Ni1iZjhlLWExY2Y2ZWMzZTE4ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 407e4552f24948079ced45eb2d10ef2f
+      - 4cadcd4ecb9746f8a68168be65d72f32
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5YTkwYjE5LTEyMDQtNDEy
-        Yi05MTkwLTllNzc3Nzg5MjkwMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyZDcxYzFiLTgxN2EtNGQy
+        Mi1hZjMzLTQ1NzEwMzMzNjczYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,72 +3935,72 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ceba0fbcc42d48eba1a7ab0fa2743867
+      - 5f9a839c7cc04148accef727c105cb0a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3MWZjNmRjLTM2ODQtNDgy
-        OC1iMzk1LTVkMWY3NWEzZDQ0MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2YmVjOWU0LTNhMTYtNDNk
+        MC1iMjQ2LWYzMTVjMTJjMjYyZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjVjOWI3ZDYtMWRlZS00NzQ3LWJj
-        ZDYtMWU1YWRlYmZjNzhmL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZmOTNhN2E2LWVkNTYt
-        NGM1ZC05N2Q5LTgyZDNjZGJhMmFhYi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NjNmYmYwMmEtNDI1OS00M2FlLTlhNzYtMTJiZmI4Nzg5NTZmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2Qt
-        NDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1ZC1i
-        ODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRkNGFh
-        Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRlNTYx
-        MGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04
-        Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNlYzY5
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5YTY1
-        ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05
-        M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZh
-        ZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01Yjcx
-        LTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlm
-        OGU2NWMwZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        M2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1
-        ZDItODU2MC1jNzBhZjkxMzdjY2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzUwYzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4
-        MGY5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2Ez
-        YzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJkNDg4LyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2It
-        Yjc5YS1mMGFjOTY2MjVkZmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzhmNGMwNDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4
-        Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9m
-        aWxlcy9mNDdhM2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjVhNjQzYmUtODcxZC00NTMwLWFj
+        NDYtMmM5NzI0N2Y0MmZlL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcxYjMyNDQ2LTdjZDEt
+        NDFlMC1iNTBlLWE1YjI0M2ZmZTBkZS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8zOWI0ZTRmNy1kNzdjLTQwNjYtOTJkMC05NTBmZjBl
+        MmJlNjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        YWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYyYWIt
+        NGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdhYi1h
+        NTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQyOTI5
+        My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1ZWE3
+        ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1h
+        ZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFkMTkx
+        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1
+        ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgxNS04
+        OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFj
+        YmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMtNGFjYy05ZTE5LTg0Yjlj
+        NDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUzNC0wZjE0LTRl
+        NDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzY1ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1
+        OGFjNy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjZk
+        MDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3YzU2LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2E3MjQwZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIw
+        ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9m
+        aWxlcy80YWJmNTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19
         XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3588,7 +4013,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3606,21 +4031,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e83899ada4c24827b6e56f0aa72b8ebb
+      - b88c178a6fef43b49db9c16b0a2b8ae1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdjNDFmNjE1LWE5NTUtNDA3
-        MS04NzQwLTA4YjY3NTkzMmIyZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2NDliOGI2LTVmYjYtNDBh
+        MS1hNzdmLTg1NDQyZjMzY2M0Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f6755021-efb7-4f24-b46b-96d523a5a232/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/acaf9702-094d-4886-bf8e-a1cf6ec3e18d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3641,51 +4066,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb17a6cdfba9494caac6093ee3caf350
+      - ff2f94cd1e524dfcbe238dd5762ca456
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjY3NTUwMjEtZWZi
-        Ny00ZjI0LWI0NmItOTZkNTIzYTVhMjMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMjMyNzczWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNhZjk3MDItMDk0
+        ZC00ODg2LWJmOGUtYTFjZjZlYzNlMThkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuMzgxODI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmOTFhNWRjNWE0NGE0NmZiOTUx
-        OWJmYjdkYzY0YTZkOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjI2Njg2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNDEyMTM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhYjJkZWQ3NDcyMjA0MDJlOTg4
+        OGYwNzFkZWJhZjZmOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjIzLjQzMzM5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjMuNjg0NzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1
-        Ni00YzVkLTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2Nk
+        MS00MWUwLWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f6755021-efb7-4f24-b46b-96d523a5a232/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/acaf9702-094d-4886-bf8e-a1cf6ec3e18d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3706,51 +4131,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e2027999a2c45868e8cb7964ddcf0c4
+      - 5046a16e499c418b8c82c5abd624f0f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjY3NTUwMjEtZWZi
-        Ny00ZjI0LWI0NmItOTZkNTIzYTVhMjMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMjMyNzczWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNhZjk3MDItMDk0
+        ZC00ODg2LWJmOGUtYTFjZjZlYzNlMThkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuMzgxODI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmOTFhNWRjNWE0NGE0NmZiOTUx
-        OWJmYjdkYzY0YTZkOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjI2Njg2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNDEyMTM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhYjJkZWQ3NDcyMjA0MDJlOTg4
+        OGYwNzFkZWJhZjZmOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjIzLjQzMzM5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjMuNjg0NzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1
-        Ni00YzVkLTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2Nk
+        MS00MWUwLWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b9a90b19-1204-412b-9190-9e7777892900/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2d71c1b-817a-4d22-af33-45710333673a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3771,53 +4196,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4bcb81822dd34793b4c269e06e5e9fa3
+      - 109b361694fb4df8a020818f2140d3c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '387'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjlhOTBiMTktMTIw
-        NC00MTJiLTkxOTAtOWU3Nzc3ODkyOTAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMjg4OTYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJkNzFjMWItODE3
+        YS00ZDIyLWFmMzMtNDU3MTAzMzM2NzNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuNDcxMjU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0MDdlNDU1MmYyNDk0ODA3OWNl
-        ZDQ1ZWIyZDEwZWYyZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjQ0ODY3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNTgyNDcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0Y2FkY2Q0ZWNiOTc0NmY4YTY4
+        MTY4YmU2NWQ3MmYzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjIzLjc0NzM0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjMuOTU1NzgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZjkzYTdhNi1lZDU2LTRjNWQtOTdkOS04MmQzY2RiYTJhYWIvdmVyc2lv
+        bS83MWIzMjQ0Ni03Y2QxLTQxZTAtYjUwZS1hNWIyNDNmZmUwZGUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1Ni00YzVk
-        LTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2NkMS00MWUw
+        LWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f6755021-efb7-4f24-b46b-96d523a5a232/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/acaf9702-094d-4886-bf8e-a1cf6ec3e18d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3838,51 +4263,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e5cbf03e4654ec1a9d518516618c6f7
+      - d98acff7cd47479eaa343cbd2f54eec4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjY3NTUwMjEtZWZi
-        Ny00ZjI0LWI0NmItOTZkNTIzYTVhMjMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMjMyNzczWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNhZjk3MDItMDk0
+        ZC00ODg2LWJmOGUtYTFjZjZlYzNlMThkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuMzgxODI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmOTFhNWRjNWE0NGE0NmZiOTUx
-        OWJmYjdkYzY0YTZkOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjI2Njg2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNDEyMTM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhYjJkZWQ3NDcyMjA0MDJlOTg4
+        OGYwNzFkZWJhZjZmOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjIzLjQzMzM5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjMuNjg0NzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1
-        Ni00YzVkLTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2Nk
+        MS00MWUwLWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b9a90b19-1204-412b-9190-9e7777892900/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2d71c1b-817a-4d22-af33-45710333673a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3903,53 +4328,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:24 GMT
+      - Fri, 29 Jul 2022 11:34:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fddc8bb5f31243cda071e5dd9479b7c5
+      - 7213feb1a9c24524b1e9c322e38a0f67
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '387'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjlhOTBiMTktMTIw
-        NC00MTJiLTkxOTAtOWU3Nzc3ODkyOTAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMjg4OTYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJkNzFjMWItODE3
+        YS00ZDIyLWFmMzMtNDU3MTAzMzM2NzNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuNDcxMjU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0MDdlNDU1MmYyNDk0ODA3OWNl
-        ZDQ1ZWIyZDEwZWYyZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjQ0ODY3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNTgyNDcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0Y2FkY2Q0ZWNiOTc0NmY4YTY4
+        MTY4YmU2NWQ3MmYzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjIzLjc0NzM0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjMuOTU1NzgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZjkzYTdhNi1lZDU2LTRjNWQtOTdkOS04MmQzY2RiYTJhYWIvdmVyc2lv
+        bS83MWIzMjQ0Ni03Y2QxLTQxZTAtYjUwZS1hNWIyNDNmZmUwZGUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1Ni00YzVk
-        LTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2NkMS00MWUw
+        LWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/771fc6dc-3684-4828-b395-5d1f75a3d440/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e6bec9e4-3a16-43d0-b246-f315c12c262e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3970,53 +4395,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad95c32f14c24835ab9f8b8d55edaf8c
+      - e389cede380346358982251d2157adb6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzcxZmM2ZGMtMzY4
-        NC00ODI4LWIzOTUtNWQxZjc1YTNkNDQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMzM5MTcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTZiZWM5ZTQtM2Ex
+        Ni00M2QwLWIyNDYtZjMxNWMxMmMyNjJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuNTQ5NTEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjZWJhMGZiY2M0MmQ0OGViYTFh
-        N2FiMGZhMjc0Mzg2NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjYxNzIxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNzU0NDk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ZjlhODM5YzdjYzA0MTQ4YWNj
+        ZWY3MjdjMTA1Y2IwYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjI0LjAxMzQ3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjQuMzM0MjI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZjkzYTdhNi1lZDU2LTRjNWQtOTdkOS04MmQzY2RiYTJhYWIvdmVyc2lv
+        bS83MWIzMjQ0Ni03Y2QxLTQxZTAtYjUwZS1hNWIyNDNmZmUwZGUvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1Ni00YzVk
-        LTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2NkMS00MWUw
+        LWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f6755021-efb7-4f24-b46b-96d523a5a232/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/acaf9702-094d-4886-bf8e-a1cf6ec3e18d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4037,51 +4462,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f136f13c7a974a1eb4c7a032c227794d
+      - 9993ce1efeb941e7aa38c1d88013d247
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjY3NTUwMjEtZWZi
-        Ny00ZjI0LWI0NmItOTZkNTIzYTVhMjMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMjMyNzczWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNhZjk3MDItMDk0
+        ZC00ODg2LWJmOGUtYTFjZjZlYzNlMThkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuMzgxODI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmOTFhNWRjNWE0NGE0NmZiOTUx
-        OWJmYjdkYzY0YTZkOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjI2Njg2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNDEyMTM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhYjJkZWQ3NDcyMjA0MDJlOTg4
+        OGYwNzFkZWJhZjZmOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjIzLjQzMzM5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjMuNjg0NzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1
-        Ni00YzVkLTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2Nk
+        MS00MWUwLWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b9a90b19-1204-412b-9190-9e7777892900/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2d71c1b-817a-4d22-af33-45710333673a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4102,53 +4527,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce277c85f1ac46419741560cda048029
+      - dd16187dfa8548dbbe95ed25ed3679e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '387'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjlhOTBiMTktMTIw
-        NC00MTJiLTkxOTAtOWU3Nzc3ODkyOTAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMjg4OTYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJkNzFjMWItODE3
+        YS00ZDIyLWFmMzMtNDU3MTAzMzM2NzNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuNDcxMjU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0MDdlNDU1MmYyNDk0ODA3OWNl
-        ZDQ1ZWIyZDEwZWYyZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjQ0ODY3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNTgyNDcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0Y2FkY2Q0ZWNiOTc0NmY4YTY4
+        MTY4YmU2NWQ3MmYzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjIzLjc0NzM0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjMuOTU1NzgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZjkzYTdhNi1lZDU2LTRjNWQtOTdkOS04MmQzY2RiYTJhYWIvdmVyc2lv
+        bS83MWIzMjQ0Ni03Y2QxLTQxZTAtYjUwZS1hNWIyNDNmZmUwZGUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1Ni00YzVk
-        LTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2NkMS00MWUw
+        LWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/771fc6dc-3684-4828-b395-5d1f75a3d440/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e6bec9e4-3a16-43d0-b246-f315c12c262e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4169,53 +4594,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fe47ab0df8a4435380e10ccbdae1e9fe
+      - d639c7ac9c3e47d087a821b83da23fc2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzcxZmM2ZGMtMzY4
-        NC00ODI4LWIzOTUtNWQxZjc1YTNkNDQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMzM5MTcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTZiZWM5ZTQtM2Ex
+        Ni00M2QwLWIyNDYtZjMxNWMxMmMyNjJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuNTQ5NTEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjZWJhMGZiY2M0MmQ0OGViYTFh
-        N2FiMGZhMjc0Mzg2NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjI0LjYxNzIxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MjQuNzU0NDk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ZjlhODM5YzdjYzA0MTQ4YWNj
+        ZWY3MjdjMTA1Y2IwYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjI0LjAxMzQ3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MjQuMzM0MjI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZjkzYTdhNi1lZDU2LTRjNWQtOTdkOS04MmQzY2RiYTJhYWIvdmVyc2lv
+        bS83MWIzMjQ0Ni03Y2QxLTQxZTAtYjUwZS1hNWIyNDNmZmUwZGUvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1Ni00YzVk
-        LTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0NDYtN2NkMS00MWUw
+        LWI1MGUtYTViMjQzZmZlMGRlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7c41f615-a955-4071-8740-08b675932b2e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5649b8b6-5fb6-40a1-a77f-85442f33cc4b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4236,55 +4661,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8f893d1f41784a7bb8d92fece5f65afe
+      - 41b4a6bd095c4cc7a1ba3ea9dc8eff93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2M0MWY2MTUtYTk1
-        NS00MDcxLTg3NDAtMDhiNjc1OTMyYjJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MjQuMzg5MTcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTY0OWI4YjYtNWZi
+        Ni00MGExLWE3N2YtODU0NDJmMzNjYzRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MjMuNjMwOTYzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiZTgzODk5YWRhNGMyNDgyN2I2ZTU2ZjBhYTcy
-        YjhlYmIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODoyNC43ODUz
-        NDZaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjI1LjI1MDcy
-        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvMGRmMThhZmYtNjRiOC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiYjg4YzE3OGE2ZmVmNDNiNDlkYjljMTZiMGEy
+        YjhhZTEiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDoyNC4zOTUx
+        MjRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjI1LjA1MTYw
+        MFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3
-        YTYtZWQ1Ni00YzVkLTk3ZDktODJkM2NkYmEyYWFiL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFiMzI0
+        NDYtN2NkMS00MWUwLWI1MGUtYTViMjQzZmZlMGRlL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzZmOTNhN2E2LWVkNTYtNGM1ZC05N2Q5LTgy
-        ZDNjZGJhMmFhYi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2I1YzliN2Q2LTFkZWUtNDc0Ny1iY2Q2LTFlNWFkZWJmYzc4
-        Zi8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzcxYjMyNDQ2LTdjZDEtNDFlMC1iNTBlLWE1
+        YjI0M2ZmZTBkZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzY1YTY0M2JlLTg3MWQtNDUzMC1hYzQ2LTJjOTcyNDdmNDJm
+        ZS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4292,7 +4717,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4305,64 +4730,64 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1196'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dfad537e83ee446296e8c77792169094
+      - 2ae5744e25494d72888d8a458d863f1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '429'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTMsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvOWVjYTM4YTItNzhkZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
-        YmIzODQ4Ny05Njc3LTRhNDMtODNlMy00MzkwYjNkMjA1YjQvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIy
-        NTE3MzgtNmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhmNGMw
-        NDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4Zi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yOWU2YTIx
-        ZC0yZjY5LTRjZDItYjcxMS02MWNjODljZjcwY2UvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1MjI4ODAt
-        OGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZh
-        ZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01Yjcx
-        LTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmMyYWU4MmUtYjdhMS00
-        ZDZmLWI2M2QtY2U3MWVmZTU2YzVhLyJ9XX0=
+        L2QxYzc5OWE2LWY3NjYtNDU4Ni1hMTliLTI0YzJmYmUzNzFmYy8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJh
+        NDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVhMzI4
+        NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVjMTBkNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhj
+        MS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVmMmUt
+        YjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEw
+        ZmMtNDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEz
+        LTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00
+        MWQxLWE4ZGYtZmQ4NDNhN2VkNWE4LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4370,7 +4795,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4383,50 +4808,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e12f54310894a94bb667322e69759a0
+      - 32214df09c9e4f6092e842d4ebafbdef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4434,7 +4859,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4447,37 +4872,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6131'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b2c7a05613e4d2ebac84f373df5d3e5
+      - e88be03d49504f5f814e9c1bf818f259
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1830'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4550,9 +4975,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -4569,9 +4994,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -4580,9 +5005,9 @@ http_interactions:
         c29sdXRpb24iOiIiLCJyZWxlYXNlIjoiMSIsInJpZ2h0cyI6IiIsInB1c2hj
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvNjNmYmYwMmEtNDI1OS00M2FlLTlh
-        NzYtMTJiZmI4Nzg5NTZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNU
-        MjM6MjY6NTguMjM4MjM3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
+        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvZWE1ZjA0NjItNjJhYi00YzFmLWE2
+        NGQtYjkxZDA2YzQ1YjZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhU
+        MTU6MDQ6MzQuMjcyMTg0WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
         OSIsInVwZGF0ZWRfZGF0ZSI6IjIwMTgtMDctMjAgMDY6MDA6MDEiLCJkZXNj
         cmlwdGlvbiI6IkR1Y2tfS2FuZ2Fyb19FcnJhdHVtIGRlc2NyaXB0aW9uIiwi
         aXNzdWVkX2RhdGUiOiIyMDE4LTAxLTI3IDE2OjA4OjA5IiwiZnJvbXN0ciI6
@@ -4611,10 +5036,10 @@ http_interactions:
         biI6IjAuNyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3Rl
         ZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4622,7 +5047,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4635,43 +5060,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad48b83a89684d90ba5945ae4f5c5f25
+      - 4247e948bfe4451988f9a866d41e9dc0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4679,7 +5104,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4692,41 +5117,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7b4acf2dff5a4d1c91f212a7ce156ad2
+      - f0d08b03305f47f990f43c28edec214f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4734,7 +5159,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4747,36 +5172,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:25 GMT
+      - Fri, 29 Jul 2022 11:34:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 809ff251c92444ed99aa05f56d0ff5ff
+      - 5d4d9e469db54347b6328eabf17059ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4798,10 +5223,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4809,7 +5234,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4822,64 +5247,64 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:26 GMT
+      - Fri, 29 Jul 2022 11:34:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1196'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ce68062c6b54ffdbe0c34a5c25f41a9
+      - 44c54811d72641fd8da1848297755249
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '429'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTMsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvOWVjYTM4YTItNzhkZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
-        YmIzODQ4Ny05Njc3LTRhNDMtODNlMy00MzkwYjNkMjA1YjQvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIy
-        NTE3MzgtNmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhmNGMw
-        NDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4Zi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yOWU2YTIx
-        ZC0yZjY5LTRjZDItYjcxMS02MWNjODljZjcwY2UvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1MjI4ODAt
-        OGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZh
-        ZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01Yjcx
-        LTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmMyYWU4MmUtYjdhMS00
-        ZDZmLWI2M2QtY2U3MWVmZTU2YzVhLyJ9XX0=
+        L2QxYzc5OWE2LWY3NjYtNDU4Ni1hMTliLTI0YzJmYmUzNzFmYy8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJh
+        NDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVhMzI4
+        NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVjMTBkNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhj
+        MS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVmMmUt
+        YjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEw
+        ZmMtNDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEz
+        LTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00
+        MWQxLWE4ZGYtZmQ4NDNhN2VkNWE4LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4887,7 +5312,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4900,50 +5325,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:26 GMT
+      - Fri, 29 Jul 2022 11:34:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3534bed88437444d8df0e74eedd434dd
+      - f768a257ec1b41858eeb4584f240a0ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4951,7 +5376,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4964,37 +5389,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:26 GMT
+      - Fri, 29 Jul 2022 11:34:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6131'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10cfd057e414424abc466d81b29e13cc
+      - f43a4fcbf0d84adfbf4fce53868708ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1830'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -5067,9 +5492,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -5086,9 +5511,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -5097,9 +5522,9 @@ http_interactions:
         c29sdXRpb24iOiIiLCJyZWxlYXNlIjoiMSIsInJpZ2h0cyI6IiIsInB1c2hj
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvNjNmYmYwMmEtNDI1OS00M2FlLTlh
-        NzYtMTJiZmI4Nzg5NTZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNU
-        MjM6MjY6NTguMjM4MjM3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
+        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvZWE1ZjA0NjItNjJhYi00YzFmLWE2
+        NGQtYjkxZDA2YzQ1YjZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhU
+        MTU6MDQ6MzQuMjcyMTg0WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
         OSIsInVwZGF0ZWRfZGF0ZSI6IjIwMTgtMDctMjAgMDY6MDA6MDEiLCJkZXNj
         cmlwdGlvbiI6IkR1Y2tfS2FuZ2Fyb19FcnJhdHVtIGRlc2NyaXB0aW9uIiwi
         aXNzdWVkX2RhdGUiOiIyMDE4LTAxLTI3IDE2OjA4OjA5IiwiZnJvbXN0ciI6
@@ -5128,10 +5553,10 @@ http_interactions:
         biI6IjAuNyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3Rl
         ZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5139,7 +5564,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5152,43 +5577,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:26 GMT
+      - Fri, 29 Jul 2022 11:34:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1fbf8f3853154dee8d9032f320cb5b08
+      - 6d462fbd251e4bc3b824f2e39969d132
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5196,7 +5621,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5209,41 +5634,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:26 GMT
+      - Fri, 29 Jul 2022 11:34:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '091db4909d1f4398a9dce3f721194af3'
+      - 77cfda32392c42c6ad734047d135a239
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/71b32446-7cd1-41e0-b50e-a5b243ffe0de/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5251,7 +5676,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5264,36 +5689,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:26 GMT
+      - Fri, 29 Jul 2022 11:34:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4fa244ec0fcc49c9ae8a4198057d7d74
+      - 51a46e2efb32494bb605febe01418976
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5315,5 +5740,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:26 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_errata_repository/proper_errata_copied_if_no_errata_packages_matches_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_errata_repository/proper_errata_copied_if_no_errata_packages_matches_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:04 GMT
+      - Fri, 29 Jul 2022 11:34:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - df4e34deac1c426a8214372feade40f4
+      - b59c4d3c25374b02814db8fbfdcba0c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iMDk0MmQwNi0zZTNiLTQ1N2UtODc4Yi1iZmY2MzMwMWVmMzcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNzo1Ny44MTIzODNa
+        cnBtL3JwbS9kYmYxNzBlMi1kYjVhLTRmN2ItOWZmMy01OGE2Yzg5MGJlNmMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMzo0OS4yMTA1NTha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iMDk0MmQwNi0zZTNiLTQ1N2UtODc4Yi1iZmY2MzMwMWVmMzcv
+        cnBtL3JwbS9kYmYxNzBlMi1kYjVhLTRmN2ItOWZmMy01OGE2Yzg5MGJlNmMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IwOTQy
-        ZDA2LTNlM2ItNDU3ZS04NzhiLWJmZjYzMzAxZWYzNy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2RiZjE3
+        MGUyLWRiNWEtNGY3Yi05ZmYzLTU4YTZjODkwYmU2Yy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:01 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b0942d06-3e3b-457e-878b-bff63301ef37/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:04 GMT
+      - Fri, 29 Jul 2022 11:34:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 97318e9712444bacb9af568a09756340
+      - d14e1b6abbc34519a9e9671a099e43dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2ZjBkOTViLTM5ZjctNGVi
-        NC1hMmM5LTdlYTAyYmQ4ZWZmMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UwZGRjYTIxLWViNjUtNDA0
+        OC05ZDA5LTBjMTY0NWViNzNjYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:04 GMT
+      - Fri, 29 Jul 2022 11:34:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3887070171964ec6b4efa4f9c985c3f9
+      - e70b589742484966beed1e8e2589cf0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/96f0d95b-39f7-4eb4-a2c9-7ea02bd8eff0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e0ddca21-eb65-4048-9d09-0c1645eb73cb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:04 GMT
+      - Fri, 29 Jul 2022 11:34:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96777cb0f87f40b2bd757d31396cc58a
+      - 2fab1924ab2f47c2ae773040d94875fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTZmMGQ5NWItMzlm
-        Ny00ZWI0LWEyYzktN2VhMDJiZDhlZmYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDQuNjY0MzY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTBkZGNhMjEtZWI2
+        NS00MDQ4LTlkMDktMGMxNjQ1ZWI3M2NiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MDEuOTE5NTY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NzMxOGU5NzEyNDQ0YmFjYjlhZjU2OGEw
-        OTc1NjM0MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjA0LjY5
-        NjIwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MDQuODIy
-        NTA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkMTRlMWI2YWJiYzM0NTE5YTllOTY3MWEw
+        OTllNDNkYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjAxLjk3
+        NTU4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MDIuMTg4
+        NzQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjA5NDJkMDYtM2UzYi00NTdl
-        LTg3OGItYmZmNjMzMDFlZjM3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGJmMTcwZTItZGI1YS00Zjdi
+        LTlmZjMtNThhNmM4OTBiZTZjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:04 GMT
+      - Fri, 29 Jul 2022 11:34:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a00e4e41ad7b4d1baac67ed80a4d55a7
+      - 5bc6ba64f1bd4bca8d055ca00f4c0f49
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:04 GMT
+      - Fri, 29 Jul 2022 11:34:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b7c84e6ce12473b9935c672cdf51d26
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZjE2NjFmNTgtYzBlMi00MGJmLTg0YTgtMGYyZjlmMmJmZTY1
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6NTQuMjk2Mjc3
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/f1661f58-c0e2-40bf-84a8-0f2f9f2bfe65/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d299c91a64104217a4df57b05fb1c2c6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5MDU1NmE1LWQwNTUtNDAz
+        Ni05NGFlLTAwOTlhOTU1NmU2MC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a90556a5-d055-4036-94ae-0099a9556e60/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4a8b3695fe8d4c3885fcbafec5feb871
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTkwNTU2YTUtZDA1
+        NS00MDM2LTk0YWUtMDA5OWE5NTU2ZTYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MDIuMzY1ODM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkMjk5YzkxYTY0MTA0MjE3YTRkZjU3YjA1
+        ZmIxYzJjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjAyLjQw
+        OTEwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MDIuNDU3
+        Mzk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b9fc7149198448db90952b21fb56124
+      - 46a3a13679754be5a67e1020d639c2ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9ea2c87bcfd74387a398d1b4187f2876
+      - 378f4ecd9f1541ae85900f55aefb24fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e5488db383d94dd9ac3b18af334c51a6
+      - 9be7fc9746774d93b2b844a2fb1160ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff8e1c6cd0a8447c94bb4f3b87604fd2
+      - 15593b7982514ae59b103d06736de81a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:28:05 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - cae2546c3d644bedbbdde1bc3d804a34
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/7433f742-2767-44b3-861b-872b0984cdd4/"
+      - "/pulp/api/v3/remotes/rpm/rpm/bb808ec7-d7ac-462a-88bd-8b62c38c8a88/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f40710fc8284a3cb189131f152cbdf4
+      - 6509cd1a5d044c9ebb1429c28181d618
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc0
-        MzNmNzQyLTI3NjctNDRiMy04NjFiLTg3MmIwOTg0Y2RkNC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjA1LjIxMjk0NVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Ji
+        ODA4ZWM3LWQ3YWMtNDYyYS04OGJkLThiNjJjMzhjOGE4OC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjAyLjc0MzIyN1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI4OjA1LjIxMjk2NFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjM0OjAyLjc0MzI0OFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/"
+      - "/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41d81c033a8445dea2fc36ae775fd2d7
+      - bc3c80204a3846c29f343755a111f30d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOWYwZWEwZDYtY2FiZS00NWQwLWEyNjUtODBmN2ZmNzJkZDM2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MDUuMzI4NTc4WiIsInZl
+        cG0vNDI5ZDkzZWItMjZkYy00MDU2LTk0OTYtMjM5ZjVjZmZhYjlmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MDIuODk0NzYxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOWYwZWEwZDYtY2FiZS00NWQwLWEyNjUtODBmN2ZmNzJkZDM2L3ZlcnNp
+        cG0vNDI5ZDkzZWItMjZkYy00MDU2LTk0OTYtMjM5ZjVjZmZhYjlmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85ZjBlYTBkNi1j
-        YWJlLTQ1ZDAtYTI2NS04MGY3ZmY3MmRkMzYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80MjlkOTNlYi0y
+        NmRjLTQwNTYtOTQ5Ni0yMzlmNWNmZmFiOWYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8186c25109e64425afefc37390baf17f
+      - 44d765d511e64a26a49e4186cf877b21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lYTAxOTIzYy1lYzQ1LTQ3NWQtODg3NC04NmYyMmQ5MzQ5N2Mv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNzo1OC41MTQzNzRa
+        cnBtL3JwbS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMzo1MC42NjY3OTVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lYTAxOTIzYy1lYzQ1LTQ3NWQtODg3NC04NmYyMmQ5MzQ5N2Mv
+        cnBtL3JwbS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2VhMDE5
-        MjNjLWVjNDUtNDc1ZC04ODc0LTg2ZjIyZDkzNDk3Yy92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UzNTQx
+        OThhLWIyYmMtNDA2My04YWRmLTNlZjMyYzVlZTQ5Mi92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ea01923c-ec45-475d-8874-86f22d93497c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1dbf7aeb2a124929b1bc3db559f68b55
+      - bf0feaf0973c454090c5a3c1d60f2777
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViODdkNDIwLWJjY2ItNDBi
-        OS1hMDkzLTYxMjM1NWExNzU4NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UwNmNkOTUyLTVhNzMtNDc1
+        Ny04ZjRjLWUyN2FkNWE5MmRlNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1edd46d97af74634a535c1870e2eb7a3
+      - b34e4dd6587e4c3d97537977b44f0035
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '368'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYTZiMGM4MTMtODJhZS00MzNiLTg4MzktNjViNjkwN2ZhYTkzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6NTcuNjU0NDc3WiIsIm5h
+        cG0vYzA2NWJjZTAtZjg1MC00MWYzLThmNzMtM2Y4MDY1YzVmNGI0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6NDkuMDM4NzczWiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyNzo1OC44NDczNDhaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozMzo1MS4xOTc2ODlaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a6b0c813-82ae-433b-8839-65b6907faa93/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c065bce0-f850-41f3-8f73-3f8065c5f4b4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68baf5e94bad47589c89690c4f41561e
+      - 0cbe2fb529fa489a83feaa7900d51180
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkYTM1Njc1LWY5ZDYtNDli
-        YS1iZDRhLTQzYTVhMjA1NDUzNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwOGEzZmE2LWU5MTAtNDcx
+        Mi1hMTYxLTUxMjMwYTk5M2E4My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/eb87d420-bccb-40b9-a093-612355a17585/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e06cd952-5a73-4757-8f4c-e27ad5a92de5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 18d6881648bf43569eed20cdffd91cb7
+      - af2059a6681b40f3a44d57502d850f09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWI4N2Q0MjAtYmNj
-        Yi00MGI5LWEwOTMtNjEyMzU1YTE3NTg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDUuNDg0OTY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTA2Y2Q5NTItNWE3
+        My00NzU3LThmNGMtZTI3YWQ1YTkyZGU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MDMuMTI0NTc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxZGJmN2FlYjJhMTI0OTI5YjFiYzNkYjU1
-        OWY2OGI1NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjA1LjUx
-        NjQ5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MDUuNTc3
-        OTg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZjBmZWFmMDk3M2M0NTQwOTBjNWEzYzFk
+        NjBmMjc3NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjAzLjE3
+        Nzg2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MDMuMzE0
+        NzUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWEwMTkyM2MtZWM0NS00NzVk
-        LTg4NzQtODZmMjJkOTM0OTdjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJiYy00MDYz
+        LThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6da35675-f9d6-49ba-bd4a-43a5a2054537/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a08a3fa6-e910-4712-a161-51230a993a83/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 982107f67bbd467abf8ff59f5dc75f2b
+      - 30edbaca930045aca7e82714cdb3af76
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmRhMzU2NzUtZjlk
-        Ni00OWJhLWJkNGEtNDNhNWEyMDU0NTM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDUuNTc2NjcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTA4YTNmYTYtZTkx
+        MC00NzEyLWExNjEtNTEyMzBhOTkzYTgzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MDMuMjg0NTA0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2OGJhZjVlOTRiYWQ0NzU4OWM4OTY5MGM0
-        ZjQxNTYxZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjA1LjYx
-        MjA4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MDUuNjU3
-        MDk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwY2JlMmZiNTI5ZmE0ODlhODNmZWFhNzkw
+        MGQ1MTE4MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjAzLjM1
+        ODI4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MDMuNDM1
+        Njc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E2YjBjODEzLTgyYWUtNDMzYi04ODM5
-        LTY1YjY5MDdmYWE5My8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MwNjViY2UwLWY4NTAtNDFmMy04Zjcz
+        LTNmODA2NWM1ZjRiNC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dbdcdbedfd144bc5b040474789cda653
+      - dfffb22597db4f33aa7222f2a61b062b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86b64485ac8347e09fd97f2c9782d17d
+      - 243ace0e3c1343b68429500b2b4aff96
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b9bbb456f5d741aca92e7196f5199f7d
+      - 57ebfaa9242e46989ba0f6edc5c18ad4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4264cd16194448518462346cc02f0cb1
+      - bd18b5d47c314707ada9fc3d11e7154b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8c0890449ab34bdc87b157d3945ef106
+      - 662c3b8da52343b0b04b5f2dfc5595ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:05 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a23bdbd21d34b5e8b3debc284d2e1ee
+      - bb6e0735025a4ed4919c152258a73e21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:06 GMT
+      - Fri, 29 Jul 2022 11:34:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/"
+      - "/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25c237e8d123469cbba341e4e18fc12b
+      - ae6e3d5bb8be428b948e66932ce440e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmU4ZjIwYjktOGUyMS00ZTM5LWEwYmQtNjJjNGRkYTg5YjQ5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MDYuMDM0NzM0WiIsInZl
+        cG0vNTdmNGM2OTAtMTNhMi00YTlhLWJiNzMtMWY1Y2RjNWE0OTBjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MDMuOTM2MzU5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNmU4ZjIwYjktOGUyMS00ZTM5LWEwYmQtNjJjNGRkYTg5YjQ5L3ZlcnNp
+        cG0vNTdmNGM2OTAtMTNhMi00YTlhLWJiNzMtMWY1Y2RjNWE0OTBjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82ZThmMjBiOS04
-        ZTIxLTRlMzktYTBiZC02MmM0ZGRhODliNDkvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81N2Y0YzY5MC0x
+        M2EyLTRhOWEtYmI3My0xZjVjZGM1YTQ5MGMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:03 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/7433f742-2767-44b3-861b-872b0984cdd4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/bb808ec7-d7ac-462a-88bd-8b62c38c8a88/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:06 GMT
+      - Fri, 29 Jul 2022 11:34:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed384bc688a94111ad90c2068f214129
+      - eda9ee579ac2438f9dbff270eb76d9e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4YTIwY2E5LWNhMzktNGYz
-        YS04MDc4LWRkZDI2NDlhOTI4ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmYTU1MTQyLTEzMjItNDZm
+        MC1hZjNlLTg5NzdkYTYwODc4Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/58a20ca9-ca39-4f3a-8078-ddd2649a928e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8fa55142-1322-46f0-af3e-8977da60878b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:06 GMT
+      - Fri, 29 Jul 2022 11:34:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 884981a140f74e678a51df7f30a026d0
+      - '0392bffe04d148d1870c31bcd3b1e4dd'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNThhMjBjYTktY2Ez
-        OS00ZjNhLTgwNzgtZGRkMjY0OWE5MjhlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDYuMzEzMzk0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGZhNTUxNDItMTMy
+        Mi00NmYwLWFmM2UtODk3N2RhNjA4NzhiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MDQuMzExMDAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJlZDM4NGJjNjg4YTk0MTExYWQ5MGMyMDY4
-        ZjIxNDEyOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjA2LjM0
-        MzcxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MDYuMzY2
-        NDk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlZGE5ZWU1NzlhYzI0MzhmOWRiZmYyNzBl
+        Yjc2ZDllNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjA0LjM4
+        MDcyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MDQuNDE0
+        ODgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc0MzNmNzQyLTI3NjctNDRiMy04NjFi
-        LTg3MmIwOTg0Y2RkNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JiODA4ZWM3LWQ3YWMtNDYyYS04OGJk
+        LThiNjJjMzhjOGE4OC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc0MzNm
-        NzQyLTI3NjctNDRiMy04NjFiLTg3MmIwOTg0Y2RkNC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JiODA4
+        ZWM3LWQ3YWMtNDYyYS04OGJkLThiNjJjMzhjOGE4OC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:06 GMT
+      - Fri, 29 Jul 2022 11:34:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58db83d96ffc46b0943a13f974e5f0a0
+      - f51dd6e54bc44093a6981c3dd45ba511
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2NzliYzg5LWJiNmEtNDEw
-        Ny04YjAyLWI1ZTZhY2QzNmU5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhNzY5MmRkLTk0MTQtNDM3
+        OS1iMDA4LTUzNTdkOTgzM2QyZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8679bc89-bb6a-4107-8b02-b5e6acd36e99/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2a7692dd-9414-4379-b008-5357d9833d2d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:07 GMT
+      - Fri, 29 Jul 2022 11:34:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2e08541ea2314481be8bcabc905abdeb
+      - dd6d701b36404008a0718f946918c477
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '656'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODY3OWJjODktYmI2
-        YS00MTA3LThiMDItYjVlNmFjZDM2ZTk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDYuNDk3NDMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmE3NjkyZGQtOTQx
+        NC00Mzc5LWIwMDgtNTM1N2Q5ODMzZDJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MDQuNTkyMDIxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI1OGRiODNkOTZmZmM0NmIwOTQz
-        YTEzZjk3NGU1ZjBhMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA2LjUyODQyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDcuMjgzNzA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmNTFkZDZlNTRiYzQ0MDkzYTY5
+        ODFjM2RkNDViYTUxMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjA0LjY1MDU5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MDYuMTE1MDMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzlmMGVhMGQ2LWNhYmUtNDVkMC1hMjY1LTgwZjdm
-        ZjcyZGQzNi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85ZjBl
-        YTBkNi1jYWJlLTQ1ZDAtYTI2NS04MGY3ZmY3MmRkMzYvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNzQzM2Y3NDItMjc2Ny00NGIz
-        LTg2MWItODcyYjA5ODRjZGQ0LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS80MjlkOTNlYi0yNmRjLTQwNTYtOTQ5Ni0yMzlmNWNm
+        ZmFiOWYvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDI5ZDkz
+        ZWItMjZkYy00MDU2LTk0OTYtMjM5ZjVjZmZhYjlmLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JiODA4ZWM3LWQ3YWMtNDYyYS04
+        OGJkLThiNjJjMzhjOGE4OC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOWYwZWEwZDYtY2FiZS00NWQwLWEyNjUtODBmN2ZmNzJk
-        ZDM2L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNDI5ZDkzZWItMjZkYy00MDU2LTk0OTYtMjM5ZjVjZmZh
+        YjlmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:07 GMT
+      - Fri, 29 Jul 2022 11:34:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 45b699441f124aebbc159c085ada0854
+      - 35136c914ab943aaac395f00ce701736
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2ZmI3YTA2LTdlMGYtNDRl
-        Mi1iZDk1LWNlMjVhMjAyZWZkOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg1MjFhODZiLTUzMzUtNGJk
+        MC1iZTI4LTkyYjc4YzViZjE3MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/16fb7a06-7e0f-44e2-bd95-ce25a202efd8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8521a86b-5335-4bd0-be28-92b78c5bf171/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:08 GMT
+      - Fri, 29 Jul 2022 11:34:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c0a5cfc8f2aa4d37a4d8dee3d4fffdec
+      - 4aa2c81d4f0d4331866ba4f37fc5bc0d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTZmYjdhMDYtN2Uw
-        Zi00NGUyLWJkOTUtY2UyNWEyMDJlZmQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDcuNTk1MzEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODUyMWE4NmItNTMz
+        NS00YmQwLWJlMjgtOTJiNzhjNWJmMTcxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MDYuODgyODgwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjQ1YjY5OTQ0MWYxMjRhZWJiYzE1OWMwODVh
-        ZGEwODU0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6MDcuNjQ2
-        OTkxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODowNy45OTAz
-        MDdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjM1MTM2YzkxNGFiOTQzYWFhYzM5NWYwMGNl
+        NzAxNzM2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MDYuOTUx
+        MDg3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDowNy4zODA0
+        NDdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTk2NmQx
-        NzktNGIzMy00N2MyLTg5ODYtOGUyMGZmMDYxY2E1LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTlkMjUw
+        OWItNTNhMS00ZDdlLThhOGYtZTgxZmY1YWU0Yjk4LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOWYwZWEwZDYtY2FiZS00NWQwLWEyNjUtODBmN2Zm
-        NzJkZDM2LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNDI5ZDkzZWItMjZkYy00MDU2LTk0OTYtMjM5ZjVj
+        ZmZhYjlmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:08 GMT
+      - Fri, 29 Jul 2022 11:34:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 30a6f958318e4773b37de04f252fe9d0
+      - 7e60b4883f5f45d2ae7573eaa75192ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/19d2509b-53a1-4d7e-8a8f-e81ff5ae4b98/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 596c0df905f941dda5e4aa146e20a286
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMTlkMjUwOWItNTNhMS00ZDdlLThhOGYtZTgxZmY1YWU0Yjk4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6MDYuOTgxNTQxWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80MjlkOTNlYi0yNmRjLTQwNTYtOTQ5Ni0yMzlmNWNmZmFiOWYv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzQyOWQ5M2ViLTI2ZGMtNDA1Ni05NDk2LTIzOWY1
+        Y2ZmYWI5Zi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:07 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8xOWQyNTA5Yi01M2ExLTRkN2UtOGE4Zi1lODFmZjVhZTRiOTgv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - dd470e7658c842e89d05ed95ed60b33f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2ZDJmNGRhLWM4MTUtNGM5
+        MC1hN2E1LWI4NzI1YWJjM2FhOC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/96d2f4da-c815-4c90-a7a5-b8725abc3aa8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5ae3924062ad4f0ca81771302442926a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTZkMmY0ZGEtYzgx
+        NS00YzkwLWE3YTUtYjg3MjVhYmMzYWE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MDcuNjU4NjUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkZDQ3MGU3NjU4Yzg0MmU4OWQwNWVkOTVl
+        ZDYwYjMzZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjA3Ljcx
+        NTMyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6MDcuOTc0
+        NzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZjZk
+        NzA4NWQtZDk0YS00ZTQzLTg2NGItZjM0OTc5NDk5MWFkLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/f6d7085d-d94a-4e43-864b-f349794991ad/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c1ab6226b23f4e2faed5c556575c14a6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2Y2ZDcwODVkLWQ5NGEtNGU0My04NjRiLWYzNDk3OTQ5OTFhZC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjA3Ljk1MzU5NFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMTlkMjUwOWItNTNhMS00ZDdlLThhOGYt
+        ZTgxZmY1YWU0Yjk4LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b53f9b518a574b23805fb2438b074a6b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:08 GMT
+      - Fri, 29 Jul 2022 11:34:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 259bca03675c45f8a2466496bdff9e99
+      - 65b4faff136841b087b44a4276b23ddd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:08 GMT
+      - Fri, 29 Jul 2022 11:34:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e634569d10b4ae3bc0e4ed34523810f
+      - dc3f551b281544fcbef5b70b9d287b53
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:08 GMT
+      - Fri, 29 Jul 2022 11:34:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8952a2c244a495b84f8eed9e3399d44
+      - 7591e3dc12544b6889db17aabbbcfe96
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:08 GMT
+      - Fri, 29 Jul 2022 11:34:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db5364ce4ace46679d085eec6e5b2016
+      - 57bb6344acce44ab863b7ae28fffdf99
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:08 GMT
+      - Fri, 29 Jul 2022 11:34:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 364486462e1a404bad9b3370e021b671
+      - 3fb8501cba204a19aac300c959be879b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d88c7760dfbe40318ec3310a6e3a2c68
+      - 30236e9bbbe0480da4fec42259d27cde
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8ccd0881455e46e79ebeb6039a5e876e
+      - 3ce915647f974bc08cfd257f4c41dd80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08eee242069847b5a80514316b892e9d'
+      - a0ab1ecdadb7440bb3b214cc9e7cd1d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49856bfc93384d569dce2a3cf7b381ab
+      - 7c263cc488984208a7246bb81dac9a66
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3128eb0fc5f443ef9d7004ae9042b33c
+      - 5c2ba0763e184939a77b1abf7fd39314
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95dbfe769c424f52813f20ba20221508
+      - de040da4500447d7ace48051ea2a9878
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4bb5078126444ed7b0660c73724fdc20
+      - a4f4b5ac451640288004968ed0d3e4a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9f0ea0d6-cabe-45d0-a265-80f7ff72dd36/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/429d93eb-26dc-4056-9496-239f5cffab9f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5035c768f9d74df0a2a1245cf7fa53d6
+      - 6be831d0837b4299acad6d88210df56c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9df53cbe6834a6aa1b7441d8e2b3be2
+      - ca1e3322e82f4e1a8898d312cda1f860
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiOWY4ZmUwLTkzYjktNDgz
-        Ny04NzliLWUwYTg3NDlhZjNlNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhNjk3MDMwLTAyMmMtNDM5
+        NC05ZWQ2LWY0M2Y4YWRiZDA3Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49e9616aa0c745baae366a5cd5f69971
+      - da5b070ff39c4b969d655f672c683575
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiMTQ1ODg5LTJkN2MtNDIw
-        Ny04ZmMzLWI0MDAxMjNiNzc3Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5NzliNjg4LWRiNzctNDdi
+        MC04OWQ0LTkxZjg2ODM0OGRkMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,49 +3935,49 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6206e309855146a6be6cefeb93ec5852
+      - 8a4aab2b85984ad493f0abd53f61514f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IwN2FlYzJlLTIxNmItNDZm
-        ZC1hYTQwLTUxZTcxNDIwNjBhZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlODhiYmMxLTNkZDQtNDFi
+        OC05MDFhLTBiNGI2Y2ViYjAyZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWYwZWEwZDYtY2FiZS00NWQwLWEy
-        NjUtODBmN2ZmNzJkZDM2L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZlOGYyMGI5LThlMjEt
-        NGUzOS1hMGJkLTYyYzRkZGE4OWI0OS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        ZjE3ODkzMDgtZDIzZC00NDgwLThmMjEtMmM5MjAxMDcxM2Y3LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvNTg5Nzkw
-        OTktNTZjZS00MTVkLWI4NzMtMjE0YTczNTZkMTAwLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3
-        Yi1hYzcxLTZiMmM4NmFkOGRiYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNDk0M2QxOWQtYzU1Mi00NWQyLTg1NjAtYzcwYWY5MTM3
-        Y2NjLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJh
-        ZTgyZS1iN2ExLTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZjQ3YTNmZTYt
-        MmM0Ni00M2VkLWJlZjQtZDMxMjQ0MTFiZDI0LyJdfV0sImRlcGVuZGVuY3lf
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDI5ZDkzZWItMjZkYy00MDU2LTk0
+        OTYtMjM5ZjVjZmZhYjlmL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU3ZjRjNjkwLTEzYTIt
+        NGE5YS1iYjczLTFmNWNkYzVhNDkwYy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8zOWI0ZTRmNy1kNzdjLTQwNjYtOTJkMC05NTBmZjBl
+        MmJlNjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        YWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvNGYyNTJl
+        Y2UtMzE5NS00N2FiLWE1NjctZTljZGRkZDUwYTIzLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFj
+        Mi1hNDAwLTM5ZWUxOTNmOTIwYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5
+        YjBlLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5
+        NTdiMS1jOTEyLTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2Yt
+        YjljMC00MjMxLTg3ZDItZTEzMDNiZmRmYTVmLyJdfV0sImRlcGVuZGVuY3lf
         c29sdmluZyI6ZmFsc2V9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3565,7 +3990,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3583,21 +4008,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2cdccd343f0246779fba6c99a54578b8
+      - fe16d528046b4298b7359cf5e2e74a82
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg1OGQyNmE0LWNkYTAtNDkz
-        Ny1hZTk0LTRkZmUzNTM4YmExZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0ZWYwMTBjLThhMmQtNGQ1
+        MC04ZWFjLThhZWFiMzUyZDBkYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8b9f8fe0-93b9-4837-879b-e0a8749af3e4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5a697030-022c-4394-9ed6-f43f8adbd077/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3618,51 +4043,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1c81503f0d6642238fe5d402aa230d91
+      - 732cb676f36840dfb4c02fae8b2d57ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGI5ZjhmZTAtOTNi
-        OS00ODM3LTg3OWItZTBhODc0OWFmM2U0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNDMxMjg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWE2OTcwMzAtMDIy
+        Yy00Mzk0LTllZDYtZjQzZjhhZGJkMDc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMTgyNDczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWRmNTNjYmU2ODM0YTZhYTFi
-        NzQ0MWQ4ZTJiM2JlMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5LjQ2NDUzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuNTk4ODMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjYTFlMzMyMmU4MmY0ZTFhODg5
+        OGQzMTJjZGExZjg2MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjIyODE4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTAuNDc2NDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUy
-        MS00ZTM5LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNh
+        Mi00YTlhLWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8b9f8fe0-93b9-4837-879b-e0a8749af3e4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5a697030-022c-4394-9ed6-f43f8adbd077/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3683,51 +4108,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 82eb0d17e980496caf7e4293f3a94996
+      - ca0478978f6a41d8bc0277c4b02f51c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGI5ZjhmZTAtOTNi
-        OS00ODM3LTg3OWItZTBhODc0OWFmM2U0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNDMxMjg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWE2OTcwMzAtMDIy
+        Yy00Mzk0LTllZDYtZjQzZjhhZGJkMDc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMTgyNDczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWRmNTNjYmU2ODM0YTZhYTFi
-        NzQ0MWQ4ZTJiM2JlMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5LjQ2NDUzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuNTk4ODMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjYTFlMzMyMmU4MmY0ZTFhODg5
+        OGQzMTJjZGExZjg2MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjIyODE4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTAuNDc2NDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUy
-        MS00ZTM5LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNh
+        Mi00YTlhLWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b145889-2d7c-4207-8fc3-b400123b7776/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7979b688-db77-47b0-89d4-91f868348dd0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3748,53 +4173,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:09 GMT
+      - Fri, 29 Jul 2022 11:34:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c6eb1a2b4e8843fb89e9a2853226ec45
+      - e4b71c82c54e4e76b40d1108abbe5c85
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIxNDU4ODktMmQ3
-        Yy00MjA3LThmYzMtYjQwMDEyM2I3Nzc2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNDgzMDkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzk3OWI2ODgtZGI3
+        Ny00N2IwLTg5ZDQtOTFmODY4MzQ4ZGQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMjU2NjY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0OWU5NjE2YWEwYzc0NWJhYWUz
-        NjZhNWNkNWY2OTk3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5LjYzMDEyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuNzYxOTE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkYTViMDcwZmYzOWM0Yjk2OWQ2
+        NTVmNjcyYzY4MzU3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjU3NDM0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTAuODExMzc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZThmMjBiOS04ZTIxLTRlMzktYTBiZC02MmM0ZGRhODliNDkvdmVyc2lv
+        bS81N2Y0YzY5MC0xM2EyLTRhOWEtYmI3My0xZjVjZGM1YTQ5MGMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUyMS00ZTM5
-        LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNhMi00YTlh
+        LWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8b9f8fe0-93b9-4837-879b-e0a8749af3e4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5a697030-022c-4394-9ed6-f43f8adbd077/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3815,51 +4240,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 36dd506547fa40b6aaf164c0531554d9
+      - fccd1cc2b5684d6c841e2a5ef9a33dda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGI5ZjhmZTAtOTNi
-        OS00ODM3LTg3OWItZTBhODc0OWFmM2U0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNDMxMjg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWE2OTcwMzAtMDIy
+        Yy00Mzk0LTllZDYtZjQzZjhhZGJkMDc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMTgyNDczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWRmNTNjYmU2ODM0YTZhYTFi
-        NzQ0MWQ4ZTJiM2JlMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5LjQ2NDUzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuNTk4ODMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjYTFlMzMyMmU4MmY0ZTFhODg5
+        OGQzMTJjZGExZjg2MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjIyODE4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTAuNDc2NDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUy
-        MS00ZTM5LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNh
+        Mi00YTlhLWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b145889-2d7c-4207-8fc3-b400123b7776/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7979b688-db77-47b0-89d4-91f868348dd0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3880,53 +4305,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b97a55806ed468498c45688e112f87e
+      - 41168e04be18480b8aed9cbf290ec3d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIxNDU4ODktMmQ3
-        Yy00MjA3LThmYzMtYjQwMDEyM2I3Nzc2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNDgzMDkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzk3OWI2ODgtZGI3
+        Ny00N2IwLTg5ZDQtOTFmODY4MzQ4ZGQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMjU2NjY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0OWU5NjE2YWEwYzc0NWJhYWUz
-        NjZhNWNkNWY2OTk3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5LjYzMDEyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuNzYxOTE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkYTViMDcwZmYzOWM0Yjk2OWQ2
+        NTVmNjcyYzY4MzU3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjU3NDM0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTAuODExMzc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZThmMjBiOS04ZTIxLTRlMzktYTBiZC02MmM0ZGRhODliNDkvdmVyc2lv
+        bS81N2Y0YzY5MC0xM2EyLTRhOWEtYmI3My0xZjVjZGM1YTQ5MGMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUyMS00ZTM5
-        LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNhMi00YTlh
+        LWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b07aec2e-216b-46fd-aa40-51e7142060ad/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ee88bbc1-3dd4-41b8-901a-0b4b6cebb02f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3947,53 +4372,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1e1483fe8834a6890acc540cad91761
+      - 425197317b47486eb6b0a76e1def360e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '387'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjA3YWVjMmUtMjE2
-        Yi00NmZkLWFhNDAtNTFlNzE0MjA2MGFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNTM0MzY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWU4OGJiYzEtM2Rk
+        NC00MWI4LTkwMWEtMGI0YjZjZWJiMDJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMzI1MzUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2MjA2ZTMwOTg1NTE0NmE2YmU2
-        Y2VmZWI5M2VjNTg1MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5Ljc5MzE3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuOTMwMzkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4YTRhYWIyYjg1OTg0YWQ0OTNm
+        MGFiZDUzZjYxNTE0ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjg2MTIzOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTEuMTE3MjM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZThmMjBiOS04ZTIxLTRlMzktYTBiZC02MmM0ZGRhODliNDkvdmVyc2lv
+        bS81N2Y0YzY5MC0xM2EyLTRhOWEtYmI3My0xZjVjZGM1YTQ5MGMvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUyMS00ZTM5
-        LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNhMi00YTlh
+        LWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8b9f8fe0-93b9-4837-879b-e0a8749af3e4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5a697030-022c-4394-9ed6-f43f8adbd077/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4014,51 +4439,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1239ce789fb641e3bdbafc9843640e8f
+      - 55d571c990e84ebaaaec727ed6aab119
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGI5ZjhmZTAtOTNi
-        OS00ODM3LTg3OWItZTBhODc0OWFmM2U0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNDMxMjg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWE2OTcwMzAtMDIy
+        Yy00Mzk0LTllZDYtZjQzZjhhZGJkMDc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMTgyNDczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWRmNTNjYmU2ODM0YTZhYTFi
-        NzQ0MWQ4ZTJiM2JlMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5LjQ2NDUzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuNTk4ODMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjYTFlMzMyMmU4MmY0ZTFhODg5
+        OGQzMTJjZGExZjg2MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjIyODE4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTAuNDc2NDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUy
-        MS00ZTM5LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNh
+        Mi00YTlhLWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b145889-2d7c-4207-8fc3-b400123b7776/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7979b688-db77-47b0-89d4-91f868348dd0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4079,53 +4504,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d93d40207fc84e449391bf9181b2973e
+      - c4f4fb7d70484dfc9a1280d74f5f73f5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIxNDU4ODktMmQ3
-        Yy00MjA3LThmYzMtYjQwMDEyM2I3Nzc2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNDgzMDkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzk3OWI2ODgtZGI3
+        Ny00N2IwLTg5ZDQtOTFmODY4MzQ4ZGQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMjU2NjY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0OWU5NjE2YWEwYzc0NWJhYWUz
-        NjZhNWNkNWY2OTk3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5LjYzMDEyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuNzYxOTE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkYTViMDcwZmYzOWM0Yjk2OWQ2
+        NTVmNjcyYzY4MzU3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjU3NDM0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTAuODExMzc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZThmMjBiOS04ZTIxLTRlMzktYTBiZC02MmM0ZGRhODliNDkvdmVyc2lv
+        bS81N2Y0YzY5MC0xM2EyLTRhOWEtYmI3My0xZjVjZGM1YTQ5MGMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUyMS00ZTM5
-        LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNhMi00YTlh
+        LWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b07aec2e-216b-46fd-aa40-51e7142060ad/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ee88bbc1-3dd4-41b8-901a-0b4b6cebb02f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4146,53 +4571,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7e78ea4f87034df4af5bcff0623a3662
+      - 194aed32695747e9827531d43cf2f3a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '387'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjA3YWVjMmUtMjE2
-        Yi00NmZkLWFhNDAtNTFlNzE0MjA2MGFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNTM0MzY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWU4OGJiYzEtM2Rk
+        NC00MWI4LTkwMWEtMGI0YjZjZWJiMDJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuMzI1MzUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2MjA2ZTMwOTg1NTE0NmE2YmU2
-        Y2VmZWI5M2VjNTg1MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjA5Ljc5MzE3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        MDkuOTMwMzkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4YTRhYWIyYjg1OTg0YWQ0OTNm
+        MGFiZDUzZjYxNTE0ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjEwLjg2MTIzOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        MTEuMTE3MjM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS82ZThmMjBiOS04ZTIxLTRlMzktYTBiZC02MmM0ZGRhODliNDkvdmVyc2lv
+        bS81N2Y0YzY5MC0xM2EyLTRhOWEtYmI3My0xZjVjZGM1YTQ5MGMvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIwYjktOGUyMS00ZTM5
-        LWEwYmQtNjJjNGRkYTg5YjQ5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2OTAtMTNhMi00YTlh
+        LWJiNzMtMWY1Y2RjNWE0OTBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/858d26a4-cda0-4937-ae94-4dfe3538ba1e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/94ef010c-8a2d-4d50-8eac-8aeab352d0dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4213,55 +4638,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf9c9c5861cf44f49c412a94a5abf66e
+      - 6ce1e4d783ee4991a2c6552bfe634bce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODU4ZDI2YTQtY2Rh
-        MC00OTM3LWFlOTQtNGRmZTM1MzhiYTFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6MDkuNTg0NDU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTRlZjAxMGMtOGEy
+        ZC00ZDUwLThlYWMtOGFlYWIzNTJkMGRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6MTAuNDA1NzI3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiMmNkY2NkMzQzZjAyNDY3NzlmYmE2Yzk5YTU0
-        NTc4YjgiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODowOS45NTk5
-        MzVaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjEwLjM1ODEw
-        NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiZmUxNmQ1MjgwNDZiNDI5OGI3MzU5Y2Y1ZTJl
+        NzRhODIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDoxMS4xNzQw
+        NTZaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjExLjcxMzQ3
+        MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmU4ZjIw
-        YjktOGUyMS00ZTM5LWEwYmQtNjJjNGRkYTg5YjQ5L3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTdmNGM2
+        OTAtMTNhMi00YTlhLWJiNzMtMWY1Y2RjNWE0OTBjL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzZlOGYyMGI5LThlMjEtNGUzOS1hMGJkLTYy
-        YzRkZGE4OWI0OS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzlmMGVhMGQ2LWNhYmUtNDVkMC1hMjY1LTgwZjdmZjcyZGQz
-        Ni8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzU3ZjRjNjkwLTEzYTItNGE5YS1iYjczLTFm
+        NWNkYzVhNDkwYy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzQyOWQ5M2ViLTI2ZGMtNDA1Ni05NDk2LTIzOWY1Y2ZmYWI5
+        Zi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4269,7 +4694,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4282,52 +4707,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '667'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e976226a25848d58b93cd3a651d7be7
+      - 340f16cf393b4531838069fb2db13d01
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '289'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQyYzAtODhmMy0xNTI4OTBlZmE3ZWYv
+        YWNrYWdlcy80NjAxOTJmYy03ZWZmLTRlZGItYTA4YS1iYmFhNDgzNWFjNWEv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9
+        a2FnZXMvOWVjYTM4YTItNzhkZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8ifSx7
+        Z2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFjOTY2MjVkZmYvIn0seyJw
+        cy82MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MjllNmEyMWQtMmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2
-        NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJh
-        ZTgyZS1iN2ExLTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIn1dfQ==
+        NDgwNjA4YzEtYjZhYS00MDkwLTlhZmYtNzNhNDQ2Y2I2YjA0LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdj
+        ZjA1ZjJlLWIyYzEtNDhiMC04MTMzLTFiZjc1ZmRkMjNlMS8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5
+        NTdiMS1jOTEyLTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4335,7 +4760,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4348,7 +4773,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4366,21 +4791,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 802ebfbb26ef4f07a3581cbb6e4eff61
+      - 4031b65807c943008ad9d33bf1b21325
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4388,7 +4813,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4401,37 +4826,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4790'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c23ebf99b58e420ea0956fa86fd9be53
+      - 87cf85bdb8d24e12ab6cef0f99b85307
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1602'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4504,9 +4929,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -4523,9 +4948,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -4535,10 +4960,10 @@ http_interactions:
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4546,7 +4971,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4559,41 +4984,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7db82cfe39c743189551a76cb6976a28
+      - 6a369628e5cb46e8952b154e82a45707
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4601,7 +5026,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4614,41 +5039,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c89611d9e4104604a2c4380eb5554534
+      - 1ec949c35923425baf73d700fdcea4b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4656,7 +5081,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4669,36 +5094,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:10 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1cb122a6480e4abc8a460bf638a757ea
+      - 96d6b248656a4b7393287ac0563a7071
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4720,10 +5145,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4731,7 +5156,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4744,52 +5169,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:11 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '667'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 679b456881e541d0ba7413b1b775e3ce
+      - 8c966a8efa3c411f93052c14f342c382
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '289'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQyYzAtODhmMy0xNTI4OTBlZmE3ZWYv
+        YWNrYWdlcy80NjAxOTJmYy03ZWZmLTRlZGItYTA4YS1iYmFhNDgzNWFjNWEv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9
+        a2FnZXMvOWVjYTM4YTItNzhkZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8ifSx7
+        Z2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFjOTY2MjVkZmYvIn0seyJw
+        cy82MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MjllNmEyMWQtMmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2
-        NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJh
-        ZTgyZS1iN2ExLTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIn1dfQ==
+        NDgwNjA4YzEtYjZhYS00MDkwLTlhZmYtNzNhNDQ2Y2I2YjA0LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzdj
+        ZjA1ZjJlLWIyYzEtNDhiMC04MTMzLTFiZjc1ZmRkMjNlMS8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5
+        NTdiMS1jOTEyLTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4797,7 +5222,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4810,7 +5235,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:11 GMT
+      - Fri, 29 Jul 2022 11:34:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4828,21 +5253,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dadda5ecf82e46b782b652b1f34f22ec
+      - 7ac8e57d21d54f8cbb00e326d2ce1daa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4850,7 +5275,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4863,37 +5288,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:11 GMT
+      - Fri, 29 Jul 2022 11:34:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4790'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 12ad6ef7205e4bbc983f9f62856ca2b4
+      - a89e332362a444adb0961b16bdb28ad9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1602'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4966,9 +5391,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -4985,9 +5410,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -4997,10 +5422,10 @@ http_interactions:
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5008,7 +5433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5021,41 +5446,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:11 GMT
+      - Fri, 29 Jul 2022 11:34:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 51687d20ff5e471f9438dc48801881cd
+      - 922da78520014e0eb70a0ac2f4e3559a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5063,7 +5488,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5076,41 +5501,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:11 GMT
+      - Fri, 29 Jul 2022 11:34:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7dfb90ee220d41a7933a013251f961ba
+      - ffde78bef7714ef4b74b9c6606009eb2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6e8f20b9-8e21-4e39-a0bd-62c4dda89b49/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/57f4c690-13a2-4a9a-bb73-1f5cdc5a490c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5118,7 +5543,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5131,36 +5556,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:11 GMT
+      - Fri, 29 Jul 2022 11:34:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd3eec9723244d5ab603c74243fb1bbb
+      - 07d5bf5d6f28456f9787be4108295988
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5182,5 +5607,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:13 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_modlemd_defaults_repository/all_modulemd_defaults_are_copied_by_default.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_modlemd_defaults_repository/all_modulemd_defaults_are_copied_by_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90e57dab3f0443329172cfcc5ef8d032
+      - 19b85094e16841b4b967f0ca815ed746
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMGVmOGRhMi02ZDVmLTRiODgtOTRmZC1hYTkxY2JiMDEyZWMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOTozNC43MDg4NDRa
+        cnBtL3JwbS9lMTk2MjdmYS05Y2Q2LTQ4ODktYmQzNi1kZDkwOTY4OGQ5MDUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNToxNS4yODMzNTVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMGVmOGRhMi02ZDVmLTRiODgtOTRmZC1hYTkxY2JiMDEyZWMv
+        cnBtL3JwbS9lMTk2MjdmYS05Y2Q2LTQ4ODktYmQzNi1kZDkwOTY4OGQ5MDUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMwZWY4
-        ZGEyLTZkNWYtNGI4OC05NGZkLWFhOTFjYmIwMTJlYy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UxOTYy
+        N2ZhLTljZDYtNDg4OS1iZDM2LWRkOTA5Njg4ZDkwNS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:24 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/30ef8da2-6d5f-4b88-94fd-aa91cbb012ec/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 62dd5c1ffaa74e7a83afb81280ce73ea
+      - b43d89f7507b4ac586973912ba66a08b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQxMDkxYzkyLTI2OTUtNDE4
-        MC04ODhiLWE4ZDMzNDE4NzY4My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwNmIwODg0LTFmMzktNDBj
+        OS05ZDQ5LTRhMjBmZjE2N2Q3Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 37fd96ec08ed47219c80f10e1d202b1a
+      - c0be6e629abf491d82d2c839741b4c7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/41091c92-2695-4180-888b-a8d334187683/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d06b0884-1f39-40c9-9d49-4a20ff167d7f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 27242ff4c30e41e29c0f534daf719346
+      - 05ae827159e94da6985ce36e83085d0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDEwOTFjOTItMjY5
-        NS00MTgwLTg4OGItYThkMzM0MTg3NjgzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MjcuNDkwMDU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDA2YjA4ODQtMWYz
+        OS00MGM5LTlkNDktNGEyMGZmMTY3ZDdmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjQuNTkyOTA2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2MmRkNWMxZmZhYTc0ZTdhODNhZmI4MTI4
-        MGNlNzNlYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjI3LjUz
-        MjY1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MjcuNjY1
-        MDcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiNDNkODlmNzUwN2I0YWM1ODY5NzM5MTJi
+        YTY2YTA4YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjI0LjYz
+        OTMyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MjQuODMz
+        NzcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzBlZjhkYTItNmQ1Zi00Yjg4
-        LTk0ZmQtYWE5MWNiYjAxMmVjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTE5NjI3ZmEtOWNkNi00ODg5
+        LWJkMzYtZGQ5MDk2ODhkOTA1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b46cdf10731c4624bbbdb9259cdb16a3
+      - 04d83c6565cd4e37bdab68953e8436d6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5c815b7e020c4c429e26f4ca5244657f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNjE0ZjQ1MjktMTFmOC00OTc2LTk5NmMtOGQ2N2YzOGQyYWRi
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MTkuMzA0NDEy
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/614f4529-11f8-4976-996c-8d67f38d2adb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0f6132c8b9cf47e0a8e46344e2427929
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4ZTY0ZTYxLTcyMzEtNGM3
+        Ni1iMWJlLTQxMzVhMDE5ZjZmOC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/98e64e61-7231-4c76-b1be-4135a019f6f8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 16c28f72b8b949ae98f18d689e7bba5a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOThlNjRlNjEtNzIz
+        MS00Yzc2LWIxYmUtNDEzNWEwMTlmNmY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjUuMDU2MzY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZjYxMzJjOGI5Y2Y0N2UwYThlNDYzNDRl
+        MjQyNzkyOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjI1LjEw
+        NzYwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MjUuMTUw
+        MzAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b8f2c263c894ba09fcbd01383ff19ed
+      - 718a6955e0984ef099efa0fabf6d2f34
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 38961c644f3a40f8a95ca823d1e71de6
+      - 5463bcf9f87d4d9686c877a6921a4012
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68afdbdd469a4e4894f96203ebbd3512
+      - 4d574027f65641d3ba832d90cb4ff91d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:27 GMT
+      - Fri, 29 Jul 2022 11:35:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8030157fd8242318d5890fa8e121261
+      - f395bc7c4acd46759d621d6c38811aeb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:30:27 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - c644fb7a50b9453abb4bf746e25e73ee
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/143772bd-ffdb-4c5a-97a6-a9206a0dff64/"
+      - "/pulp/api/v3/remotes/rpm/rpm/b765a092-0f40-4964-9ab5-8d86f2232647/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f7a1bbaa0694bc4855412fc3518da70
+      - f508abe1e646485d89578f5d4869b482
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE0
-        Mzc3MmJkLWZmZGItNGM1YS05N2E2LWE5MjA2YTBkZmY2NC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjMwOjI4LjAxMjYyMFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I3
+        NjVhMDkyLTBmNDAtNDk2NC05YWI1LThkODZmMjIzMjY0Ny8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM1OjI1LjYzNTQ1NloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjMwOjI4LjAxMjYzOFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjM1OjI1LjYzNTQ3N1oiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/"
+      - "/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b037a34377804a169a533897bd593ea9
+      - fe690843fb7144d4b3930acea48099bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzFjZDViNTctNWJkMC00N2ZhLWIyZDMtZjAwODA4ZTU1OWRhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6MjguMTIwNTk2WiIsInZl
+        cG0vYTJlZGYxY2EtZGM2OS00M2RjLWI5ZjgtMDk4MDJlN2Y3OGMzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MjUuNzc3OTM4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzFjZDViNTctNWJkMC00N2ZhLWIyZDMtZjAwODA4ZTU1OWRhL3ZlcnNp
+        cG0vYTJlZGYxY2EtZGM2OS00M2RjLWI5ZjgtMDk4MDJlN2Y3OGMzL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MWNkNWI1Ny01
-        YmQwLTQ3ZmEtYjJkMy1mMDA4MDhlNTU5ZGEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hMmVkZjFjYS1k
+        YzY5LTQzZGMtYjlmOC0wOTgwMmU3Zjc4YzMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,7 +849,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -736,92 +861,40 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2417e91db81f4b4899d9af17ccd1c7b6
+      - 67d992495be84475a51c394453682964
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:30:28 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 68107853018b4d92a1b4488bee163bdc
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '366'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNGNkODZkZjEtODk3Mi00ZWFlLWI1N2MtNDdjZDdhZmVmNjk1LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MzQuNTY0NDc2WiIsIm5h
-        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
-        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
-        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
-        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyOTozNS45NTcxMzZaIiwiZG93bmxvYWRfY29uY3VycmVu
-        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
-        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
-        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
-        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
-        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83MjhkMmZhNi0wMTU3LTRjM2UtODEzNS1lOWNkYjY0OGI2NTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNToxNi4yMzkyODZa
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83MjhkMmZhNi0wMTU3LTRjM2UtODEzNS1lOWNkYjY0OGI2NTkv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcyOGQy
+        ZmE2LTAxNTctNGMzZS04MTM1LWU5Y2RiNjQ4YjY1OS92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
+        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
+        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
+        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
+        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
+        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/4cd86df1-8972-4eae-b57c-47cd7afef695/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -829,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -842,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -860,21 +933,139 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9952f92538e44458a703ca46bb039376
+      - ee614da3391e4ed09fae380cf63029f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1MjNkZmU5LWJkMWItNGRl
-        Ny1iMTM0LTFmNmM2OTgxNGY3My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzYzA3OWI1LTRiODctNDYw
+        Yy1hODUxLTFmZTNmMTk5MzcwMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6523dfe9-bd1b-4de7-b134-1f6c69814f73/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '610'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 81dbd8fb3d144e3bbac5e5e0b889d0d2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
+        cG0vZWJkZDNjOTUtMzVhNS00ZWQwLWEyZmMtYjQwNDgwYzY4NGIxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MTUuMTI2MTY4WiIsIm5h
+        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
+        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
+        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
+        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        Mi0wNy0yOVQxMTozNToxNi42Njg3NjdaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
+        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
+        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
+        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/ebdd3c95-35a5-4ed0-a2fc-b40480c684b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c14c5e056295458a810abfb17aabc4b8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E4Yzc2NWE0LTQ4Y2YtNDgz
+        OS05OGY2LWZlZjgwNTI2MDM4NS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/23c079b5-4b87-460c-a851-1fe3f1993703/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c11181c8c814dc0966de8543a961ae1
+      - 3955e1c4bfa0435c9394193ca30be8dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjUyM2RmZTktYmQx
-        Yi00ZGU3LWIxMzQtMWY2YzY5ODE0ZjczLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MjguMzA4MjY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjNjMDc5YjUtNGI4
+        Ny00NjBjLWE4NTEtMWZlM2YxOTkzNzAzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjYuMDUxNzA4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5OTUyZjkyNTM4ZTQ0NDU4YTcwM2NhNDZi
-        YjAzOTM3NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjI4LjM1
-        MDMwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MjguMzkz
-        MTkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlZTYxNGRhMzM5MWU0ZWQwOWZhZTM4MGNm
+        NjMwMjlmMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjI2LjEw
+        MDM4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MjYuMTk2
+        NDkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRjZDg2ZGYxLTg5NzItNGVhZS1iNTdj
-        LTQ3Y2Q3YWZlZjY5NS8iXX0=
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzI4ZDJmYTYtMDE1Ny00YzNl
+        LTgxMzUtZTljZGI2NDhiNjU5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a8c765a4-48cf-4839-98f6-fef805260385/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -947,7 +1138,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -960,7 +1151,72 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 18cb28679ae746a9a415cd7232876fd7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYThjNzY1YTQtNDhj
+        Zi00ODM5LTk4ZjYtZmVmODA1MjYwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjYuMTg0NjcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMTRjNWUwNTYyOTU0NThhODEwYWJmYjE3
+        YWFiYzRiOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjI2LjI0
+        NjA3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MjYuMzI1
+        MzA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ViZGQzYzk1LTM1YTUtNGVkMC1hMmZj
+        LWI0MDQ4MGM2ODRiMS8iXX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -978,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 671d7d6d5bd84a03aed75a855989b321
+      - e3e766e148704a0988517db29cac015a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1000,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1013,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1031,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f42489151b44b09810b68d6f2ca1604
+      - 8779c7df2a2a472a948fa377b0683702
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1053,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1066,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1084,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9edc4f720fde420f8ea6e00d3550b93d
+      - e2330e5846b240769b6f0027151d41bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1106,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1119,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1137,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 976e8e2db5784d3ba56c83f248b3c7b0
+      - 1ee474ef29064f9d9aa053b96ae16174
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1159,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1172,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1190,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff90c4b9ec8c46bfbe773dea8d1d53a2
+      - 6ea11bac32d246009cc0b349351ef572
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1212,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1225,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1243,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fda8327db9bb4ca5a1a0af84c4722e7f
+      - dd3c0d70bb2c47bba915943bec577b43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1267,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1280,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:28 GMT
+      - Fri, 29 Jul 2022 11:35:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/"
+      - "/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1300,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 797482783e484cd3a91c48e25cb9f01e
+      - 6268e42cd1684928b4235461ee9f1982
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDY2NmE4ZTItNjhlOS00MWQ0LTgzOTMtZDA1YWIwMjkzYWMxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MzA6MjguOTIzNzAxWiIsInZl
+        cG0vYmRhZjczNTctZmM4Mi00OTczLTlmODctZDVlYmQ3NjViOWFjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MjYuNzYwNjA4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDY2NmE4ZTItNjhlOS00MWQ0LTgzOTMtZDA1YWIwMjkzYWMxL3ZlcnNp
+        cG0vYmRhZjczNTctZmM4Mi00OTczLTlmODctZDVlYmQ3NjViOWFjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80NjY2YThlMi02
-        OGU5LTQxZDQtODM5My1kMDVhYjAyOTNhYzEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZGFmNzM1Ny1m
+        YzgyLTQ5NzMtOWY4Ny1kNWViZDc2NWI5YWMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1323,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:26 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/143772bd-ffdb-4c5a-97a6-a9206a0dff64/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b765a092-0f40-4964-9ab5-8d86f2232647/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1343,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:29 GMT
+      - Fri, 29 Jul 2022 11:35:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 159077f8ce434558b150628589cca24b
+      - fc01c6a0b8964bee968758ed0591daaa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5OGI4NzJhLTZiMWQtNDhj
-        MS04NmRjLTI5MDYyMTRkZDc3My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4MDQxYTY5LTA1MDctNGE3
+        ZS04YWZkLWIxMmYxMTllMmU5YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/698b872a-6b1d-48c1-86dc-2906214dd773/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b8041a69-0507-4a7e-8afd-b12f119e2e9a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1409,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:29 GMT
+      - Fri, 29 Jul 2022 11:35:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95986c48a3f54601945b0e5156d5839c
+      - 32450f4782de47538d40bf09592098c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjk4Yjg3MmEtNmIx
-        ZC00OGMxLTg2ZGMtMjkwNjIxNGRkNzczLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MjkuMTk5Nzk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjgwNDFhNjktMDUw
+        Ny00YTdlLThhZmQtYjEyZjExOWUyZTlhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjcuMTExNDU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIxNTkwNzdmOGNlNDM0NTU4YjE1MDYyODU4
-        OWNjYTI0YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjI5LjIz
-        MDk5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MjkuMjUz
-        ODA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmYzAxYzZhMGI4OTY0YmVlOTY4NzU4ZWQw
+        NTkxZGFhYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjI3LjE1
+        ODc0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MjcuMTky
+        NDA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE0Mzc3MmJkLWZmZGItNGM1YS05N2E2
-        LWE5MjA2YTBkZmY2NC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I3NjVhMDkyLTBmNDAtNDk2NC05YWI1
+        LThkODZmMjIzMjY0Ny8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:27 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE0Mzc3
-        MmJkLWZmZGItNGM1YS05N2E2LWE5MjA2YTBkZmY2NC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I3NjVh
+        MDkyLTBmNDAtNDk2NC05YWI1LThkODZmMjIzMjY0Ny8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1478,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:29 GMT
+      - Fri, 29 Jul 2022 11:35:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1496,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 591eaa0d04e747ada10b0313fae413a6
+      - efbabf5dd3274c1db640a635660b0e93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAyNDViZjE1LTdjZWItNDQ2
-        Ny05OTZmLWQyMWVmYzQ2YTIxOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmYTk3ZjIwLWE1NTQtNDMy
+        OS1iZTNkLWE5NzNmMzFlYzAxNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0245bf15-7ceb-4467-996f-d21efc46a219/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7fa97f20-a554-4329-be3d-a973f31ec014/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1531,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:30 GMT
+      - Fri, 29 Jul 2022 11:35:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43c85e5423ea43ba8cd1f09c935ccfc9
+      - dc5c80215f604f26ab8668389bae20ab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDI0NWJmMTUtN2Nl
-        Yi00NDY3LTk5NmYtZDIxZWZjNDZhMjE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MjkuMzcxMDQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2ZhOTdmMjAtYTU1
+        NC00MzI5LWJlM2QtYTk3M2YzMWVjMDE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjcuMzQ5NDY0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI1OTFlYWEwZDA0ZTc0N2FkYTEw
-        YjAzMTNmYWU0MTNhNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjI5LjQwNDgzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzAuMDY5MDc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJlZmJhYmY1ZGQzMjc0YzFkYjY0
+        MGE2MzU2NjBiMGU5MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjI3LjM4ODQ5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MjguNDMzNjkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1583,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzcxY2Q1YjU3LTViZDAtNDdmYS1iMmQzLWYwMDgw
-        OGU1NTlkYS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MWNk
-        NWI1Ny01YmQwLTQ3ZmEtYjJkMy1mMDA4MDhlNTU5ZGEvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMTQzNzcyYmQtZmZkYi00YzVh
-        LTk3YTYtYTkyMDZhMGRmZjY0LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9hMmVkZjFjYS1kYzY5LTQzZGMtYjlmOC0wOTgwMmU3
+        Zjc4YzMvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTJlZGYx
+        Y2EtZGM2OS00M2RjLWI5ZjgtMDk4MDJlN2Y3OGMzLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I3NjVhMDkyLTBmNDAtNDk2NC05
+        YWI1LThkODZmMjIzMjY0Ny8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:28 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNzFjZDViNTctNWJkMC00N2ZhLWIyZDMtZjAwODA4ZTU1
-        OWRhL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYTJlZGYxY2EtZGM2OS00M2RjLWI5ZjgtMDk4MDJlN2Y3
+        OGMzL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1627,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:30 GMT
+      - Fri, 29 Jul 2022 11:35:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1645,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ddac843e97245538f474a08f92f7a73
+      - 958d069a8704456d9bbde85bfb04dce7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiZmRmOWQ3LTY1OWUtNGRk
-        Yy1hNjM4LTU4ODQ3MTQxMmY5Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmZTQyYTEyLWExMjItNDVk
+        ZS04MzM4LTlmNzUwZjQyNzc0Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fbfdf9d7-659e-4ddc-a638-588471412f9f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4fe42a12-a122-45de-8338-9f750f427742/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1680,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:30 GMT
+      - Fri, 29 Jul 2022 11:35:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e05f9d4c51cc43e98a5d6d176233cd0a
+      - cd976541ba6e48db976a13e953afab43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmJmZGY5ZDctNjU5
-        ZS00ZGRjLWE2MzgtNTg4NDcxNDEyZjlmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzAuNTMzMDY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGZlNDJhMTItYTEy
+        Mi00NWRlLTgzMzgtOWY3NTBmNDI3NzQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjguODAyNTcyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjBkZGFjODQzZTk3MjQ1NTM4ZjQ3NGEwOGY5
-        MmY3YTczIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6MzAuNTYz
-        OTc1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzozMDozMC44MjMz
-        NTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6Ijk1OGQwNjlhODcwNDQ1NmQ5YmJkZTg1YmZi
+        MDRkY2U3Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MjguODYz
+        NTI5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNToyOS4zMTE0
+        ODNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNzYyY2Y3
-        M2YtNzdmNC00MWFiLTg1MmYtZGM1NTJhOGNiMzlkLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMzE3Mzc2
+        NTgtNDA3Mi00Y2YyLTk0NjItZmZhYzVjZjlhYmM5LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNzFjZDViNTctNWJkMC00N2ZhLWIyZDMtZjAwODA4
-        ZTU1OWRhLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYTJlZGYxY2EtZGM2OS00M2RjLWI5ZjgtMDk4MDJl
+        N2Y3OGMzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1737,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b6b4003d55b4b688d148ecc84c44bae
+      - e3b9a598fe8d41f8b6c3b8db3887e654
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/31737658-4072-4cf2-9462-ffac5cf9abc9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 486e44fe544747abaed6f6c3a326cf70
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMzE3Mzc2NTgtNDA3Mi00Y2YyLTk0NjItZmZhYzVjZjlhYmM5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MjguODg2MzA2WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hMmVkZjFjYS1kYzY5LTQzZGMtYjlmOC0wOTgwMmU3Zjc4YzMv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2EyZWRmMWNhLWRjNjktNDNkYy1iOWY4LTA5ODAy
+        ZTdmNzhjMy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:29 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8zMTczNzY1OC00MDcyLTRjZjItOTQ2Mi1mZmFjNWNmOWFiYzkv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b40e6a707dfa49ebbac97884575ca281
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2YWM3ZGVjLTc5MDUtNDc3
+        OS05YTlkLTEwMWIyZmMzMTRiYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d6ac7dec-7905-4779-9a9d-101b2fc314bc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 71edb71978be41d4b9f7e345490e7273
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDZhYzdkZWMtNzkw
+        NS00Nzc5LTlhOWQtMTAxYjJmYzMxNGJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjkuNTk5NjIxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiNDBlNmE3MDdkZmE0OWViYmFjOTc4ODQ1
+        NzVjYTI4MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjI5LjY0
+        MDU2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MjkuODYz
+        NDQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZjY3
+        YzIwMjktMmY5MC00ZTVjLWI3Y2ItNTI3ODc4YTFlZTBhLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/f67c2029-2f90-4e5c-b7cb-527878a1ee0a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0f08312834cd47b0a376d27bf5b75197
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2Y2N2MyMDI5LTJmOTAtNGU1Yy1iN2NiLTUyNzg3OGExZWUwYS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM1OjI5Ljg0MTYzNVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMzE3Mzc2NTgtNDA3Mi00Y2YyLTk0NjIt
+        ZmZhYzVjZjlhYmM5LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:30 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 55a258fabecc454ab229311094159f35
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1786,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1803,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1951,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1964,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 838501a663094b669ed086fc311d591c
+      - 55e2dce873d244bea4b394a860c8549f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2004,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2025,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2045,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2066,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2087,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2107,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2126,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2139,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c34771676a4345e189575c07bb84bf09
+      - f5f86566c33d4fddb5f982f58f0c560a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2242,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2260,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2279,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2303,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2321,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2332,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2363,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2374,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2387,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 844d21adce3140d99645ff24aff194ca
+      - 274dc56237ec47ce8f584811976ddc00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2454,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2466,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2477,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2490,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '0816231f4f4142fa853a6a44e8a12a5a'
+      - 054116e6574142dab75fb9ac403103ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2526,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2537,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2550,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b749201e12e64a82abbd3aad89f3ec3b
+      - 40c0cb6d420b49aba8138dda21a85cdd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2601,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2612,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2625,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 34b9c24df07d49bfbffcbec58d51536e
+      - 2620913136c54374ad7d74700b694d33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2692,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2703,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2716,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb36a17c7f594693915894fecde4d136
+      - 8dd2d56233774247b9852eeb4dadd28c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2783,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2794,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2807,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 352d1e2e8436497ca1ae74632961a9ca
+      - 73a81661e4434237b26e28edfc695ac7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2846,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2857,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2870,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c957f5449969467495d1a230aae5cc44
+      - f45352f6b2514cf6b8142159777b51ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2909,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2920,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2933,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:31 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf998e76b3bd489f996ac4e67071ef68
+      - cc0bf181b90a479898503bae1789c321
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -2974,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -2982,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:31 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2993,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3006,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dba2e025e2ee47ba8aa148dcabaabdd5
+      - c64cce99e0c04367b64bc49424729a1e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3057,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3068,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3081,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2567858b038e43338344ddd8a78b6d24
+      - 8e27f450270344439cdade06c37c4d75
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3122,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3138,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3154,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3169,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3182,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2349b6c4a72b449981ba098ee2c68cce
+      - d36f67fdf5584b2fa58ba720225eb343
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3232,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3245,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3263,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a073562f91846c1ba210dc428d7e8ff
+      - 7154a6005d984827b8afce7042aab7b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiMGVmNjQxLWU5NzEtNGZj
-        Ny05MDE4LTRjNDg4ODdmNmVlOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhMTNiODgzLTRhODAtNDU4
+        OC04OGEwLTdjYzFjMGFhNzBkNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:31 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3301,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3319,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6e6aab0b304947648a5ab23c47c0c754
+      - ba6289f7639f4d1a8aebfaf3ecc2b868
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhZjQyYzc3LWU0MDktNGQ3
-        YS1iYjYzLTFkZDg3YjMxZmE0YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhODdjYWJiLTE4MDAtNGIz
+        Mi1iMjAzLTlhMGNjY2ZiMGM3MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3361,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3379,97 +3935,97 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1bb6620adafe403da0d4a8ca8f8f5b25
+      - a4f20a46eca14c53be280a6bff92550b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1ZmY4OTMwLTY2OTEtNDNh
-        MS05NDIyLWMyYWZlNzJkMGUwZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0OGVmYzQ2LTVjZTMtNGY5
+        ZS04OGI2LThmOTAyNTI0ODg2OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFjZDViNTctNWJkMC00N2ZhLWIy
-        ZDMtZjAwODA4ZTU1OWRhL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQ2NjZhOGUyLTY4ZTkt
-        NDFkNC04MzkzLWQwNWFiMDI5M2FjMS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        Mjk2ZTUwNTQtODIyNS00MzNjLWEzY2QtNjQxYzEwMDk1MTEzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM4NTMwYWU2LTRiYzYt
-        NDE2Zi1iYmVlLTk2MTA2YTRjZjk1MC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQtZDcxNTNhZDc4NDIyLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQy
-        M2QtNDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1
-        ZC1iODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRk
-        NGFhYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRl
-        NTYxMGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhk
-        YS04Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNl
-        YzY5Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5
-        YTY1ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3
-        MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJj
-        ODZhZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
-        cm91cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01
-        YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3Yi1iY2MzLTQ2
-        MzNhMmM3OTkwZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNGI5ZTFkMS1mYWUy
-        LTQ0NWQtYTg3Ny05Mzk5ZjhlNjVjMGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzI5ZTZhMjFkLTJmNjktNGNkMi1iNzExLTYxY2M4
-        OWNmNzBjZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MzdjMzgwYTAtYWFmZi00M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQy
-        YzAtODhmMy0xNTI4OTBlZmE3ZWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzQ5NDNkMTlkLWM1NTItNDVkMi04NTYwLWM3MGFmOTEz
-        N2NjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNTBj
-        ODJlOWQtYWY4OS00MzEzLWJmZWQtZDRjNGE2YzgwZjllLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NjQ2NWZmYS05NTFlLTRlZDUt
-        YjNjMy1hODA2ZWVkZmM4NWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzc2MDhjZTM3LTFjNzEtNGFkMC05MGFjLWVlZDc0NjBjNTYx
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2EzYzU3
-        OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJkNDg4LyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5
-        YS1mMGFjOTY2MjVkZmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzhmNGMwNDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4Zi8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1MjI4ODAt
-        OGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0
-        NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJkLTQ3MGMtYTI2MC1iZWJh
-        NjIwMDM0OWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2ZjMmFlODJlLWI3YTEtNGQ2Zi1iNjNkLWNlNzFlZmU1NmM1YS8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9mNDdh
-        M2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19XSwiZGVwZW5k
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTJlZGYxY2EtZGM2OS00M2RjLWI5
+        ZjgtMDk4MDJlN2Y3OGMzL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JkYWY3MzU3LWZjODIt
+        NDk3My05Zjg3LWQ1ZWJkNzY1YjlhYy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYy
+        YWItNGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQy
+        OTI5My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1
+        ZWE3ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBl
+        NS1hZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFk
+        MTkxOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYy
+        NTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgx
+        NS04OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJm
+        MjFjYmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
+        cm91cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0y
+        OTFhLTQzMzYtYWRiZC1kODliN2IwMWQ4NDYvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0YzgtNDU5Mi04Mzg0LWIy
+        NzZmZmE3ZTgyNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzViYmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0
+        NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0OTU0ZWVkLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81YTMyODQyNi0yYmFmLTQx
+        ODktOWNjNS02ZDhkYzM1YzEwZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQtNGU0Ni04ZmMzLTFiZmY3OTlm
+        YjYxZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjVm
+        YmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NmQwMjRjMi0xMGZjLTQwMWMt
+        YWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEy
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVm
+        MmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUtOTM2
+        Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMt
+        NTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0y
+        MmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkxLTM2ZWM4ZmMzNTA0OC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVh
+        Mi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2ZkYjk1N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJm
+        NTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19XSwiZGVwZW5k
         ZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3482,7 +4038,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3500,21 +4056,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a4f3a6c5b7c418483da01da4cd4e454
+      - 3b8f81ef694f4139be90c6717784e66a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1ZWQ2MGRkLThmZmUtNDgx
-        NS04MmEzLWUxNzhjMDQ0ZjRkYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzN2I4NDY3LWU3NDAtNGNh
+        NS05MTk3LTJkOWI2MzE5MWFjYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b0ef641-e971-4fc7-9018-4c48887f6ee9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fa13b883-4a80-4588-88a0-7cc1c0aa70d4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3535,51 +4091,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4a6a1c2b80a84b4faf2200df62925c99
+      - b70f9fdaf84d44749ea77ab38d643a69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIwZWY2NDEtZTk3
-        MS00ZmM3LTkwMTgtNGM0ODg4N2Y2ZWU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMTg4MDAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmExM2I4ODMtNGE4
+        MC00NTg4LTg4YTAtN2NjMWMwYWE3MGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzEuOTMwODYyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYTA3MzU2MmY5MTg0NmMxYmEy
-        MTBkYzQyOGQ3ZThmZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjIxOTc2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuMzczMzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MTU0YTYwMDVkOTg0ODI3Yjhh
+        ZmNlNzA0MmFhYjdiMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMxLjk5NTU0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuMjQ4MzMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhl
-        OS00MWQ0LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4
+        Mi00OTczLTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b0ef641-e971-4fc7-9018-4c48887f6ee9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fa13b883-4a80-4588-88a0-7cc1c0aa70d4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3600,51 +4156,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bea08d73c38049359b67e79d123b4b2f
+      - 0a27465f1a6b40b38a936882d813d228
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIwZWY2NDEtZTk3
-        MS00ZmM3LTkwMTgtNGM0ODg4N2Y2ZWU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMTg4MDAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmExM2I4ODMtNGE4
+        MC00NTg4LTg4YTAtN2NjMWMwYWE3MGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzEuOTMwODYyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYTA3MzU2MmY5MTg0NmMxYmEy
-        MTBkYzQyOGQ3ZThmZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjIxOTc2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuMzczMzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MTU0YTYwMDVkOTg0ODI3Yjhh
+        ZmNlNzA0MmFhYjdiMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMxLjk5NTU0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuMjQ4MzMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhl
-        OS00MWQ0LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4
+        Mi00OTczLTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/faf42c77-e409-4d7a-bb63-1dd87b31fa4a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5a87cabb-1800-4b32-b203-9a0cccfb0c70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3665,53 +4221,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e50cdab7002a4c668d8956e239eb3d5f
+      - 3ef790dbbed741ad92757b558ebb4b0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmFmNDJjNzctZTQw
-        OS00ZDdhLWJiNjMtMWRkODdiMzFmYTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMjQ1MDA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWE4N2NhYmItMTgw
+        MC00YjMyLWIyMDMtOWEwY2NjZmIwYzcwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzIuMDE5MjA4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZTZhYWIwYjMwNDk0NzY0OGE1
-        YWIyM2M0N2MwYzc1NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjQwNDQ0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuNTMzMjYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiYTYyODlmNzYzOWY0ZDFhOGFl
+        YmZhZjNlY2MyYjg2OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMyLjMwMjA5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuNTE1Njg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS80NjY2YThlMi02OGU5LTQxZDQtODM5My1kMDVhYjAyOTNhYzEvdmVyc2lv
+        bS9iZGFmNzM1Ny1mYzgyLTQ5NzMtOWY4Ny1kNWViZDc2NWI5YWMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhlOS00MWQ0
-        LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4Mi00OTcz
+        LTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b0ef641-e971-4fc7-9018-4c48887f6ee9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fa13b883-4a80-4588-88a0-7cc1c0aa70d4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3732,51 +4288,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e3e3f0eca8c4d4dac7e442d7fa80bf6
+      - 36583318ad184ccfb4e02a6bb26d10dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIwZWY2NDEtZTk3
-        MS00ZmM3LTkwMTgtNGM0ODg4N2Y2ZWU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMTg4MDAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmExM2I4ODMtNGE4
+        MC00NTg4LTg4YTAtN2NjMWMwYWE3MGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzEuOTMwODYyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYTA3MzU2MmY5MTg0NmMxYmEy
-        MTBkYzQyOGQ3ZThmZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjIxOTc2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuMzczMzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MTU0YTYwMDVkOTg0ODI3Yjhh
+        ZmNlNzA0MmFhYjdiMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMxLjk5NTU0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuMjQ4MzMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhl
-        OS00MWQ0LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4
+        Mi00OTczLTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/faf42c77-e409-4d7a-bb63-1dd87b31fa4a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5a87cabb-1800-4b32-b203-9a0cccfb0c70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3797,53 +4353,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3e2af59b73b4ceebee410de3ee0687e
+      - 6eecc25e62fd461da5e3c5c8cc35732e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmFmNDJjNzctZTQw
-        OS00ZDdhLWJiNjMtMWRkODdiMzFmYTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMjQ1MDA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWE4N2NhYmItMTgw
+        MC00YjMyLWIyMDMtOWEwY2NjZmIwYzcwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzIuMDE5MjA4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZTZhYWIwYjMwNDk0NzY0OGE1
-        YWIyM2M0N2MwYzc1NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjQwNDQ0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuNTMzMjYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiYTYyODlmNzYzOWY0ZDFhOGFl
+        YmZhZjNlY2MyYjg2OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMyLjMwMjA5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuNTE1Njg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS80NjY2YThlMi02OGU5LTQxZDQtODM5My1kMDVhYjAyOTNhYzEvdmVyc2lv
+        bS9iZGFmNzM1Ny1mYzgyLTQ5NzMtOWY4Ny1kNWViZDc2NWI5YWMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhlOS00MWQ0
-        LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4Mi00OTcz
+        LTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e5ff8930-6691-43a1-9422-c2afe72d0e0f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/348efc46-5ce3-4f9e-88b6-8f9025248868/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3864,53 +4420,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:32 GMT
+      - Fri, 29 Jul 2022 11:35:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 630e9ceeb321400797f51b9c7f603114
+      - 36e7a129f0c4401299a504ae005cb381
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVmZjg5MzAtNjY5
-        MS00M2ExLTk0MjItYzJhZmU3MmQwZTBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMjk3NzgyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzQ4ZWZjNDYtNWNl
+        My00ZjllLTg4YjYtOGY5MDI1MjQ4ODY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzIuMDg5NjE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYmI2NjIwYWRhZmU0MDNkYTBk
-        NGE4Y2E4ZjhmNWIyNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjU2NDc5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuNzA1NTA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNGYyMGE0NmVjYTE0YzUzYmUy
+        ODBhNmJmZjkyNTUwYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMyLjU3MDE2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuODEwMDc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS80NjY2YThlMi02OGU5LTQxZDQtODM5My1kMDVhYjAyOTNhYzEvdmVyc2lv
+        bS9iZGFmNzM1Ny1mYzgyLTQ5NzMtOWY4Ny1kNWViZDc2NWI5YWMvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhlOS00MWQ0
-        LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4Mi00OTcz
+        LTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6b0ef641-e971-4fc7-9018-4c48887f6ee9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fa13b883-4a80-4588-88a0-7cc1c0aa70d4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3931,51 +4487,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c9d9725d14a4dae9ae950f5f06cbfe7
+      - 3d666ab33cec469e88c19d1c8ad7f31e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIwZWY2NDEtZTk3
-        MS00ZmM3LTkwMTgtNGM0ODg4N2Y2ZWU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMTg4MDAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmExM2I4ODMtNGE4
+        MC00NTg4LTg4YTAtN2NjMWMwYWE3MGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzEuOTMwODYyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwYTA3MzU2MmY5MTg0NmMxYmEy
-        MTBkYzQyOGQ3ZThmZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjIxOTc2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuMzczMzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MTU0YTYwMDVkOTg0ODI3Yjhh
+        ZmNlNzA0MmFhYjdiMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMxLjk5NTU0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuMjQ4MzMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhl
-        OS00MWQ0LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4
+        Mi00OTczLTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/faf42c77-e409-4d7a-bb63-1dd87b31fa4a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5a87cabb-1800-4b32-b203-9a0cccfb0c70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3996,53 +4552,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b0c219139f214518a99d5616b742a765
+      - 051da6c053c04ff0ab43ec57f7f1229d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmFmNDJjNzctZTQw
-        OS00ZDdhLWJiNjMtMWRkODdiMzFmYTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMjQ1MDA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWE4N2NhYmItMTgw
+        MC00YjMyLWIyMDMtOWEwY2NjZmIwYzcwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzIuMDE5MjA4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZTZhYWIwYjMwNDk0NzY0OGE1
-        YWIyM2M0N2MwYzc1NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjQwNDQ0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuNTMzMjYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiYTYyODlmNzYzOWY0ZDFhOGFl
+        YmZhZjNlY2MyYjg2OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMyLjMwMjA5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuNTE1Njg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS80NjY2YThlMi02OGU5LTQxZDQtODM5My1kMDVhYjAyOTNhYzEvdmVyc2lv
+        bS9iZGFmNzM1Ny1mYzgyLTQ5NzMtOWY4Ny1kNWViZDc2NWI5YWMvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhlOS00MWQ0
-        LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4Mi00OTcz
+        LTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e5ff8930-6691-43a1-9422-c2afe72d0e0f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/348efc46-5ce3-4f9e-88b6-8f9025248868/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4063,53 +4619,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 748db07844a64a6c8a02faf2c3dcf075
+      - ee4c11cdba0846cfa0ffdb17685ce4ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVmZjg5MzAtNjY5
-        MS00M2ExLTk0MjItYzJhZmU3MmQwZTBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMjk3NzgyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzQ4ZWZjNDYtNWNl
+        My00ZjllLTg4YjYtOGY5MDI1MjQ4ODY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzIuMDg5NjE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYmI2NjIwYWRhZmU0MDNkYTBk
-        NGE4Y2E4ZjhmNWIyNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMw
-        OjMyLjU2NDc5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MzA6
-        MzIuNzA1NTA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNGYyMGE0NmVjYTE0YzUzYmUy
+        ODBhNmJmZjkyNTUwYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjMyLjU3MDE2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MzIuODEwMDc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS80NjY2YThlMi02OGU5LTQxZDQtODM5My1kMDVhYjAyOTNhYzEvdmVyc2lv
+        bS9iZGFmNzM1Ny1mYzgyLTQ5NzMtOWY4Ny1kNWViZDc2NWI5YWMvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4ZTItNjhlOS00MWQ0
-        LTgzOTMtZDA1YWIwMjkzYWMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjczNTctZmM4Mi00OTcz
+        LTlmODctZDVlYmQ3NjViOWFjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b5ed60dd-8ffe-4815-82a3-e178c044f4dc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e37b8467-e740-4ca5-9197-2d9b63191acc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4130,55 +4686,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57c7774c4460436fb8dcc6d5de0e53a7
+      - dcc5036fe82249dfac3782632aa8291b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjVlZDYwZGQtOGZm
-        ZS00ODE1LTgyYTMtZTE3OGMwNDRmNGRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MzA6MzIuMzUyNDk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTM3Yjg0NjctZTc0
+        MC00Y2E1LTkxOTctMmQ5YjYzMTkxYWNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MzIuMTY1NzMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiMWE0ZjNhNmM1YjdjNDE4NDgzZGEwMWRhNGNk
-        NGU0NTQiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzozMDozMi43Mzk5
-        NDRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjMwOjMzLjEyMTU3
-        NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiM2I4ZjgxZWY2OTRmNDEzOWJlOTBjNjcxNzc4
+        NGU2NmEiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNTozMi44NjQz
+        NjNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjMzLjU1MzA3
+        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY2NmE4
-        ZTItNjhlOS00MWQ0LTgzOTMtZDA1YWIwMjkzYWMxL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhZjcz
+        NTctZmM4Mi00OTczLTlmODctZDVlYmQ3NjViOWFjL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzQ2NjZhOGUyLTY4ZTktNDFkNC04MzkzLWQw
-        NWFiMDI5M2FjMS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzcxY2Q1YjU3LTViZDAtNDdmYS1iMmQzLWYwMDgwOGU1NTlk
-        YS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2JkYWY3MzU3LWZjODItNDk3My05Zjg3LWQ1
+        ZWJkNzY1YjlhYy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2EyZWRmMWNhLWRjNjktNDNkYy1iOWY4LTA5ODAyZTdmNzhj
+        My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4186,7 +4742,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4199,76 +4755,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bef882f661c14f07872a25bdda13077a
+      - a8eaee6141e34e279e25e7a5a01a1016
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '566'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
-        NTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2Ji
-        Mzg0ODctOTY3Ny00YTQzLTgzZTMtNDM5MGIzZDIwNWI0LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhiMjUx
-        NzM4LTZhNDgtNDNjYi1iNzlhLWYwYWM5NjYyNWRmZi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQt
-        MmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThj
-        NWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZm
-        LTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00
-        NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTViNzEtNDE1
-        NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkw
-        YWMtZWVkNzQ2MGM1NjFiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YwNzc5MmMzLWE0MmQtNDcwYy1hMjYw
-        LWJlYmE2MjAwMzQ5Zi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00YjY2LWFlYWQtZmY4
-        NTBiOTI2ZTVjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4276,7 +4832,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4289,50 +4845,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d0bed186bc304dedb4625d1f61f9ed8c
+      - 67dd2b0e12924e898c3fbeb139007bd4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4340,7 +4896,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4353,37 +4909,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b6b7bddf70cd40b5912ab13679eeff9e
+      - 834d9b6d90244b81920b7c0c7ec866d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4456,9 +5012,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -4474,8 +5030,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -4493,9 +5049,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -4517,9 +5073,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -4535,9 +5091,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -4546,9 +5102,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -4577,10 +5133,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4588,7 +5144,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4601,43 +5157,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8b8bf15ab0743a6acfb1562355528d4
+      - 513be9214ea447a096a75bffb9087f16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4645,7 +5201,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4658,41 +5214,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 02fee9d44b484a148f8315a0c557762e
+      - 2b9ee046dc4d4700a4074f9299d08351
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4700,7 +5256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4713,36 +5269,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5a66316f148a44848b26f1a7f76d048e
+      - 1d107891866b48b7b83fff21764355a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4764,10 +5320,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?repository_version=/pulp/api/v3/repositories/rpm/rpm/71cd5b57-5bd0-47fa-b2d3-f00808e559da/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a2edf1ca-dc69-43dc-b9f8-09802e7f78c3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4775,7 +5331,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4788,37 +5344,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68c1beb71dcb4873a2941c559237c0c2
+      - 2cc0b71c289c4b1488b218d7d20d9343
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -4829,12 +5385,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -4845,12 +5401,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -4861,14 +5417,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?repository_version=/pulp/api/v3/repositories/rpm/rpm/4666a8e2-68e9-41d4-8393-d05ab0293ac1/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?repository_version=/pulp/api/v3/repositories/rpm/rpm/bdaf7357-fc82-4973-9f87-d5ebd765b9ac/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4876,7 +5432,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4889,37 +5445,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:30:33 GMT
+      - Fri, 29 Jul 2022 11:35:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 691c302cfd944b3782a2c4c2d5904e9e
+      - d70785e88d2e450fb36a6269edb77c13
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -4930,12 +5486,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -4946,12 +5502,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -4962,9 +5518,9 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:30:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:35 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_module_stream_repository/all_module_streams_copied_if_empty_modular_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_module_stream_repository/all_module_streams_copied_if_empty_modular_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a5448f2bac84231ba2cf25d052123b0
+      - a48dd6eb263143d7be8d192f5dbbe631
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zYTY1ODliMy00ZDkzLTQ4N2YtOTcxYS1kNTNhYzliNGEyNGUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNjowMy40MjU5ODBa
+        cnBtL3JwbS82ZGU5MGZmNy0yOWU4LTQ2ODItOWIwNC1kOTg0M2Y4ODBmNTcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMzozMi42Mzg5MDVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zYTY1ODliMy00ZDkzLTQ4N2YtOTcxYS1kNTNhYzliNGEyNGUv
+        cnBtL3JwbS82ZGU5MGZmNy0yOWU4LTQ2ODItOWIwNC1kOTg0M2Y4ODBmNTcv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNhNjU4
-        OWIzLTRkOTMtNDg3Zi05NzFhLWQ1M2FjOWI0YTI0ZS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZkZTkw
+        ZmY3LTI5ZTgtNDY4Mi05YjA0LWQ5ODQzZjg4MGY1Ny92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:47 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2abcf587333e41a1835b897e4d54e2a7
+      - 87f42c8105c9471d9fbd27feb6d2bdc7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhNjFhNzU0LWJkNGQtNDU1
-        Yi04NmQyLTUyYzFhOTQyMWI2Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyODUzN2JmLTUzYzAtNGMw
+        ZS1hODcyLTE4ZDMzODUzOTc0Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb3a2d3c3d82436786bba2366ba2d75e
+      - cee5fdcd374449e795fea7695fb65b7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3a61a754-bd4d-455b-86d2-52c1a9421b62/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/328537bf-53c0-4c0e-a872-18d338539747/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 44f8dbded938496e90fcdcf9ec50bee3
+      - 02e5f1af2379403f83c7745659f93813
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2E2MWE3NTQtYmQ0
-        ZC00NTViLTg2ZDItNTJjMWE5NDIxYjYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTAuMDUxODc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzI4NTM3YmYtNTNj
+        MC00YzBlLWE4NzItMThkMzM4NTM5NzQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDcuODE0NjYwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyYWJjZjU4NzMzM2U0MWExODM1Yjg5N2U0
-        ZDU0ZTJhNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjEwLjA4
-        OTUzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTAuMjE2
-        NDkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4N2Y0MmM4MTA1Yzk0NzFkOWZiZDI3ZmVi
+        NmQyYmRjNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjQ3Ljg3
+        MTI0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6NDguMTgy
+        NjQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2E2NTg5YjMtNGQ5My00ODdm
-        LTk3MWEtZDUzYWM5YjRhMjRlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmRlOTBmZjctMjllOC00Njgy
+        LTliMDQtZDk4NDNmODgwZjU3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1051555b81a47dcba2fdd47202fa899
+      - 2faef1ae19a349cbb47ed1afe79946a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e470bcf01e424268bbcec275934a8fcd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMWM0NGZmYmEtNjZiZC00OTA3LTk4ZmMtNzUxMzAzN2RiMzFh
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MzguNjU1Mjg2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/1c44ffba-66bd-4907-98fc-7513037db31a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 440639eab22c4df0a201ab9fc8a62480
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlYjRkMTQyLWM1ZjItNDAz
+        MS05NTE1LTE0MGFkZmQ0Y2RkNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/deb4d142-c5f2-4031-9515-140adfd4cdd5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 43259520cdb341f1a11361e7fb79b25a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGViNGQxNDItYzVm
+        Mi00MDMxLTk1MTUtMTQwYWRmZDRjZGQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDguNTUzNDM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0NDA2MzllYWIyMmM0ZGYwYTIwMWFiOWZj
+        OGE2MjQ4MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjQ4LjYw
+        ODA5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6NDguNjU3
+        NTYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 89cb0df56c3c48de9a01f55ef0b8ab17
+      - 0ae6ea5278444458b07d2975f42f7910
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3463b5e0fa52413695c4f7cf124f648d
+      - 973e7d83954341459d5d8dc3016359ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e5f74889110d4a3b9241919550b29f8e
+      - fa53ce2a03c14aeaa264cd336678aab3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0143d6ab3d3a4c438a1bd7d35ec055e0
+      - c34bfa5f0a254e2cb1dbf3f66cff1208
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:10 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 58b7d5add53e43e28a8ca620a9797e58
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:48 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/894b2212-b9c5-4547-8174-b79a3c873aa4/"
+      - "/pulp/api/v3/remotes/rpm/rpm/c065bce0-f850-41f3-8f73-3f8065c5f4b4/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4065950ff63c4a6cb6a6b4299f7f87fc
+      - 904a29997f854d9fa1ccde4617cf9f29
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg5
-        NGIyMjEyLWI5YzUtNDU0Ny04MTc0LWI3OWEzYzg3M2FhNC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE2OjEwLjY0MjUyMVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Mw
+        NjViY2UwLWY4NTAtNDFmMy04ZjczLTNmODA2NWM1ZjRiNC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMzOjQ5LjAzODc3M1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjE2OjEwLjY0MjU0MFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjMzOjQ5LjAzODgwMVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:49 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/"
+      - "/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb385ece663c4dd98afe980550c93cf5
+      - 603a77479e554412a22b7824bec4edae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTliNDcyOTAtZmFhZS00ZDAwLWIzNTItY2JiZmUzM2JkMDA0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MTAuNzUyNDMxWiIsInZl
+        cG0vZGJmMTcwZTItZGI1YS00ZjdiLTlmZjMtNThhNmM4OTBiZTZjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6NDkuMjEwNTU4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTliNDcyOTAtZmFhZS00ZDAwLWIzNTItY2JiZmUzM2JkMDA0L3ZlcnNp
+        cG0vZGJmMTcwZTItZGI1YS00ZjdiLTlmZjMtNThhNmM4OTBiZTZjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xOWI0NzI5MC1m
-        YWFlLTRkMDAtYjM1Mi1jYmJmZTMzYmQwMDQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kYmYxNzBlMi1k
+        YjVhLTRmN2ItOWZmMy01OGE2Yzg5MGJlNmMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a665836401624504af00c8e913daf438
+      - 63f013c3207443c8af7166a98cd6ac2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '307'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81NmJhMDY1OC0yMDQxLTQ1ZTEtYTBlYy1iZjM5YmEwMDEyYmUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNjowNC4xMjA0NTFa
+        cnBtL3JwbS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMzozNC4wMjk4ODda
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81NmJhMDY1OC0yMDQxLTQ1ZTEtYTBlYy1iZjM5YmEwMDEyYmUv
+        cnBtL3JwbS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU2YmEw
-        NjU4LTIwNDEtNDVlMS1hMGVjLWJmMzliYTAwMTJiZS92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU0ZmRl
+        NzkzLWZhYmMtNDdmMi1iZDFjLTc2NTE2Y2I0MDY1NC92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:49 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86d861c1e86a4f5484b1666c602d2e6f
+      - b59f881bc63b4d30a131a1cb6b894a99
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlZWVlY2JjLWJkZTEtNGI3
-        Zi1iZDMzLTIwODAzZjUxZTYxMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2OTA3NDg2LTc0ZTgtNDRk
+        ZS1iNTAwLWFkNGJkNTFhMTM0Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:10 GMT
+      - Fri, 29 Jul 2022 11:33:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 594a6bd4b319419197919525187758b2
+      - badbbdf40b5e46a8bd2b4320fbffdf4f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMDhkYTc2MzgtNTcwZC00OWY3LWI4ZWEtYmM3ZjA0MDRmMWZkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MDMuMzE1NDg4WiIsIm5h
+        cG0vMWFjNjE5MmUtNzRlMi00Mzg5LWExYTItZjliYjZlNGRmZTY5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MzIuMzk4ODE2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoxNjowNC41OTM2NzdaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozMzozNC42NTMwODdaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:49 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/08da7638-570d-49f7-b8ea-bc7f0404f1fd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/1ac6192e-74e2-4389-a1a2-f9bb6e4dfe69/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 63a0b95e9780427db2d5cc11f52edb49
+      - 111413a182cf486d817a6e68fd05fff1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg5NGVmNTJiLTFmY2MtNDU0
-        Zi04ZGY4LTQ1NGUzZGFhYTBiYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJmYTliYmM2LThkYTgtNGQ4
+        Yi05MDI5LTM0Njk2ZmRkMzE4OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/deeeecbc-bde1-4b7f-bd33-20803f51e613/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b6907486-74e8-44de-b500-ad4bd51a134c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad10467c21734ee996327bdac113444d
+      - 652a49ecb77b47c39084277fb0cc7223
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGVlZWVjYmMtYmRl
-        MS00YjdmLWJkMzMtMjA4MDNmNTFlNjEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTAuOTExODI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjY5MDc0ODYtNzRl
+        OC00NGRlLWI1MDAtYWQ0YmQ1MWExMzRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDkuNTIyNzI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NmQ4NjFjMWU4NmE0ZjU0ODRiMTY2NmM2
-        MDJkMmU2ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjEwLjk0
-        MTgzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTEuMDA3
-        MTc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiNTlmODgxYmM2M2I0ZDMwYTEzMWExY2I2
+        Yjg5NGE5OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjQ5LjU3
+        OTQzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6NDkuNzA0
+        ODkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0MS00NWUx
-        LWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFiYy00N2Yy
+        LWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/894ef52b-1fcc-454f-8df8-454e3daaa0bc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2fa9bbc6-8da8-4d8b-9029-34696fdd3188/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 372e7a9902f0441188d40eea882ddf3e
+      - 238c0fb20c2f42ca9925868b59afc9f7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODk0ZWY1MmItMWZj
-        Yy00NTRmLThkZjgtNDU0ZTNkYWFhMGJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTAuOTk4NjUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmZhOWJiYzYtOGRh
+        OC00ZDhiLTkwMjktMzQ2OTZmZGQzMTg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDkuNzAwNTc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2M2EwYjk1ZTk3ODA0MjdkYjJkNWNjMTFm
-        NTJlZGI0OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjExLjAz
-        NTM4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTEuMDc2
-        Njg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxMTE0MTNhMTgyY2Y0ODZkODE3YTZlNjhm
+        ZDA1ZmZmMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjQ5Ljc1
+        ODI2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6NDkuODM5
+        MjQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA4ZGE3NjM4LTU3MGQtNDlmNy1iOGVh
-        LWJjN2YwNDA0ZjFmZC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFhYzYxOTJlLTc0ZTItNDM4OS1hMWEy
+        LWY5YmI2ZTRkZmU2OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 79e609f950ec4fe293b03b5149fc95cb
+      - 838dc7523b2f4c529c1933bc37166959
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef1f323dbc934e5d8b301a7bfd52ea6c
+      - 9fecc1ca595644bf9ecb8cef0656c420
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2a1d22ebd0dd49ee8d8847b6ba1d0ccd
+      - 82a34420983845bca233dba3d3cd19de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 331c24ab1b1f4a24b4c9e393ca54fa2a
+      - d80ef3ec24584c308da948a3bf778880
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 758f1b76499749c8870189653a7c5265
+      - 32217e3de75442a9ae31b44445094280
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8fca870663b64b33b8276492351c41c3
+      - e7251293540243ec89613f16b1549da5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:50 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f542a0971634ceb88a490dd17246944
+      - 863d03f6db814102b29a25952d2352fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTlmNTkyNjItOTA1NS00ZjJiLWIyMDItZGMzZWEyOTdlNDlkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MTEuNDM1NDYyWiIsInZl
+        cG0vZTM1NDE5OGEtYjJiYy00MDYzLThhZGYtM2VmMzJjNWVlNDkyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6NTAuNjY2Nzk1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTlmNTkyNjItOTA1NS00ZjJiLWIyMDItZGMzZWEyOTdlNDlkL3ZlcnNp
+        cG0vZTM1NDE5OGEtYjJiYy00MDYzLThhZGYtM2VmMzJjNWVlNDkyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xOWY1OTI2Mi05
-        MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMzU0MTk4YS1i
+        MmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:50 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/894b2212-b9c5-4547-8174-b79a3c873aa4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c065bce0-f850-41f3-8f73-3f8065c5f4b4/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a706547dfc4485e92e29df70b623a44
+      - d9701f9c73ab4171a839fb4f3b414690
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkMDNiOTc4LThhMTgtNDZl
-        OS04NDRlLWU2ZWU4MTlmM2UyNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiMTM5ZmM0LTU3M2YtNDdl
+        Zi1iYTUyLWVjYjYzM2NiNTYxYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4d03b978-8a18-46e9-844e-e6ee819f3e25/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ab139fc4-573f-47ef-ba52-ecb633cb561b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a35b90220ea649ffab16011f7a590e90
+      - efdbb41b0c784f179141494758a8404e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGQwM2I5NzgtOGEx
-        OC00NmU5LTg0NGUtZTZlZTgxOWYzZTI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTEuNzE0MjQ4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWIxMzlmYzQtNTcz
+        Zi00N2VmLWJhNTItZWNiNjMzY2I1NjFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTEuMTE3ODY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI4YTcwNjU0N2RmYzQ0ODVlOTJlMjlkZjcw
-        YjYyM2E0NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjExLjc0
-        NTI3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTEuNzY5
-        NDg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkOTcwMWY5YzczYWI0MTcxYTgzOWZiNGYz
+        YjQxNDY5MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjUxLjE2
+        NTAxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6NTEuMjA4
+        MjM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg5NGIyMjEyLWI5YzUtNDU0Ny04MTc0
-        LWI3OWEzYzg3M2FhNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MwNjViY2UwLWY4NTAtNDFmMy04Zjcz
+        LTNmODA2NWM1ZjRiNC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg5NGIy
-        MjEyLWI5YzUtNDU0Ny04MTc0LWI3OWEzYzg3M2FhNC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MwNjVi
+        Y2UwLWY4NTAtNDFmMy04ZjczLTNmODA2NWM1ZjRiNC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:11 GMT
+      - Fri, 29 Jul 2022 11:33:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9d72348e73824d8e87810fd2f0f7e635
+      - c98436ea553e47d6abcaed6950ee00a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjOGUzZjdhLThkYTEtNGJj
-        Yi04MDY2LWQ1NTM5NjU0MGY0Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2MGMzNDg0LWZhMjItNGY4
+        ZS1iZWFlLWVhMWRmZDM5ZTE3Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1c8e3f7a-8da1-4bcb-8066-d55396540f42/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c60c3484-fa22-4f8e-beae-ea1dfd39e17b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:12 GMT
+      - Fri, 29 Jul 2022 11:33:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 40ffb2a2181a4c2985bf1cd168c4b2c9
+      - d485d30e15ae4bc98f5c95d81190153c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '660'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWM4ZTNmN2EtOGRh
-        MS00YmNiLTgwNjYtZDU1Mzk2NTQwZjQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTEuODg1OTc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzYwYzM0ODQtZmEy
+        Mi00ZjhlLWJlYWUtZWExZGZkMzllMTdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTEuMzQwODg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI5ZDcyMzQ4ZTczODI0ZDhlODc4
-        MTBmZDJmMGY3ZTYzNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjExLjkxOTExMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTIuNTg5MzMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJjOTg0MzZlYTU1M2U0N2Q2YWJj
+        YWVkNjk1MGVlMDBhMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjUxLjM5ODM0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTIuODA3MjQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
-        cnNlZCBNb2R1bGVtZCIsImNvZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRz
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3Vm
-        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQtZGVmYXVs
-        dHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLm1vZHVsZW1kX2RlZmF1bHRzIiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
-        c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiUGFyc2VkIENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRl
-        ZCIsInRvdGFsIjo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
-        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4t
-        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNv
-        bnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
-        IjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQyLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzE5YjQ3MjkwLWZhYWUtNGQwMC1iMzUyLWNiYmZl
-        MzNiZDAwNC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xOWI0
-        NzI5MC1mYWFlLTRkMDAtYjM1Mi1jYmJmZTMzYmQwMDQvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vODk0YjIyMTItYjljNS00NTQ3
-        LTgxNzQtYjc5YTNjODczYWE0LyJdfQ==
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9kYmYxNzBlMi1kYjVhLTRmN2ItOWZmMy01OGE2Yzg5
+        MGJlNmMvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGJmMTcw
+        ZTItZGI1YS00ZjdiLTlmZjMtNThhNmM4OTBiZTZjLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MwNjViY2UwLWY4NTAtNDFmMy04
+        ZjczLTNmODA2NWM1ZjRiNC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMTliNDcyOTAtZmFhZS00ZDAwLWIzNTItY2JiZmUzM2Jk
-        MDA0L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZGJmMTcwZTItZGI1YS00ZjdiLTlmZjMtNThhNmM4OTBi
+        ZTZjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:13 GMT
+      - Fri, 29 Jul 2022 11:33:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 45dac5f7854a416a9a9874d064ce5431
+      - d87bfc18cf0d44d096d7767ed6cd9f57
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExOTRkMGI0LTJlM2ItNDJj
-        ZC1hNTMzLTcxZWFmYmNmMjZlMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmY2YwNzZkLWQxNTUtNGJi
+        Mi1hOWM2LWE5NTE2OGFmNjIzMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a194d0b4-2e3b-42cd-a533-71eafbcf26e0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1fcf076d-d155-4bb2-a9c6-a95168af6233/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:13 GMT
+      - Fri, 29 Jul 2022 11:33:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f97a2cd14d2144e2b8c6ef0a20aea22e
+      - 4846b8d43f324beba8e1e128ba198ffe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTE5NGQwYjQtMmUz
-        Yi00MmNkLWE1MzMtNzFlYWZiY2YyNmUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTMuMDM4NjM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWZjZjA3NmQtZDE1
+        NS00YmIyLWE5YzYtYTk1MTY4YWY2MjMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTMuMjczNjUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjQ1ZGFjNWY3ODU0YTQxNmE5YTk4NzRkMDY0
-        Y2U1NDMxIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTMuMDY4
-        MjE3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxNjoxMy4zMDUx
-        MDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImQ4N2JmYzE4Y2YwZDQ0ZDA5NmQ3NzY3ZWQ2
+        Y2Q5ZjU3Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6NTMuMzEy
+        MjEzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMzo1My43NjQz
+        MThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzc2ZTQy
-        Y2MtMzc0My00NmQ4LTg2ZTktYTE5ODQ0MmUyMDVkLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzFkNTUz
+        MDUtM2QzOS00NTlmLTlhYTEtZjdhMjc5ZDhmY2EwLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMTliNDcyOTAtZmFhZS00ZDAwLWIzNTItY2JiZmUz
-        M2JkMDA0LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZGJmMTcwZTItZGI1YS00ZjdiLTlmZjMtNThhNmM4
+        OTBiZTZjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:13 GMT
+      - Fri, 29 Jul 2022 11:33:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a5675560920c437e8b4c2a135a948c7f
+      - 401dbf8a16c34d54ad6e261430e84651
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/c1d55305-3d39-459f-9aa1-f7a279d8fca0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b66f9ce68adf4894b24531e246982187
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYzFkNTUzMDUtM2QzOS00NTlmLTlhYTEtZjdhMjc5ZDhmY2EwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6NTMuMzQwMTM1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kYmYxNzBlMi1kYjVhLTRmN2ItOWZmMy01OGE2Yzg5MGJlNmMv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2RiZjE3MGUyLWRiNWEtNGY3Yi05ZmYzLTU4YTZj
+        ODkwYmU2Yy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:54 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9jMWQ1NTMwNS0zZDM5LTQ1OWYtOWFhMS1mN2EyNzlkOGZjYTAv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b5c21f50f7834550b9df231127e497c1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3OWY4OWEzLTVjMjAtNGJj
+        YS1iNWVkLTRlYTAzZWMzZDBkZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e79f89a3-5c20-4bca-b5ed-4ea03ec3d0de/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 28bc14a919254aa49d8eb9c9c434426a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTc5Zjg5YTMtNWMy
+        MC00YmNhLWI1ZWQtNGVhMDNlYzNkMGRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTQuMDUxMTgyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiNWMyMWY1MGY3ODM0NTUwYjlkZjIzMTEy
+        N2U0OTdjMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjU0LjA5
+        MjM3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6NTQuMzE4
+        MTQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZjE2
+        NjFmNTgtYzBlMi00MGJmLTg0YTgtMGYyZjlmMmJmZTY1LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/f1661f58-c0e2-40bf-84a8-0f2f9f2bfe65/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 81ec7cc98fd140759c5342168b51a85c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2YxNjYxZjU4LWMwZTItNDBiZi04NGE4LTBmMmY5ZjJiZmU2NS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMzOjU0LjI5NjI3N1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYzFkNTUzMDUtM2QzOS00NTlmLTlhYTEt
+        ZjdhMjc5ZDhmY2EwLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 635a0a51e8114842b0e1f4806fcaafe8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:13 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 626649b95bed423a986f66e21afb931a
+      - 26a7076cdc984843a64f4ba3474ff481
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:13 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dee4560310cd4267a5202b0b463624d4
+      - c046b7d406d84171a01f755c91542474
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:13 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11ab9a589e2849cf8129c03f464d92d9
+      - 70b910673f3f4af6b2b6a0c26d06dabc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:13 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f090d6c5d6104a498ea15ddac40bcc78
+      - f5faf106884f4f41ad5bcafd2436c53d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:13 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7fc10780ed340ceb0a482508576dade
+      - c359b103b8164784b28cf95fa660fff1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 834cdd8e350b4683b0e41031c8dd2c5c
+      - 4b920efd740943018965ee23d17c6229
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb0d7bf11eb543279072a883b79d08ad
+      - 335c45a6c6e74fd99ddb4d4e6ede627d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2920e40e50aa4f54be6d88512b004007
+      - f487019109494416badec1376b74904a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 60c30038f6a54fbcb71a342cd2885682
+      - 2fea3532b1e2404494ccdab7331e3de3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25e1b12955d347118dd819b96361ae0f
+      - fcbf14357e0c43a9a1f87a3fd1ed085c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 440135e06beb499582a03846ca97f905
+      - 0fde12e50020480fa2dd6a44a780748c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 871a763181474fa0b3e1d6ae86ead764
+      - 7fda4d3e64ff4fc8b3f5578fd63fee54
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/dbf170e2-db5a-4f7b-9ff3-58a6c890be6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c23515f517314fb6b1ed988b178c6674
+      - ff12cac6bac8464db8214e7fe746be0f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9eeeea2185dc4d058d018100f5bceb9b
+      - ea319efa2e404be69fa1e3a346831769
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FhNGEyN2Q1LTU0MjAtNDhh
-        Mi04OTNhLWFiYTk5ZjRmOGI2Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEyZjE3NmUyLTI1MTQtNDQ2
+        YS04MzcxLWE1YTNkZDE3MTVhMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjQ4Mzk2OC1iNWM2LTRiNzMtYWU0
-        YS04N2JjYThlYjM5ZTEvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6fd81ca2deee4979a923606b214a6e46
+      - 3641cac0c6ea49d68c6e6aeb614d863d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwOGZlNDhlLWUxZDEtNDIz
-        NC1hY2M0LTU3NjhkMmU3MjlhNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1ZjA2ODk1LTgxODItNGNl
+        My1hYWZmLWI3NTlmNWUzMmNmZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5N2Qt
-        OTkyMTM4NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2ZTE4
-        NGQ5MmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzLzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0YS8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,97 +3935,97 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbadb04008ab4f9baee2f62121bb05e6
+      - 8b0c288c781b4e96b79c7395fa3fdd6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmNTAyYjgxLTg4Y2ItNGU5
-        My05OTkwLTI5ZjRhMmJiMWJmMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiYmQ4NzBjLTY1MWQtNDg1
+        NS05MzUyLTUxNWU3NDg0YTJlYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTliNDcyOTAtZmFhZS00ZDAwLWIz
-        NTItY2JiZmUzM2JkMDA0L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzE5ZjU5MjYyLTkwNTUt
-        NGYyYi1iMjAyLWRjM2VhMjk3ZTQ5ZC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJm
-        Ny04MzIyLTdhOWRkZDVhOGE3OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82YTEwYmJiZi01MWUxLTQxNWEtYTAwZi03OWI3MWFl
-        MWQzZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        N2ZmZDYwNzYtZjdkZC00NWQzLThmMTctN2ZjNDE4ZDFhZGYzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzhhYTU1NzE0LTFmOTYt
-        NGRiMy04YTMxLTM1MzI1ZmQ3N2NjMC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9iM2QzNTBiMS1mMDcxLTRkYTAtOWI5Zi1lNGQ3
-        M2E4YWIwYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvZWU3MmE5ZTYtM2FmZi00Mjc3LWIzMmItYWI5MjA0YTU1OWI5LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEy
-        YTktNDM4NS04MDIxLWJlMmNkOThmZThjMC8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzL2M3ZTM1NDE3LTlkODctNDhk
-        ZS05OGQ4LTUyZDYzNWIzZWViYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzA4Nzc2NDI2LTNmM2YtNGE2Mi1iYjFjLTk4NGM1NmZi
-        MzA0My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzY4
-        ZGM0YmU0LTgzN2YtNGY2Yi05Zjg4LTUxZGVhMzAwZGU4Ny8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzgwMGI1NWM2LTk3NTMtNDM4
-        MS05ZDc4LTBmZGUyZGRmZWU0Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVm
-        ZGMwMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Uz
-        MzhmYzExLTdmODctNDhiMi04MTQzLWE2MTkwZGJlYjhjNy8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjctNDU2
-        ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFm
-        Y2E5Zjg5MGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
-        cm91cHMvYTk4OThmYTktZDhjYy00YTM5LTk5YmYtNDk2MmJjYzBmZTA1LyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02
-        OTZlLTQ2MzMtYWJkNC1kY2VlZTJlZjc4YzIvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzItNDVmMy1iNWIwLTU2
-        OGU2ZWQyNjNmNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMjM5MjhjODYtNjJhZC00ZjJlLThmZWQtZTViZWY0OTUxMDdlLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdkOC01YWM2
-        LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJlLTcyMjNi
-        Njk4NWUyOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        M2RlNDc5YjEtZTdhYy00ZDFkLWFmNTQtNGYxMWFkMGNmNGU0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRlZjI2Zi00ZjQ4LTRh
-        MTItYjY3OS01Y2QzZGRkYTlhNTcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMxOC04YjRiLTM5ZWFjOTI2
-        M2M0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWYz
-        MWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OTk2Y2ZhZC0yZjQ4LTRlYzYt
-        YjIyMS03ZTk3YzM2ODkxYjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzZkNjBkYTJmLTBhYTctNDZhZi1iZjZmLWE5YTNkODZlZTE0
-        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2JkMjdl
-        ODQtY2I0MC00ZTg5LThkODEtY2U2MGQxNjZkMjJhLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NmY5OWQ5Mi0zNzUwLTRhNDktOThm
-        ZS00NjZhMTUyMTc5NzEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzlhZDA3ZTYxLWE5YjMtNGIxYS05OWJkLTM1NGZhZThiZDA2MS8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYtOWQwOC1h
-        MjRmYTBhYzIzZmQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2QxYzI5MjA2LTQxMTAtNDIwOC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDVhMmYxYWQtMDQy
-        YS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9kZmJlNjJhYi04Nzg5LTQ2MjAtYTUyYy03ZmE2
-        YjQ0MDNiYmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U2NmZjODQ2LTM0OGMtNDM1MC04NmUxLWMzMmJkY2E0MWQzZS8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9kMjQ0
-        MWVhYS0zZmMxLTQ3NzUtOTIwZS1hNmQ3NjhkNmMyMTcvIl19XSwiZGVwZW5k
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGJmMTcwZTItZGI1YS00ZjdiLTlm
+        ZjMtNThhNmM4OTBiZTZjL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UzNTQxOThhLWIyYmMt
+        NDA2My04YWRmLTNlZjMyYzVlZTQ5Mi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYy
+        YWItNGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQy
+        OTI5My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1
+        ZWE3ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBl
+        NS1hZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFk
+        MTkxOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYy
+        NTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgx
+        NS04OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJm
+        MjFjYmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
+        cm91cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0y
+        OTFhLTQzMzYtYWRiZC1kODliN2IwMWQ4NDYvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0YzgtNDU5Mi04Mzg0LWIy
+        NzZmZmE3ZTgyNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzViYmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0
+        NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0OTU0ZWVkLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81YTMyODQyNi0yYmFmLTQx
+        ODktOWNjNS02ZDhkYzM1YzEwZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQtNGU0Ni04ZmMzLTFiZmY3OTlm
+        YjYxZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjVm
+        YmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NmQwMjRjMi0xMGZjLTQwMWMt
+        YWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEy
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVm
+        MmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUtOTM2
+        Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMt
+        NTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0y
+        MmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkxLTM2ZWM4ZmMzNTA0OC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVh
+        Mi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2ZkYjk1N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJm
+        NTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19XSwiZGVwZW5k
         ZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3613,7 +4038,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3631,21 +4056,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 38cac2971c2b424ba8672ed5ba4ba887
+      - 01c6efe27cf748a4930a59eafae969f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxMjRkOWQ2LTI5NGYtNGFh
-        ZC05YjAwLTBkNDY5MWE2ZjAxMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViYWM3YmE0LTAzODctNDY1
+        OS1iYmYzLTFiNTRkNzM4ODkxMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/aa4a27d5-5420-48a2-893a-aba99f4f8b67/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/12f176e2-2514-446a-8371-a5a3dd1715a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3666,51 +4091,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:14 GMT
+      - Fri, 29 Jul 2022 11:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 894bd8f5c22a4573a72b0c61efc881ff
+      - 84bfe2d3e1de494096232faf2f617ede
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWE0YTI3ZDUtNTQy
-        MC00OGEyLTg5M2EtYWJhOTlmNGY4YjY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNjQzMTIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTJmMTc2ZTItMjUx
+        NC00NDZhLTgzNzEtYTVhM2RkMTcxNWEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNDAzMTMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ZWVlZWEyMTg1ZGM0ZDA1OGQw
-        MTgxMDBmNWJjZWI5YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0LjY3MjU5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTQuODAyMDg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlYTMxOWVmYTJlNDA0YmU2OWZh
+        MWUzYTM0NjgzMTc2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU2LjQ2MDc2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTYuNzM3ODAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1
-        NS00ZjJiLWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJi
+        Yy00MDYzLThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/aa4a27d5-5420-48a2-893a-aba99f4f8b67/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/45f06895-8182-4ce3-aaff-b759f5e32cfd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3731,118 +4156,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e8a23c371af24432b707f02c57f2d50a
+      - e6dcea95c5424d80bd8e0626740079ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWE0YTI3ZDUtNTQy
-        MC00OGEyLTg5M2EtYWJhOTlmNGY4YjY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNjQzMTIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDVmMDY4OTUtODE4
+        Mi00Y2UzLWFhZmYtYjc1OWY1ZTMyY2ZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNDkxNTg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ZWVlZWEyMTg1ZGM0ZDA1OGQw
-        MTgxMDBmNWJjZWI5YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0LjY3MjU5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTQuODAyMDg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1
-        NS00ZjJiLWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/308fe48e-e1d1-4234-acc4-5768d2e729a7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 8832986856924a5aabf40c00d64e8664
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzA4ZmU0OGUtZTFk
-        MS00MjM0LWFjYzQtNTc2OGQyZTcyOWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNjkzMDY1WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmQ4MWNhMmRlZWU0OTc5YTky
-        MzYwNmIyMTRhNmU0NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0LjgyOTkyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTQuOTU2MDQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzNjQxY2FjMGM2ZWE0OWQ2OGM2
+        ZTZhZWI2MTRkODYzZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU2LjgxMjE1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTcuMDg3MTYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xOWY1OTI2Mi05MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQvdmVyc2lv
+        bS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1NS00ZjJi
-        LWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJiYy00MDYz
+        LThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3f502b81-88cb-4e93-9990-29f4a2bb1bf2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/12f176e2-2514-446a-8371-a5a3dd1715a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3863,118 +4223,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d2fe3075178a49ebb44120329bd24a4a
+      - dd871b16f92841aab579647c5c7cc12a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Y1MDJiODEtODhj
-        Yi00ZTkzLTk5OTAtMjlmNGEyYmIxYmYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNzQxODkzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTJmMTc2ZTItMjUx
+        NC00NDZhLTgzNzEtYTVhM2RkMTcxNWEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNDAzMTMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmYmFkYjA0MDA4YWI0ZjliYWVl
-        MmY2MjEyMWJiMDVlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0Ljk4NTcyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTUuMTE4Mjk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xOWY1OTI2Mi05MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQvdmVyc2lv
-        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1NS00ZjJi
-        LWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/aa4a27d5-5420-48a2-893a-aba99f4f8b67/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1de53f7ee5574cbdbc6560a414aabb8f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWE0YTI3ZDUtNTQy
-        MC00OGEyLTg5M2EtYWJhOTlmNGY4YjY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNjQzMTIwWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ZWVlZWEyMTg1ZGM0ZDA1OGQw
-        MTgxMDBmNWJjZWI5YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0LjY3MjU5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTQuODAyMDg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlYTMxOWVmYTJlNDA0YmU2OWZh
+        MWUzYTM0NjgzMTc2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU2LjQ2MDc2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTYuNzM3ODAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1
-        NS00ZjJiLWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJi
+        Yy00MDYzLThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/308fe48e-e1d1-4234-acc4-5768d2e729a7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/45f06895-8182-4ce3-aaff-b759f5e32cfd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3995,53 +4288,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d7c30c6b7fa4779819f93aad57c88f0
+      - 9f8ba0e2ebe849eeba95a1802d08fdf2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzA4ZmU0OGUtZTFk
-        MS00MjM0LWFjYzQtNTc2OGQyZTcyOWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNjkzMDY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDVmMDY4OTUtODE4
+        Mi00Y2UzLWFhZmYtYjc1OWY1ZTMyY2ZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNDkxNTg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmQ4MWNhMmRlZWU0OTc5YTky
-        MzYwNmIyMTRhNmU0NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0LjgyOTkyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTQuOTU2MDQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzNjQxY2FjMGM2ZWE0OWQ2OGM2
+        ZTZhZWI2MTRkODYzZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU2LjgxMjE1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTcuMDg3MTYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xOWY1OTI2Mi05MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQvdmVyc2lv
+        bS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1NS00ZjJi
-        LWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJiYy00MDYz
+        LThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3f502b81-88cb-4e93-9990-29f4a2bb1bf2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0bbd870c-651d-4855-9352-515e7484a2ec/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4062,53 +4355,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 45e46542420848a180e8e81086fab602
+      - 73de8ba0f3654c408b84c6cca696a600
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Y1MDJiODEtODhj
-        Yi00ZTkzLTk5OTAtMjlmNGEyYmIxYmYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNzQxODkzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGJiZDg3MGMtNjUx
+        ZC00ODU1LTkzNTItNTE1ZTc0ODRhMmVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNTU5MDAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmYmFkYjA0MDA4YWI0ZjliYWVl
-        MmY2MjEyMWJiMDVlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0Ljk4NTcyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTUuMTE4Mjk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4YjBjMjg4Yzc4MWI0ZTk2Yjc5
+        YzczOTVmYTNmZGQ2YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU3LjE1ODA5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTcuMzg3MzA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xOWY1OTI2Mi05MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQvdmVyc2lv
+        bS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1NS00ZjJi
-        LWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJiYy00MDYz
+        LThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/aa4a27d5-5420-48a2-893a-aba99f4f8b67/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/12f176e2-2514-446a-8371-a5a3dd1715a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4129,51 +4422,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa098652a2704709b2567833ebe6443f
+      - d70e4bf66c284a00a6d167f5aef6be0a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWE0YTI3ZDUtNTQy
-        MC00OGEyLTg5M2EtYWJhOTlmNGY4YjY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNjQzMTIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTJmMTc2ZTItMjUx
+        NC00NDZhLTgzNzEtYTVhM2RkMTcxNWEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNDAzMTMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ZWVlZWEyMTg1ZGM0ZDA1OGQw
-        MTgxMDBmNWJjZWI5YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0LjY3MjU5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTQuODAyMDg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlYTMxOWVmYTJlNDA0YmU2OWZh
+        MWUzYTM0NjgzMTc2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU2LjQ2MDc2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTYuNzM3ODAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1
-        NS00ZjJiLWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJi
+        Yy00MDYzLThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/308fe48e-e1d1-4234-acc4-5768d2e729a7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/45f06895-8182-4ce3-aaff-b759f5e32cfd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4194,53 +4487,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1c65009c5bc4a27aa8072fe1e10867a
+      - ed1c70dbed0c4cc68e458534d2ea1938
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzA4ZmU0OGUtZTFk
-        MS00MjM0LWFjYzQtNTc2OGQyZTcyOWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNjkzMDY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDVmMDY4OTUtODE4
+        Mi00Y2UzLWFhZmYtYjc1OWY1ZTMyY2ZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNDkxNTg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmQ4MWNhMmRlZWU0OTc5YTky
-        MzYwNmIyMTRhNmU0NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0LjgyOTkyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTQuOTU2MDQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzNjQxY2FjMGM2ZWE0OWQ2OGM2
+        ZTZhZWI2MTRkODYzZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU2LjgxMjE1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTcuMDg3MTYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xOWY1OTI2Mi05MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQvdmVyc2lv
+        bS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1NS00ZjJi
-        LWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJiYy00MDYz
+        LThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3f502b81-88cb-4e93-9990-29f4a2bb1bf2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0bbd870c-651d-4855-9352-515e7484a2ec/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4261,53 +4554,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2a60c8372e904daf9bca4ace42b0bf65
+      - e4b7a44d050648a583a3bfee208158ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Y1MDJiODEtODhj
-        Yi00ZTkzLTk5OTAtMjlmNGEyYmIxYmYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNzQxODkzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGJiZDg3MGMtNjUx
+        ZC00ODU1LTkzNTItNTE1ZTc0ODRhMmVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNTU5MDAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmYmFkYjA0MDA4YWI0ZjliYWVl
-        MmY2MjEyMWJiMDVlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE0Ljk4NTcyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTUuMTE4Mjk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4YjBjMjg4Yzc4MWI0ZTk2Yjc5
+        YzczOTVmYTNmZGQ2YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU3LjE1ODA5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTcuMzg3MzA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8xOWY1OTI2Mi05MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQvdmVyc2lv
+        bS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1NS00ZjJi
-        LWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJiYy00MDYz
+        LThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e124d9d6-294f-4aad-9b00-0d4691a6f013/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/12f176e2-2514-446a-8371-a5a3dd1715a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4328,55 +4621,254 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9735c02aef4f423791420fc6a8fb2312
+      - a92cf15cd86647e9a5444c73813576b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '415'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTEyNGQ5ZDYtMjk0
-        Zi00YWFkLTliMDAtMGQ0NjkxYTZmMDEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTQuNzk3NDUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTJmMTc2ZTItMjUx
+        NC00NDZhLTgzNzEtYTVhM2RkMTcxNWEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNDAzMTMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlYTMxOWVmYTJlNDA0YmU2OWZh
+        MWUzYTM0NjgzMTc2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU2LjQ2MDc2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTYuNzM3ODAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJi
+        Yy00MDYzLThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:58 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/45f06895-8182-4ce3-aaff-b759f5e32cfd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '697'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a125f946809147db88a35d9a5f7325bc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDVmMDY4OTUtODE4
+        Mi00Y2UzLWFhZmYtYjc1OWY1ZTMyY2ZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNDkxNTg5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzNjQxY2FjMGM2ZWE0OWQ2OGM2
+        ZTZhZWI2MTRkODYzZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU2LjgxMjE1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTcuMDg3MTYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJiYy00MDYz
+        LThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:58 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0bbd870c-651d-4855-9352-515e7484a2ec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '697'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ce25e00a2052453bb334dffed9d07732
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGJiZDg3MGMtNjUx
+        ZC00ODU1LTkzNTItNTE1ZTc0ODRhMmVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNTU5MDAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4YjBjMjg4Yzc4MWI0ZTk2Yjc5
+        YzczOTVmYTNmZGQ2YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjU3LjE1ODA5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NTcuMzg3MzA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9lMzU0MTk4YS1iMmJjLTQwNjMtOGFkZi0zZWYzMmM1ZWU0OTIvdmVyc2lv
+        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5OGEtYjJiYy00MDYz
+        LThhZGYtM2VmMzJjNWVlNDkyLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:58 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5bac7ba4-0387-4659-bbf3-1b54d7388910/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 22fdd7a4ebe348aab7acd309655e1e33
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWJhYzdiYTQtMDM4
+        Ny00NjU5LWJiZjMtMWI1NGQ3Mzg4OTEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NTYuNjM5MDkwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiMzhjYWMyOTcxYzJiNDI0YmE4NjcyZWQ1YmE0
-        YmE4ODciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxNjoxNS4xNDg0
-        NTRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjE1LjUwNzc1
-        NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiMDFjNmVmZTI3Y2Y3NDhhNDkzMGE1OWVhZmFl
+        OTY5ZjkiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMzo1Ny40NDAz
+        NzRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjU4LjE5MzQ0
+        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTky
-        NjItOTA1NS00ZjJiLWIyMDItZGMzZWEyOTdlNDlkL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTM1NDE5
+        OGEtYjJiYy00MDYzLThhZGYtM2VmMzJjNWVlNDkyL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzE5ZjU5MjYyLTkwNTUtNGYyYi1iMjAyLWRj
-        M2VhMjk3ZTQ5ZC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzE5YjQ3MjkwLWZhYWUtNGQwMC1iMzUyLWNiYmZlMzNiZDAw
-        NC8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2UzNTQxOThhLWIyYmMtNDA2My04YWRmLTNl
+        ZjMyYzVlZTQ5Mi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2RiZjE3MGUyLWRiNWEtNGY3Yi05ZmYzLTU4YTZjODkwYmU2
+        Yy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4384,7 +4876,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4397,76 +4889,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74a889096ca64576874d8ced66788689
+      - 7086d68c4af04d4db56b113aed6ab0d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '563'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04ZDgxLWNlNjBkMTY2ZDIyYS8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9kNWEyZjFhZC0wNDJhLTQwNWUtYWM0NC0wYzRiMTRkYmJlY2EvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNWYzMWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWFk
-        MDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJkMDYxLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdi
-        OGMzLTk5ZTctNDliMC05OGJlLTcyMjNiNjk4NWUyOC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdk
-        OC01YWM2LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2Zjk5ZDkyLTM3
-        NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZTI0MGY3My03MWU4
-        LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00
-        YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA3OWUzNjU0LTY5NmUtNDYz
-        My1hYmQ0LWRjZWVlMmVmNzhjMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYt
-        OWQwOC1hMjRmYTBhYzIzZmQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00MzUwLTg2
-        ZTEtYzMyYmRjYTQxZDNlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzItNDVmMy1iNWIw
-        LTU2OGU2ZWQyNjNmNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00
-        ZjExYWQwY2Y0ZTQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZDFjMjkyMDYtNDExMC00MjA4LWEyMGMtYzM4
-        NTVjZDRmNDBjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4474,7 +4966,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4487,50 +4979,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:15 GMT
+      - Fri, 29 Jul 2022 11:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71202b4b69994f7c9770a08256a314d1
+      - 636a5d087d25433081dc5d7fa39f6a90
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '264'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmItOWY4OC01MWRlYTMwMGRlODcv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVmZGMwMi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvODAwYjU1YzYtOTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4YjItODE0My1hNjE5MGRiZWI4YzcvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2U3NDEzZmUwLTMwNjctNDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4538,7 +5030,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4551,37 +5043,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a3a8bb75ba274e2088bad43695bd79a8
+      - 2135aebe96114f458be4f26a0a9cf16d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4654,9 +5146,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -4672,8 +5164,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -4691,9 +5183,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -4715,9 +5207,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -4733,9 +5225,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -4744,9 +5236,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -4775,10 +5267,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4786,7 +5278,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4799,43 +5291,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dafee138607e4c808a13be580c787ede
+      - 97db30a0b93a47729ffe01b0f7b726c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4843,7 +5335,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4856,41 +5348,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d9f27ca9185d41979d50502c5bfeedc5
+      - 628b98076bf446e187c49bdaa1294fba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4898,7 +5390,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4911,36 +5403,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 185bf335b2e94b10ba47bf878b678b7a
+      - 3dc2386bf860422cbe325bbb24de6c36
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4962,10 +5454,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4973,7 +5465,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4986,76 +5478,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 78415513e6ea418db72d87f864a2c982
+      - 0d9a580fa7dd4eb4a7389f6ffc9e1384
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '563'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04ZDgxLWNlNjBkMTY2ZDIyYS8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9kNWEyZjFhZC0wNDJhLTQwNWUtYWM0NC0wYzRiMTRkYmJlY2EvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNWYzMWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWFk
-        MDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJkMDYxLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdi
-        OGMzLTk5ZTctNDliMC05OGJlLTcyMjNiNjk4NWUyOC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdk
-        OC01YWM2LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2Zjk5ZDkyLTM3
-        NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZTI0MGY3My03MWU4
-        LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00
-        YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA3OWUzNjU0LTY5NmUtNDYz
-        My1hYmQ0LWRjZWVlMmVmNzhjMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYt
-        OWQwOC1hMjRmYTBhYzIzZmQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00MzUwLTg2
-        ZTEtYzMyYmRjYTQxZDNlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzItNDVmMy1iNWIw
-        LTU2OGU2ZWQyNjNmNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00
-        ZjExYWQwY2Y0ZTQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZDFjMjkyMDYtNDExMC00MjA4LWEyMGMtYzM4
-        NTVjZDRmNDBjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5063,7 +5555,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5076,50 +5568,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 258f1bcf4f434f049d923ef889410d42
+      - f4caa00a4b264941831c9f562c322184
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '264'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmItOWY4OC01MWRlYTMwMGRlODcv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVmZGMwMi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvODAwYjU1YzYtOTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4YjItODE0My1hNjE5MGRiZWI4YzcvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2U3NDEzZmUwLTMwNjctNDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5127,7 +5619,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5140,37 +5632,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8698fef99c2c427c876877ec841bb757
+      - 2349125d80944173beafe2a53fb1e7ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -5243,9 +5735,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -5261,8 +5753,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -5280,9 +5772,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -5304,9 +5796,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -5322,9 +5814,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -5333,9 +5825,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -5364,10 +5856,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5375,7 +5867,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5388,43 +5880,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9791ddcad7441e59a64b84214e21946
+      - 0677b174e1f247d1a34ef8f0c66af68c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5432,7 +5924,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5445,41 +5937,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 198e649796cf421ba05b2b4cb1b4a550
+      - 53cad0998eb54104b9747991184f8157
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e354198a-b2bc-4063-8adf-3ef32c5ee492/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5487,7 +5979,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5500,36 +5992,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:16 GMT
+      - Fri, 29 Jul 2022 11:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d33cdac14f0d4ccb9e7d8addcdcab1eb
+      - bf3ed43742a5421192ef75130e85a766
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5551,5 +6043,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:00 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_module_stream_repository/all_module_streams_copied_if_no_modular_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_module_stream_repository/all_module_streams_copied_if_no_modular_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:55 GMT
+      - Fri, 29 Jul 2022 11:33:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,27 +35,94 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 292136390edc4dbf8b7a668f28d59bb9
+      - 366556017ed54bde8ed22bbc969e9d32
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS81NDA4ZDM2MC05ZmM0LTQzYTAtYWIyYS1kOTc2YTZkOTY5ZjEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMzoxNC42MDM2OTFa
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS81NDA4ZDM2MC05ZmM0LTQzYTAtYWIyYS1kOTc2YTZkOTY5ZjEv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU0MDhk
+        MzYwLTlmYzQtNDNhMC1hYjJhLWQ5NzZhNmQ5NjlmMS92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
+        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
+        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
+        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
+        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
+        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
+        ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:30 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 48188e7150ec415b90eec80684500ed0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxMGFhOGViLTY5ZTMtNDJi
+        YS1hMDA3LTc0MjgwMmE1MjdkYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:55 GMT
+      - Fri, 29 Jul 2022 11:33:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 30374dffc6f54dde975bfda0856b7fdc
+      - 26b8125893164909a30331e61b4539f5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f10aa8eb-69e3-42ba-a007-742802a527dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:55 GMT
+      - Fri, 29 Jul 2022 11:33:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -137,31 +204,43 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e3e8448b21f6429bb8d6ce4236f0727a
+      - 3b7d3077f2e44e24bd0b6ccd4e4a3faf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjEwYWE4ZWItNjll
+        My00MmJhLWEwMDctNzQyODAyYTUyN2RjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MzAuNzY3MzEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0ODE4OGU3MTUwZWM0MTViOTBlZWM4MDY4
+        NDUwMGVkMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjMwLjg1
+        MTYyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MzEuMTc1
+        NjQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTQwOGQzNjAtOWZjNC00M2Ew
+        LWFiMmEtZDk3NmE2ZDk2OWYxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:55 GMT
+      - Fri, 29 Jul 2022 11:33:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 51134556ff2f4ce5ac495fc15ec6e967
+      - e0e8b40173ed4e768de4ddc91d533e34
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -222,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -235,7 +314,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:55 GMT
+      - Fri, 29 Jul 2022 11:33:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -247,27 +326,88 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '448'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a9e81ec059e4bd79efcef969ff0878e
+      - 965a2a115adb4f7da3e53e2ffd292683
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNGFkZDYyNWQtZWIzZC00NjNlLWI2N2UtZGJmZjU5ZjI2NTg2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MjAuOTUwNzAw
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:31 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4add625d-eb3d-463e-b67e-dbff59f26586/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 73d1f915ba2e4d8f90fad12542b126c6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IxOTFkZGJmLTliMDctNGY3
+        ZC1iZjM1LWRmM2I3N2IxMmEyMy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b191ddbf-9b07-4f7d-bf35-df3b77b12a23/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -275,7 +415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -288,7 +428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:55 GMT
+      - Fri, 29 Jul 2022 11:33:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -296,31 +436,42 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 849bcc5ee23b461399355c27c7b4cb21
+      - 771f773b88044d328745be9d5468e89b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjE5MWRkYmYtOWIw
+        Ny00ZjdkLWJmMzUtZGYzYjc3YjEyYTIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MzEuNTg2MDQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3M2QxZjkxNWJhMmU0ZDhmOTBmYWQxMjU0
+        MmIxMjZjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjMxLjY1
+        NDg1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MzEuNzE0
+        NzM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -328,7 +479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -341,7 +492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:55 GMT
+      - Fri, 29 Jul 2022 11:33:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -359,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '07998e15f82d4e9a95e3d9944ffcdb25'
+      - '019e1e2824254c34b4d0c3d6c6332057'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -381,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -412,21 +563,127 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68b553858f2345fea05256ab2e39a22d
+      - bbf5e22a86614637bdd55831c61e4345
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 941f6f9c81714845a1ed7f2187adf471
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3afb4c97beed4365b325a4f002aaf8be
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -443,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -456,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/5679eb5a-2777-4cd8-8462-fb46ba054752/"
+      - "/pulp/api/v3/remotes/rpm/rpm/1ac6192e-74e2-4389-a1a2-f9bb6e4dfe69/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -476,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a48baef3cf6945dda7936bbfab3f0a37
+      - ed93e505addd437abf4fceda72328fe7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU2
-        NzllYjVhLTI3NzctNGNkOC04NDYyLWZiNDZiYTA1NDc1Mi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjU2LjExMDIwMloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFh
+        YzYxOTJlLTc0ZTItNDM4OS1hMWEyLWY5YmI2ZTRkZmU2OS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMzOjMyLjM5ODgxNloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjE1OjU2LjExMDIzNVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjMzOjMyLjM5ODg0OVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -511,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -524,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/"
+      - "/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -544,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb6ad07ff8aa4e57baa7573bb5f69376
+      - b72c86d817a643d592cfa7b01bf2665c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjAzNzdhMzUtODE2Zi00ZDk1LWIxMjMtNTZlMzU4NmI3NjNmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6NTYuMjI0NDU0WiIsInZl
+        cG0vNmRlOTBmZjctMjllOC00NjgyLTliMDQtZDk4NDNmODgwZjU3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MzIuNjM4OTA1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjAzNzdhMzUtODE2Zi00ZDk1LWIxMjMtNTZlMzU4NmI3NjNmL3ZlcnNp
+        cG0vNmRlOTBmZjctMjllOC00NjgyLTliMDQtZDk4NDNmODgwZjU3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMDM3N2EzNS04
-        MTZmLTRkOTUtYjEyMy01NmUzNTg2Yjc2M2YvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82ZGU5MGZmNy0y
+        OWU4LTQ2ODItOWIwNC1kOTg0M2Y4ODBmNTcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -568,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -579,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -592,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6088da90633045f396e75f29c5bb0a77
+      - 34765b093bf54da68bb6a26899db1607
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82YTg3Mzg4ZC1lMzU2LTRkNGQtYjJmYi1hY2JiY2JlZDQ3NTkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxMzo0OC4yMzkwODFa
+        cnBtL3JwbS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMzoxNi4xODE4MDNa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82YTg3Mzg4ZC1lMzU2LTRkNGQtYjJmYi1hY2JiY2JlZDQ3NTkv
+        cnBtL3JwbS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZhODcz
-        ODhkLWUzNTYtNGQ0ZC1iMmZiLWFjYmJjYmVkNDc1OS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk5YzZk
+        OTcwLWIwMGEtNDk2NC1hNDdlLTY4MjUxZGI0ZTQwMS92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -634,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:32 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6a87388d-e356-4d4d-b2fb-acbbcbed4759/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -645,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -658,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -676,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c01010be52e74da2ba0a406a4c74d862
+      - 49ccb6fcda984008951723df216362ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzMjY1YjQzLTdlMjctNGY3
-        YS1hNmFjLWUxMDYwYzA2MTNlNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyZDUwMDFhLThlMjAtNDhl
+        Zi1hOTI0LWUyZTgyM2Q4ZDM3ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -698,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -711,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f6819d41d32d4d5c8f06538ac3a99663
+      - 61b471c8ea63474b95c77999159725c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '366'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vY2Q3ZDcwZjItNDRkZS00NTZlLTllYTQtMzFhYWNmYThmMzFjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTM6NDcuMDcxMTIxWiIsIm5h
-        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5v
-        cmcvc3JwbS11bnNpZ25lZC8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2Vy
-        dCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
-        bCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjIt
-        MDUtMjNUMjM6MTM6NDkuMDUzODkxWiIsImRvd25sb2FkX2NvbmN1cnJlbmN5
-        IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRl
-        IiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYw
-        LjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGlt
-        ZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJz
-        bGVzX2F1dGhfdG9rZW4iOm51bGx9XX0=
+        cG0vZDEzNDg1MmEtZjUxNy00M2U3LTllYjMtZmI1ZjY4MzlhNTRlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MTQuMzUyMjg3WiIsIm5h
+        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
+        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
+        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
+        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        Mi0wNy0yOVQxMTozMzoxNi44OTUxMThaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
+        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
+        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
+        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/cd7d70f2-44de-456e-9ea4-31aacfa8f31c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/d134852a-f517-43e7-9eb3-fb5f6839a54e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -763,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -776,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -794,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 259d4d0ff22049cfa90bade9c0439089
+      - 1c965cf248da49018b4cea72b3989f88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjYjE3MjQ1LWMxMDAtNGU5
-        OC1hMGEwLWMwMGRiZGI3ZWZlMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4OGQzZGNhLTM0NzgtNDMy
+        ZS1hZDExLWZmOGI0ZTU5YzQ0YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/23265b43-7e27-4f7a-a6ac-e1060c0613e6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2d5001a-8e20-48ef-a924-e2e823d8d37e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -829,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 51f599184ec84c5cb03334f4a4cd3c28
+      - e33d4c2c4f39421fbe7cb42dbae7fe8a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjMyNjViNDMtN2Uy
-        Ny00ZjdhLWE2YWMtZTEwNjBjMDYxM2U2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTYuMzcyMzcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJkNTAwMWEtOGUy
+        MC00OGVmLWE5MjQtZTJlODIzZDhkMzdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MzIuOTg3NDg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMDEwMTBiZTUyZTc0ZGEyYmEwYTQwNmE0
-        Yzc0ZDg2MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE1OjU2LjQw
-        MTk0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTU6NTYuNDYw
-        MDk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0OWNjYjZmY2RhOTg0MDA4OTUxNzIzZGYy
+        MTYzNjJlZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjMzLjA3
+        MDc3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MzMuMjMw
+        MjA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmE4NzM4OGQtZTM1Ni00ZDRk
-        LWIyZmItYWNiYmNiZWQ0NzU5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAwYS00OTY0
+        LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dcb17245-c100-4e98-a0a0-c00dbdb7efe1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f88d3dca-3478-432e-ad11-ff8b4e59c44a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -894,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6d042b7cc6404c2eb63a4a3ded90083b
+      - 7da28c61345444b1bc4595db5fdfabec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNiMTcyNDUtYzEw
-        MC00ZTk4LWEwYTAtYzAwZGJkYjdlZmUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTYuNDU5OTY5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjg4ZDNkY2EtMzQ3
+        OC00MzJlLWFkMTEtZmY4YjRlNTljNDRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MzMuMjA1OTkzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyNTlkNGQwZmYyMjA0OWNmYTkwYmFkZTlj
-        MDQzOTA4OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE1OjU2LjQ5
-        MjE2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTU6NTYuNTM4
-        OTE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxYzk2NWNmMjQ4ZGE0OTAxOGI0Y2VhNzJi
+        Mzk4OWY4OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjMzLjMw
+        MDEzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MzMuNDA2
+        ODc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NkN2Q3MGYyLTQ0ZGUtNDU2ZS05ZWE0
-        LTMxYWFjZmE4ZjMxYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2QxMzQ4NTJhLWY1MTctNDNlNy05ZWIz
+        LWZiNWY2ODM5YTU0ZS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -946,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -959,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -977,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6579bed519d840dfbbb07de0b7148a14
+      - 5a6c5743d74f4c51afcc8ddc7bbfad22
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -999,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1012,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1030,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f9482aa8d1d043a1a20df29a9e5adafb
+      - 186963dc6ab046e08bf6a8ffdd794e71
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1065,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1083,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d664f93e36194cc19daade137290c7c0
+      - 4888595a85514ea9b3b45aaa2008635d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1105,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1118,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1136,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95a0bea5214d4a24a13b538aa39d3f61
+      - 1a7030db8ca84c95a168f5d889d87211
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1158,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1171,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1189,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2e8d0e141038414f9891587b23dd56e5
+      - 7856518f8c7f49fca7300867fa609164
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1211,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1224,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1242,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af0b733952f2462aa0a8414277ea1b31
+      - e17d48501d404f30978600774d3fc039
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:33 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1266,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1279,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:56 GMT
+      - Fri, 29 Jul 2022 11:33:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/"
+      - "/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1299,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1abccbab4a6d4501a1ba5684713ed5dc
+      - 622e137184b641778a4fe2f4bf1987d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmNmMjNlOTMtNjM0NC00NmY5LWFhZGItOWFmYmEyYjJiMWJmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6NTYuODk3MjI5WiIsInZl
+        cG0vNTRmZGU3OTMtZmFiYy00N2YyLWJkMWMtNzY1MTZjYjQwNjU0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MzQuMDI5ODg3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmNmMjNlOTMtNjM0NC00NmY5LWFhZGItOWFmYmEyYjJiMWJmL3ZlcnNp
+        cG0vNTRmZGU3OTMtZmFiYy00N2YyLWJkMWMtNzY1MTZjYjQwNjU0L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iY2YyM2U5My02
-        MzQ0LTQ2ZjktYWFkYi05YWZiYTJiMmIxYmYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81NGZkZTc5My1m
+        YWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1322,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:34 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5679eb5a-2777-4cd8-8462-fb46ba054752/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/1ac6192e-74e2-4389-a1a2-f9bb6e4dfe69/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1342,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1355,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:57 GMT
+      - Fri, 29 Jul 2022 11:33:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1373,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4abe09bbb0d4bdaa58aeb4b1ce7bb85
+      - baab61ac908e4941b6e8e83cfb2ccc3f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU0NWVjMTI3LWM3NmUtNDdm
-        ZC04ZDQzLTg0MTdjMjk0YmE5Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M1NTE1NWNhLWVhMjEtNGFj
+        OS1iZWNmLTc1MmYzMzAzYTg2MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/545ec127-c76e-47fd-8d43-8417c294ba96/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c55155ca-ea21-4ac9-becf-752f3303a860/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1408,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:57 GMT
+      - Fri, 29 Jul 2022 11:33:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c310c530fc074c828af51b631320b648
+      - c9c078e21da14451a152ce7ba8557f6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTQ1ZWMxMjctYzc2
-        ZS00N2ZkLThkNDMtODQxN2MyOTRiYTk2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTcuMTc2MTQwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzU1MTU1Y2EtZWEy
+        MS00YWM5LWJlY2YtNzUyZjMzMDNhODYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MzQuNTU0ODA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJkNGFiZTA5YmJiMGQ0YmRhYTU4YWViNGIx
-        Y2U3YmI4NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE1OjU3LjIw
-        NjI3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTU6NTcuMjI3
-        NTY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiYWFiNjFhYzkwOGU0OTQxYjZlOGU4M2Nm
+        YjJjY2MzZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjM0LjYx
+        OTExN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MzQuNjYw
+        MTgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU2NzllYjVhLTI3NzctNGNkOC04NDYy
-        LWZiNDZiYTA1NDc1Mi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFhYzYxOTJlLTc0ZTItNDM4OS1hMWEy
+        LWY5YmI2ZTRkZmU2OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:34 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU2Nzll
-        YjVhLTI3NzctNGNkOC04NDYyLWZiNDZiYTA1NDc1Mi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFhYzYx
+        OTJlLTc0ZTItNDM4OS1hMWEyLWY5YmI2ZTRkZmU2OS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1477,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:57 GMT
+      - Fri, 29 Jul 2022 11:33:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1495,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 88605787ea8646a09d3bebe4b74a1b46
+      - 8997a0b6291a4019bc0ed1780e5884df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlkMDdmODcwLTM1Y2MtNDM2
-        OC05N2U2LTg5MTI0YTYzN2RhNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyNDI4YjMzLTkxZmQtNDJj
+        OC05YzZkLWI0NjU0MjAzMjM4My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9d07f870-35cc-4368-97e6-89124a637da6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/32428b33-91fd-42c8-9c6d-b46542032383/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1530,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:58 GMT
+      - Fri, 29 Jul 2022 11:33:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 923f8d83da69425c9aa80b9c8a99a748
+      - ef02f1fd50d14100bb30b88504761cac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '658'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWQwN2Y4NzAtMzVj
-        Yy00MzY4LTk3ZTYtODkxMjRhNjM3ZGE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTcuMzQ1NTI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzI0MjhiMzMtOTFm
+        ZC00MmM4LTljNmQtYjQ2NTQyMDMyMzgzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MzQuNzk5Nzk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI4ODYwNTc4N2VhODY0NmEwOWQz
-        YmViZTRiNzRhMWI0NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjU3LjM3Mzc1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTU6
-        NTguMDEyNDkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI4OTk3YTBiNjI5MWE0MDE5YmMw
+        ZWQxNzgwZTU4ODRkZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjM0Ljg2MzEwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MzYuNDc3OTgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
-        cnNlZCBNb2R1bGVtZCIsImNvZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRz
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3Vm
-        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQtZGVmYXVs
-        dHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLm1vZHVsZW1kX2RlZmF1bHRzIiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
-        c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiUGFyc2VkIENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRl
-        ZCIsInRvdGFsIjo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
-        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4t
-        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNv
-        bnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
-        IjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQyLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2IwMzc3YTM1LTgxNmYtNGQ5NS1iMTIzLTU2ZTM1
-        ODZiNzYzZi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMDM3
-        N2EzNS04MTZmLTRkOTUtYjEyMy01NmUzNTg2Yjc2M2YvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNTY3OWViNWEtMjc3Ny00Y2Q4
-        LTg0NjItZmI0NmJhMDU0NzUyLyJdfQ==
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS82ZGU5MGZmNy0yOWU4LTQ2ODItOWIwNC1kOTg0M2Y4
+        ODBmNTcvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmRlOTBm
+        ZjctMjllOC00NjgyLTliMDQtZDk4NDNmODgwZjU3LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzFhYzYxOTJlLTc0ZTItNDM4OS1h
+        MWEyLWY5YmI2ZTRkZmU2OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYjAzNzdhMzUtODE2Zi00ZDk1LWIxMjMtNTZlMzU4NmI3
-        NjNmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNmRlOTBmZjctMjllOC00NjgyLTliMDQtZDk4NDNmODgw
+        ZjU3L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1626,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:58 GMT
+      - Fri, 29 Jul 2022 11:33:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1644,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4215981ae8bf4bef8520b7f7d0bfd98f
+      - f3d98079d0da49d8b7b2b3c5649ee958
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwY2YxN2VmLTA5ZDItNDlk
-        NS04YWFhLTVhZDA3Yzc3ZGZiYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5YjIxNjVmLTQzNjUtNDZl
+        My05MWI5LWU0NWI0ZmIyMDIzYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/50cf17ef-09d2-49d5-8aaa-5ad07c77dfba/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/99b2165f-4365-46e3-91b9-e45b4fb2023b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1679,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:58 GMT
+      - Fri, 29 Jul 2022 11:33:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83c87818d992442c9ff0ac5869a04cee
+      - 786efdd2e3734bb497440e8dee72bd7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTBjZjE3ZWYtMDlk
-        Mi00OWQ1LThhYWEtNWFkMDdjNzdkZmJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTguMjk3MjI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTliMjE2NWYtNDM2
+        NS00NmUzLTkxYjktZTQ1YjRmYjIwMjNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MzcuMDcwMDIwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjQyMTU5ODFhZThiZjRiZWY4NTIwYjdmN2Qw
-        YmZkOThmIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTU6NTguMzI0
-        MzI3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxNTo1OC41NTc4
-        MTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImYzZDk4MDc5ZDBkYTQ5ZDhiN2IyYjNjNTY0
+        OWVlOTU4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MzcuMTMy
+        MjkxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMzozNy44MDEz
+        NzhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTgyNDQz
-        MGItMjk5ZS00ODhhLWIwNDAtYTA0YTFmMTM2NDQ1LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMWQ0NjBh
+        NzMtODExNy00YmVjLTg1NDItZTg5N2E0MGZhNjBlLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYjAzNzdhMzUtODE2Zi00ZDk1LWIxMjMtNTZlMzU4
-        NmI3NjNmLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNmRlOTBmZjctMjllOC00NjgyLTliMDQtZDk4NDNm
+        ODgwZjU3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1736,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1749,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:58 GMT
+      - Fri, 29 Jul 2022 11:33:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d182b9364df4a4995243e29661469a3
+      - 30ed29907ee94d83b91ad45ae1bba1e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/1d460a73-8117-4bec-8542-e897a40fa60e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 57ac250658fc404fa1100a6f5a5e4917
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMWQ0NjBhNzMtODExNy00YmVjLTg1NDItZTg5N2E0MGZhNjBlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MzcuMTg2MTIxWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82ZGU5MGZmNy0yOWU4LTQ2ODItOWIwNC1kOTg0M2Y4ODBmNTcv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzZkZTkwZmY3LTI5ZTgtNDY4Mi05YjA0LWQ5ODQz
+        Zjg4MGY1Ny8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:38 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8xZDQ2MGE3My04MTE3LTRiZWMtODU0Mi1lODk3YTQwZmE2MGUv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4031f64979a44fcca2b1e3dcc2a44621
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1MGY3NmIwLWMwZjUtNGEy
+        NS04OWIyLTYwNzEzYTJkNDdmNy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/350f76b0-c0f5-4a25-89b2-60713a2d47f7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1b3a98bbc2534fad856edee01ef8fbd8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzUwZjc2YjAtYzBm
+        NS00YTI1LTg5YjItNjA3MTNhMmQ0N2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MzguMzAyNTU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI0MDMxZjY0OTc5YTQ0ZmNjYTJiMWUzZGNj
+        MmE0NDYyMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjM4LjM2
+        NzI4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MzguNjc5
+        ODg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMWM0
+        NGZmYmEtNjZiZC00OTA3LTk4ZmMtNzUxMzAzN2RiMzFhLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/1c44ffba-66bd-4907-98fc-7513037db31a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 84d66beb22d2451fad282aa3adbfe4af
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzFjNDRmZmJhLTY2YmQtNDkwNy05OGZjLTc1MTMwMzdkYjMxYS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMzOjM4LjY1NTI4NloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMWQ0NjBhNzMtODExNy00YmVjLTg1NDIt
+        ZTg5N2E0MGZhNjBlLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5726037462b14e40a06b6781f1d2e054
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1950,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1963,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed1542b121a144c6ba865c674b225550
+      - 90c5aa073994431cbf2f99a9aa8040f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2003,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2024,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2044,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2065,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2086,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2106,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2125,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2138,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 556b1e4dce1c406f81e2cc36c887d122
+      - 4da76c4b583f48ef86bb1df466bf225e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2241,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2259,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2278,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2302,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2320,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2331,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2362,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2373,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2386,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8265671550f54254934ad82cf75e012f
+      - '003248aa4e3a4f9a80d52d59fc78b5ab'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2453,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2465,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2476,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2489,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e58b1511ea124bad99a30dab24ba6e6d
+      - 7104f8a56a9241c4bd98cc537fbecb80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2525,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2536,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2549,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd0b40268f2f4fa791b8809cf6463edb
+      - 59a863a6d988431282b33887564e4ba9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2600,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2611,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2624,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9c6b5ac8ac143c784995fcf5cc199c6
+      - b09e368ea0b7447a8ffe541f0632809d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2691,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2702,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2715,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 36d67ccd611d408f910ec9fc2e92f07a
+      - 4cac6c0d4a6b4af5bf41056100c1857b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2782,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2793,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2806,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dc329bdb2dbe4cfaa608149a55a1676f
+      - 50af26d1235c4215949e754277675c36
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2845,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2856,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2869,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a50b01c32a924defbbf37e8eed491c95
+      - bb87a6a9749a4533a9c9eb7e552ceb00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2908,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2919,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2932,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab296d50593c4a79ba3fa33ced90a41b
+      - e8006364631948c1ba11cfc9ba1af8c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -2973,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -2981,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2992,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3005,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - caa9eced3c6a4a01aaf6d4364ee0f6b2
+      - 841af163fc7f42d984ddebca17d20ba9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3056,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3067,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3080,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3406eed5b08a484fa707a0ecaaae6a48
+      - bca80ce26bae48768455c56a61edd87b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3121,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3137,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3153,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/6de90ff7-29e8-4682-9b04-d9843f880f57/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3168,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3181,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3c1b6c26d44249fbbb4b64894a043e22
+      - ab1dc75f7e6040209d10ef5ff2828f1f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3231,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3244,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3262,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b13400057054028b3609a24a01a8d94
+      - 5cd1b3f5f17b46a782f63c9b374bbce4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1OGFjZGFiLTU1NjEtNGE3
-        Yi05MzJlLWUwNTdiMTg5ZTBhZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhZTFiZWE3LTczZWMtNDM1
+        YS1iZWQwLWI1OTBkMzY1YjVhZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjQ4Mzk2OC1iNWM2LTRiNzMtYWU0
-        YS04N2JjYThlYjM5ZTEvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3300,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:15:59 GMT
+      - Fri, 29 Jul 2022 11:33:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3318,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a8874cb824fb43459cdf569d6580e395
+      - 333899f044d34ed2a54d844fb2fc1411
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RiM2MyODY1LWU5MTMtNDk3
-        ZS05N2UyLTdlMWRlMDk0MmUyYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2Njc2Y2U3LWRhOTktNDY0
+        YS1iN2YzLTc3NTFhZGFlNzgzOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:15:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5N2Qt
-        OTkyMTM4NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2ZTE4
-        NGQ5MmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzLzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0YS8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3360,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3378,97 +3935,97 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71a7b6a5f6954c9cbcce339343b0007f
+      - ab3003255b574fcba786af32910416cb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4OTY1ZmMyLTExZWMtNDY2
-        Zi05ZDNhLThkZTQ5MGY3ODZkMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY0YWY2ZTM4LThlYTktNDYw
+        OC05OGFiLTQ1MTU3YTAyNGM4Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjAzNzdhMzUtODE2Zi00ZDk1LWIx
-        MjMtNTZlMzU4NmI3NjNmL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JjZjIzZTkzLTYzNDQt
-        NDZmOS1hYWRiLTlhZmJhMmIyYjFiZi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJm
-        Ny04MzIyLTdhOWRkZDVhOGE3OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82YTEwYmJiZi01MWUxLTQxNWEtYTAwZi03OWI3MWFl
-        MWQzZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        N2ZmZDYwNzYtZjdkZC00NWQzLThmMTctN2ZjNDE4ZDFhZGYzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzhhYTU1NzE0LTFmOTYt
-        NGRiMy04YTMxLTM1MzI1ZmQ3N2NjMC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9iM2QzNTBiMS1mMDcxLTRkYTAtOWI5Zi1lNGQ3
-        M2E4YWIwYmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvZWU3MmE5ZTYtM2FmZi00Mjc3LWIzMmItYWI5MjA0YTU1OWI5LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEy
-        YTktNDM4NS04MDIxLWJlMmNkOThmZThjMC8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzL2M3ZTM1NDE3LTlkODctNDhk
-        ZS05OGQ4LTUyZDYzNWIzZWViYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzA4Nzc2NDI2LTNmM2YtNGE2Mi1iYjFjLTk4NGM1NmZi
-        MzA0My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzY4
-        ZGM0YmU0LTgzN2YtNGY2Yi05Zjg4LTUxZGVhMzAwZGU4Ny8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzgwMGI1NWM2LTk3NTMtNDM4
-        MS05ZDc4LTBmZGUyZGRmZWU0Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVm
-        ZGMwMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Uz
-        MzhmYzExLTdmODctNDhiMi04MTQzLWE2MTkwZGJlYjhjNy8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjctNDU2
-        ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFm
-        Y2E5Zjg5MGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
-        cm91cHMvYTk4OThmYTktZDhjYy00YTM5LTk5YmYtNDk2MmJjYzBmZTA1LyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02
-        OTZlLTQ2MzMtYWJkNC1kY2VlZTJlZjc4YzIvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzItNDVmMy1iNWIwLTU2
-        OGU2ZWQyNjNmNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMjM5MjhjODYtNjJhZC00ZjJlLThmZWQtZTViZWY0OTUxMDdlLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdkOC01YWM2
-        LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJlLTcyMjNi
-        Njk4NWUyOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        M2RlNDc5YjEtZTdhYy00ZDFkLWFmNTQtNGYxMWFkMGNmNGU0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRlZjI2Zi00ZjQ4LTRh
-        MTItYjY3OS01Y2QzZGRkYTlhNTcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMxOC04YjRiLTM5ZWFjOTI2
-        M2M0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWYz
-        MWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OTk2Y2ZhZC0yZjQ4LTRlYzYt
-        YjIyMS03ZTk3YzM2ODkxYjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzZkNjBkYTJmLTBhYTctNDZhZi1iZjZmLWE5YTNkODZlZTE0
-        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2JkMjdl
-        ODQtY2I0MC00ZTg5LThkODEtY2U2MGQxNjZkMjJhLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NmY5OWQ5Mi0zNzUwLTRhNDktOThm
-        ZS00NjZhMTUyMTc5NzEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzlhZDA3ZTYxLWE5YjMtNGIxYS05OWJkLTM1NGZhZThiZDA2MS8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYtOWQwOC1h
-        MjRmYTBhYzIzZmQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2QxYzI5MjA2LTQxMTAtNDIwOC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDVhMmYxYWQtMDQy
-        YS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9kZmJlNjJhYi04Nzg5LTQ2MjAtYTUyYy03ZmE2
-        YjQ0MDNiYmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U2NmZjODQ2LTM0OGMtNDM1MC04NmUxLWMzMmJkY2E0MWQzZS8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9kMjQ0
-        MWVhYS0zZmMxLTQ3NzUtOTIwZS1hNmQ3NjhkNmMyMTcvIl19XSwiZGVwZW5k
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmRlOTBmZjctMjllOC00NjgyLTli
+        MDQtZDk4NDNmODgwZjU3L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU0ZmRlNzkzLWZhYmMt
+        NDdmMi1iZDFjLTc2NTE2Y2I0MDY1NC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYy
+        YWItNGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQy
+        OTI5My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1
+        ZWE3ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBl
+        NS1hZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFk
+        MTkxOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYy
+        NTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgx
+        NS04OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJm
+        MjFjYmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
+        cm91cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0y
+        OTFhLTQzMzYtYWRiZC1kODliN2IwMWQ4NDYvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0YzgtNDU5Mi04Mzg0LWIy
+        NzZmZmE3ZTgyNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzViYmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0
+        NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0OTU0ZWVkLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81YTMyODQyNi0yYmFmLTQx
+        ODktOWNjNS02ZDhkYzM1YzEwZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQtNGU0Ni04ZmMzLTFiZmY3OTlm
+        YjYxZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjVm
+        YmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NmQwMjRjMi0xMGZjLTQwMWMt
+        YWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEy
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVm
+        MmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUtOTM2
+        Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMt
+        NTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0y
+        MmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkxLTM2ZWM4ZmMzNTA0OC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVh
+        Mi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2ZkYjk1N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJm
+        NTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19XSwiZGVwZW5k
         ZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3481,7 +4038,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3499,21 +4056,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41efbd0d8625419eb89fc97b8f6cdd02
+      - 81f6bdb5e91c49d88e27cbe2c9af39de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkYjJjNjQ3LTIyY2ItNDc2
-        ZS1iYzk2LWMwNWE1MzZhNmQ0Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0NTZlNWI4LTEwMmUtNDQ4
+        My1hNzc1LWI2MDFhY2VmYWMxYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a58acdab-5561-4a7b-932e-e057b189e0ae/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4ae1bea7-73ec-435a-bed0-b590d365b5ae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3534,51 +4091,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d369465c4ad346a68edcb0a0ec680025
+      - 115cabfa15b04ef6a6e371698786976d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '381'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTU4YWNkYWItNTU2
-        MS00YTdiLTkzMmUtZTA1N2IxODllMGFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTkuOTA2NjcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGFlMWJlYTctNzNl
+        Yy00MzVhLWJlZDAtYjU5MGQzNjViNWFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuMzkzNTA2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2YjEzNDAwMDU3MDU0MDI4YjM2
-        MDlhMjRhMDFhOGQ5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjU5Ljk0NzM3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuMDg0OTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1Y2QxYjNmNWYxN2I0NmE3ODJm
+        NjNjOWIzNzRiYmNlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQxLjQ3NDQ2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDEuNzk3Njg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0
-        NC00NmY5LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFi
+        Yy00N2YyLWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a58acdab-5561-4a7b-932e-e057b189e0ae/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a6676ce7-da99-464a-b7f3-7751adae7838/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3599,118 +4156,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68410fae046b4d34b84dadf4f8e97703
+      - '018eccb3fc0f4e8a89e98f4038a056fe'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '381'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTU4YWNkYWItNTU2
-        MS00YTdiLTkzMmUtZTA1N2IxODllMGFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTkuOTA2NjcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY2NzZjZTctZGE5
+        OS00NjRhLWI3ZjMtNzc1MWFkYWU3ODM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuNDg2NTMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2YjEzNDAwMDU3MDU0MDI4YjM2
-        MDlhMjRhMDFhOGQ5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjU5Ljk0NzM3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuMDg0OTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0
-        NC00NmY5LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/db3c2865-e913-497e-97e2-7e1de0942e2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:00 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2f863796f7c546f5af5363f75fb33892
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGIzYzI4NjUtZTkx
-        My00OTdlLTk3ZTItN2UxZGUwOTQyZTJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTkuOTU4MDUyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhODg3NGNiODI0ZmI0MzQ1OWNk
-        ZjU2OWQ2NTgwZTM5NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjAwLjExNzgyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuMjY0MjgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMzM4OTlmMDQ0ZDM0ZWQyYTU0
+        ZDg0NGZiMmZjMTQxMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQxLjg4MjEyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDIuMTYzNzI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iY2YyM2U5My02MzQ0LTQ2ZjktYWFkYi05YWZiYTJiMmIxYmYvdmVyc2lv
+        bS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0NC00NmY5
-        LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFiYy00N2Yy
+        LWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a58acdab-5561-4a7b-932e-e057b189e0ae/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4ae1bea7-73ec-435a-bed0-b590d365b5ae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3731,51 +4223,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 70e728524cad4d43a98f5d99ffbc15f8
+      - ce44f35716af4c18934543ad61d71140
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '381'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTU4YWNkYWItNTU2
-        MS00YTdiLTkzMmUtZTA1N2IxODllMGFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTkuOTA2NjcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGFlMWJlYTctNzNl
+        Yy00MzVhLWJlZDAtYjU5MGQzNjViNWFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuMzkzNTA2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2YjEzNDAwMDU3MDU0MDI4YjM2
-        MDlhMjRhMDFhOGQ5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjU5Ljk0NzM3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuMDg0OTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1Y2QxYjNmNWYxN2I0NmE3ODJm
+        NjNjOWIzNzRiYmNlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQxLjQ3NDQ2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDEuNzk3Njg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0
-        NC00NmY5LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFi
+        Yy00N2YyLWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/db3c2865-e913-497e-97e2-7e1de0942e2b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a6676ce7-da99-464a-b7f3-7751adae7838/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3796,53 +4288,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e0baadde2d2746c09fd2d86b1ffbe811
+      - b0fa09f84c554cc893a6f06854a6fa28
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGIzYzI4NjUtZTkx
-        My00OTdlLTk3ZTItN2UxZGUwOTQyZTJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTkuOTU4MDUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY2NzZjZTctZGE5
+        OS00NjRhLWI3ZjMtNzc1MWFkYWU3ODM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuNDg2NTMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhODg3NGNiODI0ZmI0MzQ1OWNk
-        ZjU2OWQ2NTgwZTM5NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjAwLjExNzgyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuMjY0MjgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMzM4OTlmMDQ0ZDM0ZWQyYTU0
+        ZDg0NGZiMmZjMTQxMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQxLjg4MjEyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDIuMTYzNzI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iY2YyM2U5My02MzQ0LTQ2ZjktYWFkYi05YWZiYTJiMmIxYmYvdmVyc2lv
+        bS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0NC00NmY5
-        LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFiYy00N2Yy
+        LWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d8965fc2-11ec-466f-9d3a-8de490f786d2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/64af6e38-8ea9-4608-98ab-45157a024c82/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3863,53 +4355,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc489e79904a46b1adc653897a6df829
+      - ec221cad642a42d7b802a0ea4e72becf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDg5NjVmYzItMTFl
-        Yy00NjZmLTlkM2EtOGRlNDkwZjc4NmQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDAuMDA2NjE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjRhZjZlMzgtOGVh
+        OS00NjA4LTk4YWItNDUxNTdhMDI0YzgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuNTc1MDQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MWE3YjZhNWY2OTU0YzljYmNj
-        ZTMzOTM0M2IwMDA3ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjAwLjI5MzY4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuNDIzNTgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhYjMwMDMyNTViNTc0ZmNiYTc4
+        NmFmMzI5MTA0MTZjYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQyLjIzNjcxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDIuNTUyMjQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iY2YyM2U5My02MzQ0LTQ2ZjktYWFkYi05YWZiYTJiMmIxYmYvdmVyc2lv
+        bS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0NC00NmY5
-        LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFiYy00N2Yy
+        LWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a58acdab-5561-4a7b-932e-e057b189e0ae/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4ae1bea7-73ec-435a-bed0-b590d365b5ae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3930,51 +4422,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ea5dac491344d1f8d1b73a9d3a42541
+      - c46c00bf30f34e3a89bf8ddb7c057447
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '381'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTU4YWNkYWItNTU2
-        MS00YTdiLTkzMmUtZTA1N2IxODllMGFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTkuOTA2NjcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGFlMWJlYTctNzNl
+        Yy00MzVhLWJlZDAtYjU5MGQzNjViNWFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuMzkzNTA2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2YjEzNDAwMDU3MDU0MDI4YjM2
-        MDlhMjRhMDFhOGQ5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjU5Ljk0NzM3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuMDg0OTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1Y2QxYjNmNWYxN2I0NmE3ODJm
+        NjNjOWIzNzRiYmNlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQxLjQ3NDQ2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDEuNzk3Njg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0
-        NC00NmY5LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFi
+        Yy00N2YyLWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/db3c2865-e913-497e-97e2-7e1de0942e2b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a6676ce7-da99-464a-b7f3-7751adae7838/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3995,53 +4487,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e9fb9ce5b0424aa29c1946cfc976dc46
+      - c64fd6cd14b74584900d6b8e4c72f070
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGIzYzI4NjUtZTkx
-        My00OTdlLTk3ZTItN2UxZGUwOTQyZTJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6NTkuOTU4MDUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY2NzZjZTctZGE5
+        OS00NjRhLWI3ZjMtNzc1MWFkYWU3ODM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuNDg2NTMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhODg3NGNiODI0ZmI0MzQ1OWNk
-        ZjU2OWQ2NTgwZTM5NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjAwLjExNzgyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuMjY0MjgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMzM4OTlmMDQ0ZDM0ZWQyYTU0
+        ZDg0NGZiMmZjMTQxMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQxLjg4MjEyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDIuMTYzNzI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iY2YyM2U5My02MzQ0LTQ2ZjktYWFkYi05YWZiYTJiMmIxYmYvdmVyc2lv
+        bS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0NC00NmY5
-        LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFiYy00N2Yy
+        LWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d8965fc2-11ec-466f-9d3a-8de490f786d2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/64af6e38-8ea9-4608-98ab-45157a024c82/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4062,53 +4554,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:00 GMT
+      - Fri, 29 Jul 2022 11:33:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 44606a0e095d466aa179ff42022f7d5b
+      - 2ac236134fe543dbbbab5f6cae85578d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDg5NjVmYzItMTFl
-        Yy00NjZmLTlkM2EtOGRlNDkwZjc4NmQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDAuMDA2NjE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjRhZjZlMzgtOGVh
+        OS00NjA4LTk4YWItNDUxNTdhMDI0YzgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuNTc1MDQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MWE3YjZhNWY2OTU0YzljYmNj
-        ZTMzOTM0M2IwMDA3ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjAwLjI5MzY4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDAuNDIzNTgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhYjMwMDMyNTViNTc0ZmNiYTc4
+        NmFmMzI5MTA0MTZjYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQyLjIzNjcxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDIuNTUyMjQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iY2YyM2U5My02MzQ0LTQ2ZjktYWFkYi05YWZiYTJiMmIxYmYvdmVyc2lv
+        bS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0NC00NmY5
-        LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFiYy00N2Yy
+        LWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6db2c647-22cb-476e-bc96-c05a536a6d42/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4ae1bea7-73ec-435a-bed0-b590d365b5ae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4129,55 +4621,254 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e47f8986d154bd7940f6b2746a6cd22
+      - 6ad5c206083e4294b5e3d94ca0385d6f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '416'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmRiMmM2NDctMjJj
-        Yi00NzZlLWJjOTYtYzA1YTUzNmE2ZDQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDAuMDYyMzM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGFlMWJlYTctNzNl
+        Yy00MzVhLWJlZDAtYjU5MGQzNjViNWFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuMzkzNTA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1Y2QxYjNmNWYxN2I0NmE3ODJm
+        NjNjOWIzNzRiYmNlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQxLjQ3NDQ2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDEuNzk3Njg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFi
+        Yy00N2YyLWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:43 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a6676ce7-da99-464a-b7f3-7751adae7838/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '697'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 591e0a2a26004d7ea02898cb678a9301
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY2NzZjZTctZGE5
+        OS00NjRhLWI3ZjMtNzc1MWFkYWU3ODM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuNDg2NTMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMzM4OTlmMDQ0ZDM0ZWQyYTU0
+        ZDg0NGZiMmZjMTQxMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQxLjg4MjEyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDIuMTYzNzI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFiYy00N2Yy
+        LWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:43 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/64af6e38-8ea9-4608-98ab-45157a024c82/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '697'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0d4dc90ebde04a14a27736dbadf08200
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjRhZjZlMzgtOGVh
+        OS00NjA4LTk4YWItNDUxNTdhMDI0YzgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuNTc1MDQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhYjMwMDMyNTViNTc0ZmNiYTc4
+        NmFmMzI5MTA0MTZjYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjQyLjIzNjcxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        NDIuNTUyMjQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS81NGZkZTc5My1mYWJjLTQ3ZjItYmQxYy03NjUxNmNiNDA2NTQvdmVyc2lv
+        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3OTMtZmFiYy00N2Yy
+        LWJkMWMtNzY1MTZjYjQwNjU0LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:44 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a456e5b8-102e-4483-a775-b601acefac1c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7e96b95b97bb44528a6f25c579894669
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQ1NmU1YjgtMTAy
+        ZS00NDgzLWE3NzUtYjYwMWFjZWZhYzFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6NDEuNjcyMjI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiNDFlZmJkMGQ4NjI1NDE5ZWI4OWZjOTdiOGY2
-        Y2RkMDIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxNjowMC40NTM1
-        NTVaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjAwLjc5OTc1
-        OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiODFmNmJkYjVlOTFjNDlkODhlMjdjYmUyYzlh
+        ZjM5ZGUiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMzo0Mi42Mjk2
+        NDVaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjQzLjY0MzQy
+        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNl
-        OTMtNjM0NC00NmY5LWFhZGItOWFmYmEyYjJiMWJmL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTRmZGU3
+        OTMtZmFiYy00N2YyLWJkMWMtNzY1MTZjYjQwNjU0L3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2JjZjIzZTkzLTYzNDQtNDZmOS1hYWRiLTlh
-        ZmJhMmIyYjFiZi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2IwMzc3YTM1LTgxNmYtNGQ5NS1iMTIzLTU2ZTM1ODZiNzYz
-        Zi8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzU0ZmRlNzkzLWZhYmMtNDdmMi1iZDFjLTc2
+        NTE2Y2I0MDY1NC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzZkZTkwZmY3LTI5ZTgtNDY4Mi05YjA0LWQ5ODQzZjg4MGY1
+        Ny8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4185,7 +4876,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4198,76 +4889,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f74b94ca6bd64af9a81e6b78a71e905c
+      - 3d54c265cb024fc397a223b610e7e6b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '563'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04ZDgxLWNlNjBkMTY2ZDIyYS8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9kNWEyZjFhZC0wNDJhLTQwNWUtYWM0NC0wYzRiMTRkYmJlY2EvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNWYzMWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWFk
-        MDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJkMDYxLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdi
-        OGMzLTk5ZTctNDliMC05OGJlLTcyMjNiNjk4NWUyOC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdk
-        OC01YWM2LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2Zjk5ZDkyLTM3
-        NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZTI0MGY3My03MWU4
-        LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00
-        YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA3OWUzNjU0LTY5NmUtNDYz
-        My1hYmQ0LWRjZWVlMmVmNzhjMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYt
-        OWQwOC1hMjRmYTBhYzIzZmQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00MzUwLTg2
-        ZTEtYzMyYmRjYTQxZDNlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzItNDVmMy1iNWIw
-        LTU2OGU2ZWQyNjNmNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00
-        ZjExYWQwY2Y0ZTQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZDFjMjkyMDYtNDExMC00MjA4LWEyMGMtYzM4
-        NTVjZDRmNDBjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4275,7 +4966,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4288,50 +4979,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a619ac25f1bc48a0b9d5e840fd9ce7db
+      - 991d70c0a9d54639b12011b3e7cd167b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '264'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmItOWY4OC01MWRlYTMwMGRlODcv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVmZGMwMi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvODAwYjU1YzYtOTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4YjItODE0My1hNjE5MGRiZWI4YzcvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2U3NDEzZmUwLTMwNjctNDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4339,7 +5030,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4352,37 +5043,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3bdf7ad527b24d1f8e54880b1eba8a60
+      - c6222b516c664e5dad622814551d8740
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4455,9 +5146,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -4473,8 +5164,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -4492,9 +5183,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -4516,9 +5207,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -4534,9 +5225,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -4545,9 +5236,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -4576,10 +5267,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4587,7 +5278,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4600,43 +5291,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c6b5ddf9eecf44968607c892c2a64b43
+      - aa98b67efd1a4fc4b94cdde64c02006b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4644,7 +5335,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4657,41 +5348,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4413aec42db3417390b69f3a6856816b
+      - 4cbbb05d5ccd49f093ef1a6900616fe6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4699,7 +5390,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4712,36 +5403,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 35904ef79a1547059c0f4ed6348e79b0
+      - b7ab7d12c8b4444c960b976825ddc9d5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4763,10 +5454,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4774,7 +5465,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4787,76 +5478,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58e005c4ecfb479a8c778149699f5dcf
+      - 9d232d43d3784903b110e8b03bfe6c91
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '563'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04ZDgxLWNlNjBkMTY2ZDIyYS8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9kNWEyZjFhZC0wNDJhLTQwNWUtYWM0NC0wYzRiMTRkYmJlY2EvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNWYzMWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWFk
-        MDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJkMDYxLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdi
-        OGMzLTk5ZTctNDliMC05OGJlLTcyMjNiNjk4NWUyOC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdk
-        OC01YWM2LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2Zjk5ZDkyLTM3
-        NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZTI0MGY3My03MWU4
-        LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00
-        YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA3OWUzNjU0LTY5NmUtNDYz
-        My1hYmQ0LWRjZWVlMmVmNzhjMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYt
-        OWQwOC1hMjRmYTBhYzIzZmQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00MzUwLTg2
-        ZTEtYzMyYmRjYTQxZDNlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzItNDVmMy1iNWIw
-        LTU2OGU2ZWQyNjNmNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00
-        ZjExYWQwY2Y0ZTQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZDFjMjkyMDYtNDExMC00MjA4LWEyMGMtYzM4
-        NTVjZDRmNDBjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4864,7 +5555,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4877,50 +5568,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ee972f38ede94f448ccd6e83b8df0577
+      - ace500218d1348e6b30c25f045f1b05f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '264'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmItOWY4OC01MWRlYTMwMGRlODcv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVmZGMwMi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvODAwYjU1YzYtOTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy9lMzM4ZmMxMS03Zjg3LTQ4YjItODE0My1hNjE5MGRiZWI4YzcvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2U3NDEzZmUwLTMwNjctNDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4928,7 +5619,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4941,37 +5632,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 741177d9a70d4f5bb7824909297c5c3d
+      - af8a84ca008e4b64be9d736ea315f683
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -5044,9 +5735,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -5062,8 +5753,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -5081,9 +5772,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -5105,9 +5796,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -5123,9 +5814,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -5134,9 +5825,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -5165,10 +5856,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5176,7 +5867,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5189,43 +5880,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 800d446251944b7bb16789fe70a76263
+      - ab51799428e640588108655be87847c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5233,7 +5924,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5246,41 +5937,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a75d4cff610747d78d39453a0fded90f
+      - e4246c2d362440fba7c3427d159aed69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/54fde793-fabc-47f2-bd1c-76516cb40654/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5288,7 +5979,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5301,36 +5992,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:01 GMT
+      - Fri, 29 Jul 2022 11:33:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 937c65cf3e9b4b19b7f44d4e001ec2b8
+      - affbfa1a6345490eb0a7d58921dfc9a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5352,5 +6043,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:46 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_module_stream_repository/module_streams_copied_with_include_modular_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_module_stream_repository/module_streams_copied_with_include_modular_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:02 GMT
+      - Fri, 29 Jul 2022 11:33:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad3daedf507d4d7ca996969b92747ba9
+      - a6df5e765d6f4a40b4be111525eb6b82
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iMDM3N2EzNS04MTZmLTRkOTUtYjEyMy01NmUzNTg2Yjc2M2Yv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTo1Ni4yMjQ0NTRa
+        cnBtL3JwbS9kOTFlMGJkOC1lMzViLTRkMTEtOWJiOS1kYTE4Njg5YjEwYTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjo1OC40MjU4Mzla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iMDM3N2EzNS04MTZmLTRkOTUtYjEyMy01NmUzNTg2Yjc2M2Yv
+        cnBtL3JwbS9kOTFlMGJkOC1lMzViLTRkMTEtOWJiOS1kYTE4Njg5YjEwYTEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IwMzc3
-        YTM1LTgxNmYtNGQ5NS1iMTIzLTU2ZTM1ODZiNzYzZi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q5MWUw
+        YmQ4LWUzNWItNGQxMS05YmI5LWRhMTg2ODliMTBhMS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:12 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b0377a35-816f-4d95-b123-56e3586b763f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:02 GMT
+      - Fri, 29 Jul 2022 11:33:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fff1585322c5477c8cdefe0621367298
+      - ef52af5c32b54f00bc88da5248712048
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiNTA0NDY1LWNhODEtNDMx
-        YS05MjAxLTY2NzgyNzY3NTU3OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4NzRmZjM1LWQ3ZTgtNDhl
+        YS1iMDBjLTIyODM1NzhiYjAxMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:02 GMT
+      - Fri, 29 Jul 2022 11:33:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ddd49c013e074dfba80fbc48da2cd36d
+      - ec76ebe67afc404980cf2a7878cb5e71
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cb504465-ca81-431a-9201-667827675578/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4874ff35-d7e8-48ea-b00c-2283578bb013/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:02 GMT
+      - Fri, 29 Jul 2022 11:33:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4c698b340bc54ad4a61f9324ce6b7965
+      - 209b9dcb0ac24679b24cb2335f6f3057
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2I1MDQ0NjUtY2E4
-        MS00MzFhLTkyMDEtNjY3ODI3Njc1NTc4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDIuNzM2MDU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDg3NGZmMzUtZDdl
+        OC00OGVhLWIwMGMtMjI4MzU3OGJiMDEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MTIuOTY1NTk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmZmYxNTg1MzIyYzU0NzdjOGNkZWZlMDYy
-        MTM2NzI5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjAyLjc2
-        NDU5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MDIuODg5
-        NzU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlZjUyYWY1YzMyYjU0ZjAwYmM4OGRhNTI0
+        ODcxMjA0OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjEzLjA0
+        MzkwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MTMuNDIx
+        ODM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjAzNzdhMzUtODE2Zi00ZDk1
-        LWIxMjMtNTZlMzU4NmI3NjNmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxZTBiZDgtZTM1Yi00ZDEx
+        LTliYjktZGExODY4OWIxMGExLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fc33862dfa51455e9f6b23ac4c86f610
+      - 55dd3c3112c14c5ea6943e49a35887f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:13 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - feac806000564390a5d0ee6976388c01
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMjk5OGNiYWYtNTEzNS00MTE2LWE3ODUtMzE0YzY5ODU4Y2Iw
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MDMuOTMyNzM4
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:13 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/2998cbaf-5135-4116-a785-314c69858cb0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:13 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 80a111e5c5c34a8aaddd644801cc0e63
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViMmVhZmQ3LTY4ZmItNGM1
+        MC1iNmI1LTkxNDc1ZWE5N2RhYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:13 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/eb2eafd7-68fb-4c50-b6b5-91475ea97dab/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:13 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d1f9de9aaa814352b8fa03993c6a3864
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWIyZWFmZDctNjhm
+        Yi00YzUwLWI2YjUtOTE0NzVlYTk3ZGFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MTMuNzg3MDUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4MGExMTFlNWM1YzM0YThhYWRkZDY0NDgw
+        MWNjMGU2MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjEzLjg0
+        ODM5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MTMuOTE4
+        NTg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:13 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e2b28a043bde49649529a6a61fea475c
+      - 7d3e8e288aac4a849c28ad168d0187a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a53d5e67e71f449d94940e6e9089d04d
+      - 41db2255f0984dc4beb73e08ab62f429
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d17c2bedade64cb4bbc192f6eae62ac0
+      - cb16efbdbc5c44c9a71f74f3d162cbb9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 00b75d8539144cf6a49698d8691e5c14
+      - 4426c6b7baed4db8abc4059d40cf6801
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - b5fb377a6f3c40eea471976be1baabe7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:14 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/08da7638-570d-49f7-b8ea-bc7f0404f1fd/"
+      - "/pulp/api/v3/remotes/rpm/rpm/d134852a-f517-43e7-9eb3-fb5f6839a54e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 63d0c378035d43e08bc7895b3aa7dcfc
+      - 5e62b2ff270a4f6cb601226b54d9278c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA4
-        ZGE3NjM4LTU3MGQtNDlmNy1iOGVhLWJjN2YwNDA0ZjFmZC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE2OjAzLjMxNTQ4OFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Qx
+        MzQ4NTJhLWY1MTctNDNlNy05ZWIzLWZiNWY2ODM5YTU0ZS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMzOjE0LjM1MjI4N1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjE2OjAzLjMxNTUwN1oiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjMzOjE0LjM1MjMxM1oiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:14 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/"
+      - "/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dc45a22111394d74ac099967df422685
+      - 1a307e66bd5d419dadd4bac07ceeb53e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vM2E2NTg5YjMtNGQ5My00ODdmLTk3MWEtZDUzYWM5YjRhMjRlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MDMuNDI1OTgwWiIsInZl
+        cG0vNTQwOGQzNjAtOWZjNC00M2EwLWFiMmEtZDk3NmE2ZDk2OWYxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MTQuNjAzNjkxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vM2E2NTg5YjMtNGQ5My00ODdmLTk3MWEtZDUzYWM5YjRhMjRlL3ZlcnNp
+        cG0vNTQwOGQzNjAtOWZjNC00M2EwLWFiMmEtZDk3NmE2ZDk2OWYxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zYTY1ODliMy00
-        ZDkzLTQ4N2YtOTcxYS1kNTNhYzliNGEyNGUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81NDA4ZDM2MC05
+        ZmM0LTQzYTAtYWIyYS1kOTc2YTZkOTY5ZjEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57e1a487d026431797768f08cada2d36
+      - 6d94518af6124a3ca41c1bf445dec3a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iY2YyM2U5My02MzQ0LTQ2ZjktYWFkYi05YWZiYTJiMmIxYmYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTo1Ni44OTcyMjla
+        cnBtL3JwbS8yODA2OWM2MS0wZGU4LTQ4MzQtYmEyMS01MDExY2U2ODYzN2Uv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjo1OS43ODY4NDla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iY2YyM2U5My02MzQ0LTQ2ZjktYWFkYi05YWZiYTJiMmIxYmYv
+        cnBtL3JwbS8yODA2OWM2MS0wZGU4LTQ4MzQtYmEyMS01MDExY2U2ODYzN2Uv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JjZjIz
-        ZTkzLTYzNDQtNDZmOS1hYWRiLTlhZmJhMmIyYjFiZi92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI4MDY5
+        YzYxLTBkZTgtNDgzNC1iYTIxLTUwMTFjZTY4NjM3ZS92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:14 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/bcf23e93-6344-46f9-aadb-9afba2b2b1bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1979806895c641bcbfb406c9dd8b6667
+      - 27368ce0332d4de18abbd9d9dca05033
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyZTFjMWI1LTQxNGUtNDU1
-        OC04OWY1LTcxNDI4MTE3ZWIwOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJmZDRlNjkxLWIwZDAtNDRl
+        Ni1iN2NjLTgyZWFkNDU2ZmMzYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9386437b3fb149a1935af7a775e082f0
+      - 39412dcfe3f84644b5afd646abfd2e7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNTY3OWViNWEtMjc3Ny00Y2Q4LTg0NjItZmI0NmJhMDU0NzUyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6NTYuMTEwMjAyWiIsIm5h
+        cG0vY2Q1NWI3MDMtZmIzYS00MGU2LWI2MDItZTNmZGE4MGVlMGViLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6NTguMjA4ODIwWiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoxNTo1Ny4yMjMyMzFaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozMzowMC40NDc0MjJaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5679eb5a-2777-4cd8-8462-fb46ba054752/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/cd55b703-fb3a-40e6-b602-e3fda80ee0eb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57f0e89172604746b895ba71cbf381c6
+      - b5d7629086f74aa9b10c4570e53a3f0b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3ZjBjZGRlLTcxMTMtNDQw
-        OC04NTA0LTA0Mjk2YzYxY2ZjMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwYjJiNGEyLWRmOTAtNGQ5
+        My1iODUxLTBiOTYxNTA2MDMxMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/82e1c1b5-414e-4558-89f5-71428117eb09/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2fd4e691-b0d0-44e6-b7cc-82ead456fc3c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9f70cc1951b7413e8fdc55be15c82fb1
+      - 4db3d9fe9b784a8db8522d107c11691f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODJlMWMxYjUtNDE0
-        ZS00NTU4LTg5ZjUtNzE0MjgxMTdlYjA5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDMuNjAwNzg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmZkNGU2OTEtYjBk
+        MC00NGU2LWI3Y2MtODJlYWQ0NTZmYzNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MTQuOTk1NzM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxOTc5ODA2ODk1YzY0MWJjYmZiNDA2Yzlk
-        ZDhiNjY2NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjAzLjYz
-        MzU2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MDMuNjk1
-        NjMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyNzM2OGNlMDMzMmQ0ZGUxOGFiYmQ5ZDlk
+        Y2EwNTAzMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjE1LjA2
+        NDQzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MTUuMjQ3
+        MTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmNmMjNlOTMtNjM0NC00NmY5
-        LWFhZGItOWFmYmEyYjJiMWJmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRlOC00ODM0
+        LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/37f0cdde-7113-4408-8504-04296c61cfc3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/30b2b4a2-df90-4d93-b851-0b9615060312/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 252602c5ca554bdfb4c5e63872eee260
+      - 6f053b03314c4ed8bd7d022e3f984263
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzdmMGNkZGUtNzEx
-        My00NDA4LTg1MDQtMDQyOTZjNjFjZmMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDMuNjgzMjc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzBiMmI0YTItZGY5
+        MC00ZDkzLWI4NTEtMGI5NjE1MDYwMzEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MTUuMjE5MTEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1N2YwZTg5MTcyNjA0NzQ2Yjg5NWJhNzFj
-        YmYzODFjNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjAzLjcx
-        MzUwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MDMuNzU5
-        NDYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiNWQ3NjI5MDg2Zjc0YWE5YjEwYzQ1NzBl
+        NTNhM2YwYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjE1LjMw
+        NDM4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MTUuNDI5
+        MzMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU2NzllYjVhLTI3NzctNGNkOC04NDYy
-        LWZiNDZiYTA1NDc1Mi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NkNTViNzAzLWZiM2EtNDBlNi1iNjAy
+        LWUzZmRhODBlZTBlYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ead909396a204f1aa849670992298f07
+      - 35b224e0943d452daeb6fc91d1810a1f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b6730c49e69f4228a8101f693789f6d5
+      - b45669c42ffd46c48dc28d88d89d6c46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f606f8d775141d7956e07e0638d2e30
+      - f49ce454032440e0a10b1e9706696688
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - edd72a3c2c694f40bb8c49245cfb7b05
+      - 406e2f0822cd416282ac8250baae9eb6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7c7415888cb648df9bd62a265720362b
+      - 9d4bfc2366b244f6910e045a29466826
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:03 GMT
+      - Fri, 29 Jul 2022 11:33:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ee172546bb314cdfbe3a94b947910ba1
+      - 54017b5126d54d409618ee59334200e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:04 GMT
+      - Fri, 29 Jul 2022 11:33:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/"
+      - "/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2671a66e379b4cc0be46a865fef93eb8
+      - 121d427dbbfe49c3b1c4177c4a0309e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTZiYTA2NTgtMjA0MS00NWUxLWEwZWMtYmYzOWJhMDAxMmJlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MDQuMTIwNDUxWiIsInZl
+        cG0vOTljNmQ5NzAtYjAwYS00OTY0LWE0N2UtNjgyNTFkYjRlNDAxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MTYuMTgxODAzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTZiYTA2NTgtMjA0MS00NWUxLWEwZWMtYmYzOWJhMDAxMmJlL3ZlcnNp
+        cG0vOTljNmQ5NzAtYjAwYS00OTY0LWE0N2UtNjgyNTFkYjRlNDAxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81NmJhMDY1OC0y
-        MDQxLTQ1ZTEtYTBlYy1iZjM5YmEwMDEyYmUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85OWM2ZDk3MC1i
+        MDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:16 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/08da7638-570d-49f7-b8ea-bc7f0404f1fd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/d134852a-f517-43e7-9eb3-fb5f6839a54e/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:04 GMT
+      - Fri, 29 Jul 2022 11:33:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbe76abb170f47b29de7bfc7951210f0
+      - d5d58c96ea464cba83cb3f7fc0bda93e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc2NTU5NDBiLTYyOGYtNGU3
-        ZC1iY2NmLWIxYmI5Y2MyNTZlOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzNjMwZjVkLTViZGEtNDBj
+        My1iYzc3LTIxM2JlZmJhNGY2ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7655940b-628f-4e7d-bccf-b1bb9cc256e9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/23630f5d-5bda-40c3-bc77-213befba4f6d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:04 GMT
+      - Fri, 29 Jul 2022 11:33:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d88d68b90e6b4222b628345f08e5f83e
+      - a269ad8a825a4ce48cd10e9b6114ad7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzY1NTk0MGItNjI4
-        Zi00ZTdkLWJjY2YtYjFiYjljYzI1NmU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDQuNTQ1OTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjM2MzBmNWQtNWJk
+        YS00MGMzLWJjNzctMjEzYmVmYmE0ZjZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MTYuNzk3NjA2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmYmU3NmFiYjE3MGY0N2IyOWRlN2JmYzc5
-        NTEyMTBmMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjA0LjU3
-        NjA4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MDQuNTk3
-        OTUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkNWQ1OGM5NmVhNDY0Y2JhODNjYjNmN2Zj
+        MGJkYTkzZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjE2Ljg1
+        OTM0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MTYuOTAz
+        OTU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA4ZGE3NjM4LTU3MGQtNDlmNy1iOGVh
-        LWJjN2YwNDA0ZjFmZC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2QxMzQ4NTJhLWY1MTctNDNlNy05ZWIz
+        LWZiNWY2ODM5YTU0ZS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:16 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA4ZGE3
-        NjM4LTU3MGQtNDlmNy1iOGVhLWJjN2YwNDA0ZjFmZC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2QxMzQ4
+        NTJhLWY1MTctNDNlNy05ZWIzLWZiNWY2ODM5YTU0ZS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:04 GMT
+      - Fri, 29 Jul 2022 11:33:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d4072a48e7b4785949634370dd0f249
+      - f7680c2857f94e7abe2d50469c16d102
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4ODVkZTQxLTE3ZjAtNGI4
-        NC05YmI1LWRlMTZkNzMwZTg4OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiYjAyNmE3LTVhYjktNGE1
+        MC1hOWE4LWM5NjUyMjcwNGU0YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0885de41-17f0-4b84-9bb5-de16d730e889/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bbb026a7-5ab9-4a50-a9a8-c96522704e4a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:05 GMT
+      - Fri, 29 Jul 2022 11:33:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e687e72a0044538935b1c39ec23306b
+      - f9e59585d9904ed082d52763f6fc9579
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '660'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDg4NWRlNDEtMTdm
-        MC00Yjg0LTliYjUtZGUxNmQ3MzBlODg5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDQuNzEzNjkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmJiMDI2YTctNWFi
+        OS00YTUwLWE5YTgtYzk2NTIyNzA0ZTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MTcuMDcwMDk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI3ZDQwNzJhNDhlN2I0Nzg1OTQ5
-        NjM0MzcwZGQwZjI0OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA0Ljc0MzQ4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDUuMzgwNjg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmNzY4MGMyODU3Zjk0ZTdhYmUy
+        ZDUwNDY5YzE2ZDEwMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjE3LjE0NTU0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MTguODIyMDUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,43 +1834,43 @@ http_interactions:
         c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
         IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
         c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiUGFyc2VkIENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRl
-        ZCIsInRvdGFsIjo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
-        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4t
-        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNv
-        bnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
-        IjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQyLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzNhNjU4OWIzLTRkOTMtNDg3Zi05NzFhLWQ1M2Fj
-        OWI0YTI0ZS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zYTY1
-        ODliMy00ZDkzLTQ4N2YtOTcxYS1kNTNhYzliNGEyNGUvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMDhkYTc2MzgtNTcwZC00OWY3
-        LWI4ZWEtYmM3ZjA0MDRmMWZkLyJdfQ==
+        b3RhbCI6MjAsImRvbmUiOjIwLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBDb21wcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuY29tcHMiLCJz
+        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgi
+        Om51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5hZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6NywiZG9uZSI6Nywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9h
+        ZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFz
+        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo0Miwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS81NDA4ZDM2MC05ZmM0LTQzYTAtYWIyYS1kOTc2YTZk
+        OTY5ZjEvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTQwOGQz
+        NjAtOWZjNC00M2EwLWFiMmEtZDk3NmE2ZDk2OWYxLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2QxMzQ4NTJhLWY1MTctNDNlNy05
+        ZWIzLWZiNWY2ODM5YTU0ZS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:19 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vM2E2NTg5YjMtNGQ5My00ODdmLTk3MWEtZDUzYWM5YjRh
-        MjRlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNTQwOGQzNjAtOWZjNC00M2EwLWFiMmEtZDk3NmE2ZDk2
+        OWYxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:05 GMT
+      - Fri, 29 Jul 2022 11:33:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dbbe8f64508545cca9e34581ab7ccbb8
+      - 716cba9bdd9e4bbc90a7d7a94d2da7d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzZTZkZTZkLTkwYWMtNGU3
-        Yi04NWVkLTU3MzMwNGVkMTk2NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkMWI1Njk5LWVlYTktNGRh
+        MC1hNGVkLTM1NmVkYzJlNjc2Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c3e6de6d-90ac-4e7b-85ed-573304ed1964/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2d1b5699-eea9-4da0-a4ed-356edc2e6762/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:05 GMT
+      - Fri, 29 Jul 2022 11:33:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 380767c6270a4c0c94f829f8426b8769
+      - e33c6c8346584c6e915c1cb4a67ebcdb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzNlNmRlNmQtOTBh
-        Yy00ZTdiLTg1ZWQtNTczMzA0ZWQxOTY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDUuNjM5MTk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQxYjU2OTktZWVh
+        OS00ZGEwLWE0ZWQtMzU2ZWRjMmU2NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MTkuNDYwNTc4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImRiYmU4ZjY0NTA4NTQ1Y2NhOWUzNDU4MWFi
-        N2NjYmI4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MDUuNjY3
-        MDgwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxNjowNS45MDU4
-        MzFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjcxNmNiYTliZGQ5ZTRiYmM5MGE3ZDdhOTRk
+        MmRhN2QwIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MTkuNTMy
+        MzMyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMzoyMC4xNDk1
+        MzdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZjQwNTBj
-        YzgtZjMyYy00ZTQ0LTk1N2ItZTgxZmQ0MmU5YjdhLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZGNhOTlm
+        YzAtOTA2Yi00ZTZlLThlOTMtNWM2NjdiZDNkNTNmLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vM2E2NTg5YjMtNGQ5My00ODdmLTk3MWEtZDUzYWM5
-        YjRhMjRlLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNTQwOGQzNjAtOWZjNC00M2EwLWFiMmEtZDk3NmE2
+        ZDk2OWYxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ca3ca70fcb3b4c0b9df9e984d2dc82d2
+      - d1e181d4bdb840188c0db44a7c454f73
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:20 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/dca99fc0-906b-4e6e-8e93-5c667bd3d53f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9e97ffac199b42aba5b823af642ccd92
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vZGNhOTlmYzAtOTA2Yi00ZTZlLThlOTMtNWM2NjdiZDNkNTNmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MTkuNTY2NTQ0WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS81NDA4ZDM2MC05ZmM0LTQzYTAtYWIyYS1kOTc2YTZkOTY5ZjEv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzU0MDhkMzYwLTlmYzQtNDNhMC1hYjJhLWQ5NzZh
+        NmQ5NjlmMS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:20 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9kY2E5OWZjMC05MDZiLTRlNmUtOGU5My01YzY2N2JkM2Q1M2Yv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 96323febb98a43ba878df7ae8a2c7262
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2Nzc0ZDBhLWE1MWYtNGNi
+        OS1iMWRhLTNlMTIyM2YwOWY5MS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:20 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d6774d0a-a51f-4cb9-b1da-3e1223f09f91/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 50042056d2394a4c9381c822642ca2c6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDY3NzRkMGEtYTUx
+        Zi00Y2I5LWIxZGEtM2UxMjIzZjA5ZjkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjAuNjE4OTY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5NjMyM2ZlYmI5OGE0M2JhODc4ZGY3YWU4
+        YTJjNzI2MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjIwLjY5
+        Njc2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MjAuOTc1
+        Mjk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNGFk
+        ZDYyNWQtZWIzZC00NjNlLWI2N2UtZGJmZjU5ZjI2NTg2LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:21 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4add625d-eb3d-463e-b67e-dbff59f26586/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2278a02c59b8430e99a3427a659350e4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzRhZGQ2MjVkLWViM2QtNDYzZS1iNjdlLWRiZmY1OWYyNjU4Ni8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMzOjIwLjk1MDcwMFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vZGNhOTlmYzAtOTA2Yi00ZTZlLThlOTMt
+        NWM2NjdiZDNkNTNmLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:21 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - dc585f78771b415491ca0f56a25334fe
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5cdc02c9b7144c869e66cff9fbad8c93
+      - edcaf24f9a6e46dfb5bc550cde840d93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a78f8fdb11cc44978d9128df1b2fb3a5
+      - 5b1d6e0016a640beb194a9882318c372
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 59f02777f09045dfa7ccfbaf3b65751f
+      - b3206acf5bfd4d708231256db734865e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ba46707681c457d93acfb65478dcb55
+      - c7b0959363ad4f3bbcf019850b7e5cbf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d992cd151e6476fbc3880f75ae2d54f
+      - ea429ee6424b4a1692a0082252d824e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73e45924d5e14e96a506ea0150b1ee54
+      - 526a820a99c34dbbb6f973464f593461
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - de671e7341174c7ba7010b68a69aa826
+      - 1bedc4fcf6564557be74e018e825b87a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3bf02942054c4f21a1c785c1ac0593f4
+      - e05f5890276145fa88a17b7174fd3d44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:06 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0daa7f8aeae044af8dc683d394274b7e
+      - 53fd834ef7874de5875098cc230a2601
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a6d952e6c6474aad8c637086d87eb4a0
+      - a3c060056d9c4af19561a1bd03520b26
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6043deff0b01406288907634bec807ad
+      - 9ddb1062e7a5499581ba5c4ce60a624b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af2ef0a6d65c4ef4bace78bd818dcd95
+      - '097f703977934625ad960aa8939ac85a'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3a6589b3-4d93-487f-971a-d53ac9b4a24e/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5408d360-9fc4-43a0-ab2a-d976a6d969f1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae54bba6305045d5b161ca00155f9a30
+      - f12b8171d0ff461bb780c0c90de4b4f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3611612fc6ec400dbc8fb4e45bf48637
+      - a3e4daab1da44bb7b8feec84ffe55351
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiMTc0NmFjLTUwY2UtNGMw
-        My1iMjhmLTFjNTZjNTMwMzJmZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1NzlkOWQxLWE2NzAtNDhk
+        MC1iOTBmLWEyZWJkMTE3YTA2ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjQ4Mzk2OC1iNWM2LTRiNzMtYWU0
-        YS04N2JjYThlYjM5ZTEvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9371a4fb7f74495958dab2696498a74
+      - 7eba3d92e7ca4236ae6b3ad8aa746e53
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3NDE4OGQ3LTM0NDItNDg0
-        MC04N2RkLThlYzFmOTI1NDJmNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjMmUwYTQ3LWRkOWMtNGM3
+        Ni05YjExLTMwZjc4YmFjZTkyYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5N2Qt
-        OTkyMTM4NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2ZTE4
-        NGQ5MmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzLzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0YS8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,79 +3935,79 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc1a47dd6aad4feeb91f8389f351c40a
+      - 04fbd442c152404f8984e858e667af17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1NTRkNGQ1LTc1ZmMtNDMy
-        NC05ZTc1LTQ2NjIzODQ5MzJhZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5Mjc3YTYwLTA0MDYtNGQy
+        YS1iYWJkLWE1ZTY0ZjkwYmNjMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2E2NTg5YjMtNGQ5My00ODdmLTk3
-        MWEtZDUzYWM5YjRhMjRlL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU2YmEwNjU4LTIwNDEt
-        NDVlMS1hMGVjLWJmMzliYTAwMTJiZS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJm
-        Ny04MzIyLTdhOWRkZDVhOGE3OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82YTEwYmJiZi01MWUxLTQxNWEtYTAwZi03OWI3MWFl
-        MWQzZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        N2ZmZDYwNzYtZjdkZC00NWQzLThmMTctN2ZjNDE4ZDFhZGYzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2IzZDM1MGIxLWYwNzEt
-        NGRhMC05YjlmLWU0ZDczYThhYjBiZS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjky
-        MDRhNTU5YjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvZWY4MjdkZDctYTJhOS00Mzg1LTgwMjEtYmUyY2Q5OGZlOGMwLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvYzdl
-        MzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJkNjM1YjNlZWJhLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIy
-        LTgxNDMtYTYxOTBkYmViOGM3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdy
-        b3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdj
-        YzItNDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvMjM5MjhjODYtNjJhZC00ZjJlLThmZWQtZTVi
-        ZWY0OTUxMDdlLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yODQwNDdkOC01YWM2LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTct
-        NDliMC05OGJlLTcyMjNiNjk4NWUyOC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvNWUyNDBmNzMtNzFlOC00YzE4LThiNGItMzllYWM5
-        MjYzYzRjLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81
-        ZjMxZDlkZC02OTc4LTQwYWItYTI4ZC0xMzVlMDI4MDcyMjkvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkNjBkYTJmLTBhYTctNDZh
-        Zi1iZjZmLWE5YTNkODZlZTE0OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2JkMjdlODQtY2I0MC00ZTg5LThkODEtY2U2MGQxNjZk
-        MjJhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NmY5
-        OWQ5Mi0zNzUwLTRhNDktOThmZS00NjZhMTUyMTc5NzEvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1MzI2ZmZlLTZiZTEtNDUyMy04
-        YTY3LWE5Y2RmZDZlNWJmMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvYmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2Zk
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMWMyOTIw
-        Ni00MTEwLTQyMDgtYTIwYy1jMzg1NWNkNGY0MGMvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1YTJmMWFkLTA0MmEtNDA1ZS1hYzQ0
-        LTBjNGIxNGRiYmVjYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJmLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNjZmYzg0Ni0z
-        NDhjLTQzNTAtODZlMS1jMzJiZGNhNDFkM2UvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvZDI0NDFlYWEtM2ZjMS00
-        Nzc1LTkyMGUtYTZkNzY4ZDZjMjE3LyJdfV0sImRlcGVuZGVuY3lfc29sdmlu
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTQwOGQzNjAtOWZjNC00M2EwLWFi
+        MmEtZDk3NmE2ZDk2OWYxL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk5YzZkOTcwLWIwMGEt
+        NDk2NC1hNDdlLTY4MjUxZGI0ZTQwMS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvNGYy
+        NTJlY2UtMzE5NS00N2FiLWE1NjctZTljZGRkZDUwYTIzLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5
+        LWJhZTMtNzBkNGM2ZTkwNzc1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdy
+        b3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1ZTM2OGQ3LTI5
+        MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8zNWJiYTAwYi02ZjE2LTQzYzEtODFhNS03ZWU5NjIxZGNlMjIvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEt
+        NDA5MC05YWZmLTczYTQ0NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvNjVmYmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVh
+        MjU4YWM3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        NmQwMjRjMi0xMGZjLTQwMWMtYWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5
+        MC04MWU5LTNhNWIxYWQ4NGEyNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQy
+        M2UxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85ZWNh
+        MzhhMi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1i
+        ZDJiLTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvYTcyNDBkMjYtOTBmOC00YWMyLWE5OWEtMjJmYTIyOWM5YjBl
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkw
+        NS02MWY1LTQ3MmItOGU5MS0zNmVjOGZjMzUwNDgvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MyNDc0MjU0LTE1YTItNDQ2NC05ZDEy
+        LTI0MWVmNmQ0NTNiMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1j
+        OTEyLTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvNGFiZjUzN2YtYjljMC00
+        MjMxLTg3ZDItZTEzMDNiZmRmYTVmLyJdfV0sImRlcGVuZGVuY3lfc29sdmlu
         ZyI6ZmFsc2V9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3595,7 +4020,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3613,21 +4038,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74794c436c074480abb0da8ebd5bb232
+      - a186386f18254307abf3ad5729150ad3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0YWU2YzNkLWRjMGItNDg2
-        Ny1iZWJhLTU0YjU1ZWI0YWI5NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1ZTNlOTJlLWMyYTctNDQw
+        YS04YmNhLWNmMWExODRjOWMyNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1b1746ac-50ce-4c03-b28f-1c56c53032fe/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e579d9d1-a670-48d0-b90f-a2ebd117a06d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3648,51 +4073,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 908345538c0744dc9d473c730ec54594
+      - a4d59120d8db45f8a1b83ccf47782686
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWIxNzQ2YWMtNTBj
-        ZS00YzAzLWIyOGYtMWM1NmM1MzAzMmZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMjQyOTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTU3OWQ5ZDEtYTY3
+        MC00OGQwLWI5MGYtYTJlYmQxMTdhMDZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuNjk3NjU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzNjExNjEyZmM2ZWM0MDBkYmM4
-        ZmI0ZTQ1YmY0ODYzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjI3NzI1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNDEyNTM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhM2U0ZGFhYjFkYTQ0YmI3Yjhm
+        ZWVjODRmZmU1NTM1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjIzLjc2NTU5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuMTM3MjU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0
-        MS00NWUxLWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAw
+        YS00OTY0LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1b1746ac-50ce-4c03-b28f-1c56c53032fe/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1c2e0a47-dd9c-4c76-9b11-30f78bace92c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3713,118 +4138,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 54e946e73d1d42699c34755603e23a5b
+      - 84b88473a3894967bafacab16c9a9aa4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWIxNzQ2YWMtNTBj
-        ZS00YzAzLWIyOGYtMWM1NmM1MzAzMmZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMjQyOTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWMyZTBhNDctZGQ5
+        Yy00Yzc2LTliMTEtMzBmNzhiYWNlOTJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuNzg1NDg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzNjExNjEyZmM2ZWM0MDBkYmM4
-        ZmI0ZTQ1YmY0ODYzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjI3NzI1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNDEyNTM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0
-        MS00NWUxLWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/474188d7-3442-4840-87dd-8ec1f92542f5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:07 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - c0dee6cfb3e64c798f6677017494c361
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDc0MTg4ZDctMzQ0
-        Mi00ODQwLTg3ZGQtOGVjMWY5MjU0MmY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMjk3NDEyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjOTM3MWE0ZmI3Zjc0NDk1OTU4
-        ZGFiMjY5NjQ5OGE3NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjQ0Mjc3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNTcyNjQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZWJhM2Q5MmU3Y2E0MjM2YWU2
+        YjNhZDhhYTc0NmU1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjI0LjE5MjI5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuNDk0NDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS81NmJhMDY1OC0yMDQxLTQ1ZTEtYTBlYy1iZjM5YmEwMDEyYmUvdmVyc2lv
+        bS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0MS00NWUx
-        LWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAwYS00OTY0
+        LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1b1746ac-50ce-4c03-b28f-1c56c53032fe/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e579d9d1-a670-48d0-b90f-a2ebd117a06d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3845,51 +4205,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ade7999095a544efbc1da656cd88c091
+      - d24c8ec17ac04197ae3852bf8c476111
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWIxNzQ2YWMtNTBj
-        ZS00YzAzLWIyOGYtMWM1NmM1MzAzMmZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMjQyOTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTU3OWQ5ZDEtYTY3
+        MC00OGQwLWI5MGYtYTJlYmQxMTdhMDZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuNjk3NjU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzNjExNjEyZmM2ZWM0MDBkYmM4
-        ZmI0ZTQ1YmY0ODYzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjI3NzI1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNDEyNTM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhM2U0ZGFhYjFkYTQ0YmI3Yjhm
+        ZWVjODRmZmU1NTM1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjIzLjc2NTU5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuMTM3MjU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0
-        MS00NWUxLWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAw
+        YS00OTY0LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/474188d7-3442-4840-87dd-8ec1f92542f5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1c2e0a47-dd9c-4c76-9b11-30f78bace92c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3910,53 +4270,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:07 GMT
+      - Fri, 29 Jul 2022 11:33:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4f78cd876f74bc1bf53f74cb5602ea6
+      - 87b5bf0077374f65a7701de182778a61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDc0MTg4ZDctMzQ0
-        Mi00ODQwLTg3ZGQtOGVjMWY5MjU0MmY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMjk3NDEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWMyZTBhNDctZGQ5
+        Yy00Yzc2LTliMTEtMzBmNzhiYWNlOTJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuNzg1NDg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjOTM3MWE0ZmI3Zjc0NDk1OTU4
-        ZGFiMjY5NjQ5OGE3NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjQ0Mjc3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNTcyNjQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZWJhM2Q5MmU3Y2E0MjM2YWU2
+        YjNhZDhhYTc0NmU1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjI0LjE5MjI5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuNDk0NDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS81NmJhMDY1OC0yMDQxLTQ1ZTEtYTBlYy1iZjM5YmEwMDEyYmUvdmVyc2lv
+        bS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0MS00NWUx
-        LWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAwYS00OTY0
+        LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6554d4d5-75fc-4324-9e75-4662384932af/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/49277a60-0406-4d2a-babd-a5e64f90bcc1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3977,53 +4337,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31e4034196ab45daa1ba6574787e0c4b
+      - 3836680c2c1d4fb584c6529a7b0f7ae7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjU1NGQ0ZDUtNzVm
-        Yy00MzI0LTllNzUtNDY2MjM4NDkzMmFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMzQ3NTUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDkyNzdhNjAtMDQw
+        Ni00ZDJhLWJhYmQtYTVlNjRmOTBiY2MxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuODc1NzM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiYzFhNDdkZDZhYWQ0ZmVlYjkx
-        ZjgzODlmMzUxYzQwYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjYwNDEwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNzM4MzM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNGZiZDQ0MmMxNTI0MDRmODk4
+        NGU4NThlNjY3YWYxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjI0LjU2NjcwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuODcxNzQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS81NmJhMDY1OC0yMDQxLTQ1ZTEtYTBlYy1iZjM5YmEwMDEyYmUvdmVyc2lv
+        bS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0MS00NWUx
-        LWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAwYS00OTY0
+        LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1b1746ac-50ce-4c03-b28f-1c56c53032fe/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e579d9d1-a670-48d0-b90f-a2ebd117a06d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4044,51 +4404,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c768774799549479a3527e6e8759a49
+      - ce73628e91244c70a6f9437afb362263
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWIxNzQ2YWMtNTBj
-        ZS00YzAzLWIyOGYtMWM1NmM1MzAzMmZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMjQyOTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTU3OWQ5ZDEtYTY3
+        MC00OGQwLWI5MGYtYTJlYmQxMTdhMDZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuNjk3NjU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzNjExNjEyZmM2ZWM0MDBkYmM4
-        ZmI0ZTQ1YmY0ODYzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjI3NzI1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNDEyNTM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhM2U0ZGFhYjFkYTQ0YmI3Yjhm
+        ZWVjODRmZmU1NTM1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjIzLjc2NTU5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuMTM3MjU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0
-        MS00NWUxLWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAw
+        YS00OTY0LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/474188d7-3442-4840-87dd-8ec1f92542f5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1c2e0a47-dd9c-4c76-9b11-30f78bace92c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4109,53 +4469,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbf03cfdb2d6483797853ce63bfddc33
+      - 1f8f2a483c1e48c987f32092f2cab3bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDc0MTg4ZDctMzQ0
-        Mi00ODQwLTg3ZGQtOGVjMWY5MjU0MmY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMjk3NDEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWMyZTBhNDctZGQ5
+        Yy00Yzc2LTliMTEtMzBmNzhiYWNlOTJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuNzg1NDg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjOTM3MWE0ZmI3Zjc0NDk1OTU4
-        ZGFiMjY5NjQ5OGE3NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjQ0Mjc3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNTcyNjQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZWJhM2Q5MmU3Y2E0MjM2YWU2
+        YjNhZDhhYTc0NmU1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjI0LjE5MjI5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuNDk0NDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS81NmJhMDY1OC0yMDQxLTQ1ZTEtYTBlYy1iZjM5YmEwMDEyYmUvdmVyc2lv
+        bS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0MS00NWUx
-        LWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAwYS00OTY0
+        LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6554d4d5-75fc-4324-9e75-4662384932af/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/49277a60-0406-4d2a-babd-a5e64f90bcc1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4176,53 +4536,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a01c012c2dc74522ad57503bb63ea202
+      - 10c3361de7e04564a9e8fc9bc9fd8495
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjU1NGQ0ZDUtNzVm
-        Yy00MzI0LTllNzUtNDY2MjM4NDkzMmFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMzQ3NTUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDkyNzdhNjAtMDQw
+        Ni00ZDJhLWJhYmQtYTVlNjRmOTBiY2MxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuODc1NzM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiYzFhNDdkZDZhYWQ0ZmVlYjkx
-        ZjgzODlmMzUxYzQwYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjA3LjYwNDEwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MDcuNzM4MzM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNGZiZDQ0MmMxNTI0MDRmODk4
+        NGU4NThlNjY3YWYxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjI0LjU2NjcwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuODcxNzQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS81NmJhMDY1OC0yMDQxLTQ1ZTEtYTBlYy1iZjM5YmEwMDEyYmUvdmVyc2lv
+        bS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2NTgtMjA0MS00NWUx
-        LWEwZWMtYmYzOWJhMDAxMmJlLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAwYS00OTY0
+        LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/94ae6c3d-dc0b-4867-beba-54b55eb4ab95/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e579d9d1-a670-48d0-b90f-a2ebd117a06d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4243,55 +4603,254 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a92ca17d96a34cbaaf0c6c040726b242
+      - fb4ed91695714fdb9e0c6ced4dcbf254
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '416'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTRhZTZjM2QtZGMw
-        Yi00ODY3LWJlYmEtNTRiNTVlYjRhYjk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MDcuMzk5OTY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTU3OWQ5ZDEtYTY3
+        MC00OGQwLWI5MGYtYTJlYmQxMTdhMDZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuNjk3NjU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhM2U0ZGFhYjFkYTQ0YmI3Yjhm
+        ZWVjODRmZmU1NTM1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjIzLjc2NTU5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuMTM3MjU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAw
+        YS00OTY0LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:25 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1c2e0a47-dd9c-4c76-9b11-30f78bace92c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '697'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 23e7ee4cbc9440498401ea1e0b96fcf7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWMyZTBhNDctZGQ5
+        Yy00Yzc2LTliMTEtMzBmNzhiYWNlOTJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuNzg1NDg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZWJhM2Q5MmU3Y2E0MjM2YWU2
+        YjNhZDhhYTc0NmU1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjI0LjE5MjI5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuNDk0NDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAwYS00OTY0
+        LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:25 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/49277a60-0406-4d2a-babd-a5e64f90bcc1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '697'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - de2cc6ffe6aa4bbfaeef56b64844d878
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDkyNzdhNjAtMDQw
+        Ni00ZDJhLWJhYmQtYTVlNjRmOTBiY2MxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuODc1NzM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNGZiZDQ0MmMxNTI0MDRmODk4
+        NGU4NThlNjY3YWYxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjI0LjU2NjcwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MjQuODcxNzQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS85OWM2ZDk3MC1iMDBhLTQ5NjQtYTQ3ZS02ODI1MWRiNGU0MDEvdmVyc2lv
+        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5NzAtYjAwYS00OTY0
+        LWE0N2UtNjgyNTFkYjRlNDAxLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e5e3e92e-c2a7-440a-8bca-cf1a184c9c25/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2e50427dd5284d36a612eaa5fccadef4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVlM2U5MmUtYzJh
+        Ny00NDBhLThiY2EtY2YxYTE4NGM5YzI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MjMuOTc5ODM5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiNzQ3OTRjNDM2YzA3NDQ4MGFiYjBkYThlYmQ1
-        YmIyMzIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxNjowNy43Njc3
-        NzFaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjA4LjEwODk5
-        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiYTE4NjM4NmYxODI1NDMwN2FiZjNhZDU3Mjkx
+        NTBhZDMiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMzoyNC45Mjcw
+        NjRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjI1Ljc3NTUw
+        NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTZiYTA2
-        NTgtMjA0MS00NWUxLWEwZWMtYmYzOWJhMDAxMmJlL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTljNmQ5
+        NzAtYjAwYS00OTY0LWE0N2UtNjgyNTFkYjRlNDAxL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzU2YmEwNjU4LTIwNDEtNDVlMS1hMGVjLWJm
-        MzliYTAwMTJiZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzNhNjU4OWIzLTRkOTMtNDg3Zi05NzFhLWQ1M2FjOWI0YTI0
-        ZS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzk5YzZkOTcwLWIwMGEtNDk2NC1hNDdlLTY4
+        MjUxZGI0ZTQwMS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzU0MDhkMzYwLTlmYzQtNDNhMC1hYjJhLWQ5NzZhNmQ5Njlm
+        MS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4299,7 +4858,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4312,68 +4871,68 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1372'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2536d3543834a63a659415e9a40889c
+      - d7df4700f3cf45329341b961280ea613
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '472'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTUsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
+        cGFja2FnZXMvNjVmYmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04ZDgxLWNlNjBkMTY2ZDIyYS8i
+        Y2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9kNWEyZjFhZC0wNDJhLTQwNWUtYWM0NC0wYzRiMTRkYmJlY2EvIn0s
+        YWdlcy85ZWNhMzhhMi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNWYzMWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyJ9LHsi
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8y
-        YWU3YjhjMy05OWU3LTQ5YjAtOThiZS03MjIzYjY5ODVlMjgvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjg0
-        MDQ3ZDgtNWFjNi00NmFiLTk1ZTgtYjI1MDljMjhlMjlhLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1MzI2
-        ZmZlLTZiZTEtNDUyMy04YTY3LWE5Y2RmZDZlNWJmMC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NmY5OWQ5
-        Mi0zNzUwLTRhNDktOThmZS00NjZhMTUyMTc5NzEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWUyNDBmNzMt
-        NzFlOC00YzE4LThiNGItMzllYWM5MjYzYzRjLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNlNGVmMjZmLTRm
-        NDgtNGExMi1iNjc5LTVjZDNkZGRhOWE1Ny8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNh
-        LTRmZmYtOWQwOC1hMjRmYTBhYzIzZmQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00
-        MzUwLTg2ZTEtYzMyYmRjYTQxZDNlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzItNDVm
-        My1iNWIwLTU2OGU2ZWQyNjNmNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMWMyOTIwNi00MTEwLTQyMDgt
-        YTIwYy1jMzg1NWNkNGY0MGMvIn1dfQ==
+        LzM1YmJhMDBiLTZmMTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJh
+        NDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYw
+        OGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYy
+        ZS1iMmMxLTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQt
+        MTVhMi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEw
+        ZmMtNDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjkxMmM5MDUtNjFmNS00
+        NzJiLThlOTEtMzZlYzhmYzM1MDQ4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1ZTM2OGQ3LTI5MWEtNDMz
+        Ni1hZGJkLWQ4OWI3YjAxZDg0Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xMDgwNDgyNy02NGM4LTQ1OTIt
+        ODM4NC1iMjc2ZmZhN2U4MjYvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4381,7 +4940,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4394,41 +4953,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '140'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4e2f7443a6444fba059f4aa590cfdcb
+      - c5348fbba986496f8e74176309ea86d8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBkYmViOGM3
+        b2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2ZTkwNzc1
         LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4436,7 +4995,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4449,37 +5008,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '7483'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bae1ca0f1f424dd8a13c53c8ef3d63c4
+      - eaaef1e0dd984b0e87a55c9a09d6ab56
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4552,9 +5111,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -4570,8 +5129,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -4589,9 +5148,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -4613,9 +5172,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -4631,9 +5190,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -4643,10 +5202,10 @@ http_interactions:
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4654,7 +5213,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4667,43 +5226,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4a1c3c48829e4dab92094a85b020ac80
+      - 25f69d24130548c0be9c3ed48f3cbea1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4711,7 +5270,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4724,41 +5283,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d5bdbf131fc41b6bc47ac8b9a0f2b5c
+      - dc4eea84bbd1402aa5be78a99b3cf7aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4766,7 +5325,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4779,36 +5338,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 217e2d19225d4a3097d1738c5d6de913
+      - 85827d857c874bf6a6cf04070676ea06
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4830,10 +5389,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4841,7 +5400,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4854,68 +5413,68 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:08 GMT
+      - Fri, 29 Jul 2022 11:33:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1372'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83cf6824a07d461280a8df81ced6aefb
+      - 586d2ac188e14ac4bfac446cc5dafcb9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '472'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTUsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
+        cGFja2FnZXMvNjVmYmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04ZDgxLWNlNjBkMTY2ZDIyYS8i
+        Y2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9kNWEyZjFhZC0wNDJhLTQwNWUtYWM0NC0wYzRiMTRkYmJlY2EvIn0s
+        YWdlcy85ZWNhMzhhMi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNWYzMWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyJ9LHsi
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8y
-        YWU3YjhjMy05OWU3LTQ5YjAtOThiZS03MjIzYjY5ODVlMjgvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjg0
-        MDQ3ZDgtNWFjNi00NmFiLTk1ZTgtYjI1MDljMjhlMjlhLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1MzI2
-        ZmZlLTZiZTEtNDUyMy04YTY3LWE5Y2RmZDZlNWJmMC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NmY5OWQ5
-        Mi0zNzUwLTRhNDktOThmZS00NjZhMTUyMTc5NzEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWUyNDBmNzMt
-        NzFlOC00YzE4LThiNGItMzllYWM5MjYzYzRjLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNlNGVmMjZmLTRm
-        NDgtNGExMi1iNjc5LTVjZDNkZGRhOWE1Ny8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNh
-        LTRmZmYtOWQwOC1hMjRmYTBhYzIzZmQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00
-        MzUwLTg2ZTEtYzMyYmRjYTQxZDNlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzItNDVm
-        My1iNWIwLTU2OGU2ZWQyNjNmNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMWMyOTIwNi00MTEwLTQyMDgt
-        YTIwYy1jMzg1NWNkNGY0MGMvIn1dfQ==
+        LzM1YmJhMDBiLTZmMTYtNDNjMS04MWE1LTdlZTk2MjFkY2UyMi8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJh
+        NDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYw
+        OGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYy
+        ZS1iMmMxLTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQt
+        MTVhMi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEw
+        ZmMtNDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjkxMmM5MDUtNjFmNS00
+        NzJiLThlOTEtMzZlYzhmYzM1MDQ4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1ZTM2OGQ3LTI5MWEtNDMz
+        Ni1hZGJkLWQ4OWI3YjAxZDg0Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xMDgwNDgyNy02NGM4LTQ1OTIt
+        ODM4NC1iMjc2ZmZhN2U4MjYvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4923,7 +5482,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4936,41 +5495,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:09 GMT
+      - Fri, 29 Jul 2022 11:33:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '140'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4810bf2461d84417bf9707f32a29c763
+      - f236456e2b074554a16fe10f58fb0ded
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBkYmViOGM3
+        b2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2ZTkwNzc1
         LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4978,7 +5537,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4991,37 +5550,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:09 GMT
+      - Fri, 29 Jul 2022 11:33:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '7483'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 62d8c725fcba4cf799c2d1ca3a3ae84d
+      - d3ff278560e546b19b43b409b496d7c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -5094,9 +5653,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -5112,8 +5671,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -5131,9 +5690,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -5155,9 +5714,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -5173,9 +5732,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -5185,10 +5744,10 @@ http_interactions:
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5196,7 +5755,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5209,43 +5768,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:09 GMT
+      - Fri, 29 Jul 2022 11:33:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 767dd055a1754b0f8da6f3db086130c5
+      - ab6413221ae64512b953638eca3a916a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5253,7 +5812,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5266,41 +5825,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:09 GMT
+      - Fri, 29 Jul 2022 11:33:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5410e75536c143c78834e116ec67317f
+      - 1618ac8efa614cc49e244af8d75db0e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/56ba0658-2041-45e1-a0ec-bf39ba0012be/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/99c6d970-b00a-4964-a47e-68251db4e401/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5308,7 +5867,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5321,36 +5880,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:09 GMT
+      - Fri, 29 Jul 2022 11:33:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ed05f26956547039af3eca66c02b2fb
+      - 9e84dff46d2a4bbb8e78f7753552433b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5372,5 +5931,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:28 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_module_stream_repository/module_streams_copied_with_modular_exclude_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_module_stream_repository/module_streams_copied_with_modular_exclude_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ac9e64b1b69b4bbe8deea4a646a33734
+      - 3371079d274f482785c167487b4f4f44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '314'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xOWI0NzI5MC1mYWFlLTRkMDAtYjM1Mi1jYmJmZTMzYmQwMDQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNjoxMC43NTI0MzFa
+        cnBtL3JwbS82NmJjNDk4OC0wMTJjLTQwNTctYTQ4Mi1iNWU1YzU3ZTUzZjcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjo0My4zOTE3MzBa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xOWI0NzI5MC1mYWFlLTRkMDAtYjM1Mi1jYmJmZTMzYmQwMDQv
+        cnBtL3JwbS82NmJjNDk4OC0wMTJjLTQwNTctYTQ4Mi1iNWU1YzU3ZTUzZjcv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzE5YjQ3
-        MjkwLWZhYWUtNGQwMC1iMzUyLWNiYmZlMzNiZDAwNC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY2YmM0
+        OTg4LTAxMmMtNDA1Ny1hNDgyLWI1ZTVjNTdlNTNmNy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:56 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/19b47290-faae-4d00-b352-cbbfe33bd004/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/66bc4988-012c-4057-a482-b5e5c57e53f7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb2c869ac39c441488566b33e615cb84
+      - 26693c889868491ab3a89c3712bee364
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4ODUzMjg2LWFmNTEtNGJi
-        Ni1hMDA0LTE2YjhiZTNhMzQwYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2NGQyZWI5LTYwZmYtNDZh
+        Mi1iZDRlLWYxMzlhNjhkMTMzMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 28e07d76c7ee456e84409b75632897a2
+      - 8d6f5872b1bd42b586fd8fbc79a72305
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b8853286-af51-4bb6-a004-16b8be3a340b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/264d2eb9-60ff-46a2-bd4e-f139a68d1332/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57ff014a34d34734a5050b683d4a6254
+      - d2c5f74c67f1424faf01cc74e6a353ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjg4NTMyODYtYWY1
-        MS00YmI2LWEwMDQtMTZiOGJlM2EzNDBiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTcuNTAzMzcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjY0ZDJlYjktNjBm
+        Zi00NmEyLWJkNGUtZjEzOWE2OGQxMzMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTYuNzM4ODY2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmYjJjODY5YWMzOWM0NDE0ODg1NjZiMzNl
-        NjE1Y2I4NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjE3LjUz
-        MzY0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTcuNjU4
-        Nzc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyNjY5M2M4ODk4Njg0OTFhYjNhODljMzcx
+        MmJlZTM2NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjU2Ljgw
+        ODE4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NTcuMTQw
+        MTM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTliNDcyOTAtZmFhZS00ZDAw
-        LWIzNTItY2JiZmUzM2JkMDA0LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjZiYzQ5ODgtMDEyYy00MDU3
+        LWE0ODItYjVlNWM1N2U1M2Y3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9df14b894f4492195d31fbfdd64c087
+      - 5dbc22df081343edb2878dc41b168d11
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 87867b7573c4457daa4947a68d477890
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vYTQ5OWVlOWMtNTg3Ny00NzM3LWI5MTctMDk5ZWQ0MDU4MzNk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6NDguNTg2MDQ2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:57 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/a499ee9c-5877-4737-b917-099ed405833d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c42b372770274ec8b53fc85dfb5c886a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlkMTlhZTk4LTUwNjctNDU4
+        NS1hYjA1LTY3N2YzNGJiZmJmYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:57 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9d19ae98-5067-4585-ab05-677f34bbfbfc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5c7e674a97a544bc93cda58c65cd50ef
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWQxOWFlOTgtNTA2
+        Ny00NTg1LWFiMDUtNjc3ZjM0YmJmYmZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTcuNTAzNDExWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjNDJiMzcyNzcwMjc0ZWM4YjUzZmM4NWRm
+        YjVjODg2YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjU3LjU1
+        OTg3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NTcuNjM4
+        MTQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:57 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 659bff18f6624dc3b8a9e11c1ac9f36b
+      - b8d3ddbf566a49aea471be583ef31a80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46321bf9483149509929850d1076dbd8
+      - 21ab8aacedfc4de7b35e2cbc7d18e027
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ed39cb9c88041609961dbe7bc6a066a
+      - d3152e2ce9df4dc8bc4a14f820b7b163
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:17 GMT
+      - Fri, 29 Jul 2022 11:32:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e066aaff24844d4aba478ffb1ff7a91a
+      - 1e79dd80bf47427099fa5786ce3c340c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f63c37dad406494abdb8c95e18f18ae4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/874a17e7-5193-4c78-972a-efb072475aef/"
+      - "/pulp/api/v3/remotes/rpm/rpm/cd55b703-fb3a-40e6-b602-e3fda80ee0eb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6abb7843f1394d528babda98b485f77b
+      - '04079ea5e8094277bbb7f35b2338e270'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3
-        NGExN2U3LTUxOTMtNGM3OC05NzJhLWVmYjA3MjQ3NWFlZi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE2OjE4LjAzODUxNFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Nk
+        NTViNzAzLWZiM2EtNDBlNi1iNjAyLWUzZmRhODBlZTBlYi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjU4LjIwODgyMFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjE2OjE4LjAzODUzMloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjMyOjU4LjIwODkwNFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22b9e226d44049b7a54208e4ec10bf29
+      - 38627b54cd77431394cee6b4023a301f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMGUxMGM4MDctMWFmNC00N2IxLWEyODEtYTVhZmZhOTM2NDZhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MTguMTQ2OTI5WiIsInZl
+        cG0vZDkxZTBiZDgtZTM1Yi00ZDExLTliYjktZGExODY4OWIxMGExLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6NTguNDI1ODM5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMGUxMGM4MDctMWFmNC00N2IxLWEyODEtYTVhZmZhOTM2NDZhL3ZlcnNp
+        cG0vZDkxZTBiZDgtZTM1Yi00ZDExLTliYjktZGExODY4OWIxMGExL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wZTEwYzgwNy0x
-        YWY0LTQ3YjEtYTI4MS1hNWFmZmE5MzY0NmEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kOTFlMGJkOC1l
+        MzViLTRkMTEtOWJiOS1kYTE4Njg5YjEwYTEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 19385ea3dee1412288abe419326433cb
+      - 9dc08610de6e479bbdec6b2cb705b481
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xOWY1OTI2Mi05MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNjoxMS40MzU0NjJa
+        cnBtL3JwbS8yYWQ3ZGUyMC0xNDA2LTRlOWUtOTM2Zi01NGIzMTgwZTFjMDEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMjo0NC42NzE0MTha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xOWY1OTI2Mi05MDU1LTRmMmItYjIwMi1kYzNlYTI5N2U0OWQv
+        cnBtL3JwbS8yYWQ3ZGUyMC0xNDA2LTRlOWUtOTM2Zi01NGIzMTgwZTFjMDEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzE5ZjU5
-        MjYyLTkwNTUtNGYyYi1iMjAyLWRjM2VhMjk3ZTQ5ZC92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJhZDdk
+        ZTIwLTE0MDYtNGU5ZS05MzZmLTU0YjMxODBlMWMwMS92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:58 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/19f59262-9055-4f2b-b202-dc3ea297e49d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2ad7de20-1406-4e9e-936f-54b3180e1c01/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4aa8081e39db4d5d9ff8a56f5b0a2141
+      - 548991bd9c954e059a24bf09ed133236
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkMGFmODk5LTc3MmQtNGMy
-        Zi05YWNiLWM1YzAyMzc5YzEyNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyYzAxZGQyLWFlYzEtNGFk
+        ZC05ODUwLWIyYThiOTUzODI5NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a35e903c684e46858e61f21ee5c475fe
+      - d26fd551b0cd43e7981faccb5bdd9f17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '368'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vODk0YjIyMTItYjljNS00NTQ3LTgxNzQtYjc5YTNjODczYWE0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MTAuNjQyNTIxWiIsIm5h
+        cG0vOGMyOTU2N2EtZTViYi00MGQ3LThlM2ItNTRlN2UzNzQ0MjRmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6NDMuMTgwMDg4WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoxNjoxMS43NjQ1NDlaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozMjo0NS4yMjk5NDlaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:58 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/894b2212-b9c5-4547-8174-b79a3c873aa4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/8c29567a-e5bb-40d7-8e3b-54e7e374424f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 164e727f9e6646c0b392c454c5e7a2eb
+      - 976f8632e6e54576a2d5971bf624b383
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M1ODZjMGIwLTFmYjktNDg1
-        Ni1hMjgxLTI4MGJhYjM1MGEyOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ2MDJlMWE0LWM0NmYtNGZm
+        ZC05M2MxLTc0ZDllNDZkNjIzMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3d0af899-772d-4c2f-9acb-c5c02379c126/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b2c01dd2-aec1-4add-9850-b2a8b9538295/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4917a49ef3a4c6ab2eb4e28594b0bdb
+      - 3ad592464be14ae7b183a6dbdc29d996
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2QwYWY4OTktNzcy
-        ZC00YzJmLTlhY2ItYzVjMDIzNzljMTI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTguMzE0MDk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjJjMDFkZDItYWVj
+        MS00YWRkLTk4NTAtYjJhOGI5NTM4Mjk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTguNzM2MzY0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0YWE4MDgxZTM5ZGI0ZDVkOWZmOGE1NmY1
-        YjBhMjE0MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjE4LjM0
-        Mzg2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTguNDA4
-        NDA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NDg5OTFiZDljOTU0ZTA1OWEyNGJmMDll
+        ZDEzMzIzNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjU4Ljc5
+        NTU3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NTguOTMw
+        NjQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTlmNTkyNjItOTA1NS00ZjJi
-        LWIyMDItZGMzZWEyOTdlNDlkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmFkN2RlMjAtMTQwNi00ZTll
+        LTkzNmYtNTRiMzE4MGUxYzAxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c586c0b0-1fb9-4856-a281-280bab350a29/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4602e1a4-c46f-4ffd-93c1-74d9e46d6230/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7924672f33ef46cbaa9c19a63396f7cb
+      - f5370194e89a42338adc3e1beedd8bdb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzU4NmMwYjAtMWZi
-        OS00ODU2LWEyODEtMjgwYmFiMzUwYTI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTguNDAxNTM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDYwMmUxYTQtYzQ2
+        Zi00ZmZkLTkzYzEtNzRkOWU0NmQ2MjMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6NTguOTI0NzM3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxNjRlNzI3ZjllNjY0NmMwYjM5MmM0NTRj
-        NWU3YTJlYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjE4LjQz
-        OTM3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTguNDg2
-        NjQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NzZmODYzMmU2ZTU0NTc2YTJkNTk3MWJm
+        NjI0YjM4MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjU4Ljk4
+        NjEzOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6NTkuMTAw
+        MTEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg5NGIyMjEyLWI5YzUtNDU0Ny04MTc0
-        LWI3OWEzYzg3M2FhNC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhjMjk1NjdhLWU1YmItNDBkNy04ZTNi
+        LTU0ZTdlMzc0NDI0Zi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 91300c8bf1d242f89ae7e2b8328294bf
+      - d95296c8f8ee48a8853dbf5b3b5cfb76
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8bfdabec7a5445695c21169bc0a7158
+      - 5a66838f35d24befa7e7e13c8a17a53b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10935b0c52eb4eee9877995ef19835c2
+      - 836c83fc814b493492450651e43b8564
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa4ec49c3a74451e99e15bd6925d3c9f
+      - a09d40f084c84479a1ea5c0973f90e7d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71b5b11e6ddc4bfe84462b3014a8739c
+      - dab292f07fc24c0684d62abf8c562b54
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b2a443224e5847169b4090cb2b19b94e
+      - 7df62acbe7a7434ab8dfda010b3d6dcf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:18 GMT
+      - Fri, 29 Jul 2022 11:32:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/"
+      - "/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 235b31fd40924788aeee9b73aab46674
+      - 90096600e1984c6a8e341ebfe09fc0b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzMwZDFhOTMtYjc0Ny00MGNlLTliMzktZjIzN2I1ZjRkMDUyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MTguODQxODczWiIsInZl
+        cG0vMjgwNjljNjEtMGRlOC00ODM0LWJhMjEtNTAxMWNlNjg2MzdlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6NTkuNzg2ODQ5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzMwZDFhOTMtYjc0Ny00MGNlLTliMzktZjIzN2I1ZjRkMDUyL3ZlcnNp
+        cG0vMjgwNjljNjEtMGRlOC00ODM0LWJhMjEtNTAxMWNlNjg2MzdlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MzBkMWE5My1i
-        NzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yODA2OWM2MS0w
+        ZGU4LTQ4MzQtYmEyMS01MDExY2U2ODYzN2UvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:59 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/874a17e7-5193-4c78-972a-efb072475aef/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/cd55b703-fb3a-40e6-b602-e3fda80ee0eb/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:19 GMT
+      - Fri, 29 Jul 2022 11:33:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53a125862176443c9a55837ab9ea778b
+      - 7c625d5181c54118955c1c56db1809a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4MDJkZmNlLWRiNmEtNGE3
-        Yi05OWZlLTEwOTI5N2Q3MjQyZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzZjQwYzQyLTkxYTUtNDQx
+        My05ZWU3LWY5MWQ5MzA4YzhjYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0802dfce-db6a-4a7b-99fe-109297d7242f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/53f40c42-91a5-4413-9ee7-f91d9308c8cc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:19 GMT
+      - Fri, 29 Jul 2022 11:33:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e8901326a284dae92524f5106dc4c0d
+      - 07cebaf02b674b4bac7428b759386b38
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDgwMmRmY2UtZGI2
-        YS00YTdiLTk5ZmUtMTA5Mjk3ZDcyNDJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTkuMTMxMDAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTNmNDBjNDItOTFh
+        NS00NDEzLTllZTctZjkxZDkzMDhjOGNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDAuMzM1MTMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI1M2ExMjU4NjIxNzY0NDNjOWE1NTgzN2Fi
-        OWVhNzc4YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjE5LjE1
-        OTU3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MTkuMTgx
-        NTU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3YzYyNWQ1MTgxYzU0MTE4OTU1YzFjNTZk
+        YjE4MDlhMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjAwLjQx
+        Mjk4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MDAuNDU1
+        ODAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3NGExN2U3LTUxOTMtNGM3OC05NzJh
-        LWVmYjA3MjQ3NWFlZi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NkNTViNzAzLWZiM2EtNDBlNi1iNjAy
+        LWUzZmRhODBlZTBlYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:00 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3NGEx
-        N2U3LTUxOTMtNGM3OC05NzJhLWVmYjA3MjQ3NWFlZi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NkNTVi
+        NzAzLWZiM2EtNDBlNi1iNjAyLWUzZmRhODBlZTBlYi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:19 GMT
+      - Fri, 29 Jul 2022 11:33:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 287f744c6702465a98e352b223705c75
+      - 9a5fe515d32e4ff6941f204d672a0fdb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxZjdhYzY5LTk1MzktNDBm
-        ZC1hNzEwLWI3YzcwZjUzNjEzNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjOTEzNjdjLTZkNzgtNDcw
+        Ni04MmY2LWVmYmNiNzMyYWRjZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/61f7ac69-9539-40fd-a710-b7c70f536136/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0c91367c-6d78-4706-82f6-efbcb732adcd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:20 GMT
+      - Fri, 29 Jul 2022 11:33:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a20fa06558ba43b892039b411d76eaf5
+      - f222a72d7a2940e28b814ce4aefb0973
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjFmN2FjNjktOTUz
-        OS00MGZkLWE3MTAtYjdjNzBmNTM2MTM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MTkuMzAyODk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGM5MTM2N2MtNmQ3
+        OC00NzA2LTgyZjYtZWZiY2I3MzJhZGNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDAuNjIzMzAzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyODdmNzQ0YzY3MDI0NjVhOThl
-        MzUyYjIyMzcwNWM3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjE5LjMzMjg3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MTkuOTczNzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI5YTVmZTUxNWQzMmU0ZmY2OTQx
+        ZjIwNGQ2NzJhMGZkYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjAwLjY5Njg0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDIuMTc3Mjc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
-        cnNlZCBNb2R1bGVtZCIsImNvZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRz
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3Vm
-        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQtZGVmYXVs
-        dHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLm1vZHVsZW1kX2RlZmF1bHRzIiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
-        c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiUGFyc2VkIENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRl
-        ZCIsInRvdGFsIjo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
-        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4t
-        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNv
-        bnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
-        IjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQyLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzBlMTBjODA3LTFhZjQtNDdiMS1hMjgxLWE1YWZm
-        YTkzNjQ2YS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wZTEw
-        YzgwNy0xYWY0LTQ3YjEtYTI4MS1hNWFmZmE5MzY0NmEvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vODc0YTE3ZTctNTE5My00Yzc4
-        LTk3MmEtZWZiMDcyNDc1YWVmLyJdfQ==
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9kOTFlMGJkOC1lMzViLTRkMTEtOWJiOS1kYTE4Njg5
+        YjEwYTEvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxZTBi
+        ZDgtZTM1Yi00ZDExLTliYjktZGExODY4OWIxMGExLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NkNTViNzAzLWZiM2EtNDBlNi1i
+        NjAyLWUzZmRhODBlZTBlYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:02 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMGUxMGM4MDctMWFmNC00N2IxLWEyODEtYTVhZmZhOTM2
-        NDZhL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZDkxZTBiZDgtZTM1Yi00ZDExLTliYjktZGExODY4OWIx
+        MGExL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:20 GMT
+      - Fri, 29 Jul 2022 11:33:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39c9b9616d5842e0a2fe20bee96e3acf
+      - d0689065990d4912bd489fbd38f4bbee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5ZGM5MWI2LTM5YTctNGI1
-        Ny1iNzlkLWYwZGIwYjM3NzIyMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjNWY2ZWM1LTg2MzYtNDI3
+        Ni1iMTNkLTcyYzQ0MDMyM2I2Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b9dc91b6-39a7-4b57-b79d-f0db0b377220/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6c5f6ec5-8636-4276-b13d-72c440323b6f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:20 GMT
+      - Fri, 29 Jul 2022 11:33:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86e895a2210445b48f58771154659e3a
+      - cbcbf85de3f44737a0017766ed816a9a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjlkYzkxYjYtMzlh
-        Ny00YjU3LWI3OWQtZjBkYjBiMzc3MjIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjAuMjQ1NzM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmM1ZjZlYzUtODYz
+        Ni00Mjc2LWIxM2QtNzJjNDQwMzIzYjZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDIuNjY1ODMwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjM5YzliOTYxNmQ1ODQyZTBhMmZlMjBiZWU5
-        NmUzYWNmIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6MjAuMjgy
-        MzIzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxNjoyMC41MjUx
-        NTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImQwNjg5MDY1OTkwZDQ5MTJiZDQ4OWZiZDM4
+        ZjRiYmVlIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MDIuNzIz
+        ODEyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMzowMy4zMTEz
+        MzNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMzNjYzFk
-        NWEtMzQ0ZC00MDNlLWI1ZDAtMTNhMzkzYjE2ZmY0LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjUzN2Rj
+        ZDEtNzdmZC00MDQ5LWEzYWQtYmE4MzUyNjNkZTAxLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMGUxMGM4MDctMWFmNC00N2IxLWEyODEtYTVhZmZh
-        OTM2NDZhLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZDkxZTBiZDgtZTM1Yi00ZDExLTliYjktZGExODY4
+        OWIxMGExLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,200 +2006,500 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:20 GMT
+      - Fri, 29 Jul 2022 11:33:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 428833f1daad462ea5bc07a34c809df2
+      - 7a45ffb845ae4280a19b9657f4bcea5c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1944'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/6537dcd1-77fd-4049-a3ad-ba835263de01/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4e98d36c25bc45f784b15bfbc9f8f9a1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNjUzN2RjZDEtNzdmZC00MDQ5LWEzYWQtYmE4MzUyNjNkZTAxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzM6MDIuNzU3MTM4WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kOTFlMGJkOC1lMzViLTRkMTEtOWJiOS1kYTE4Njg5YjEwYTEv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2Q5MWUwYmQ4LWUzNWItNGQxMS05YmI5LWRhMTg2
+        ODliMTBhMS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:03 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS82NTM3ZGNkMS03N2ZkLTQwNDktYTNhZC1iYTgzNTI2M2RlMDEv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 70ee0dd8153d4ab3af204709be0dbbad
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkYTA4MjQzLWI3NmYtNGI1
+        Yy1iNzA1LWFiNzQwM2ZiNTk4Ni8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fda08243-b76f-4b5c-b705-ab7403fb5986/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1229db14b81b4269bffa2294b63768eb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmRhMDgyNDMtYjc2
+        Zi00YjVjLWI3MDUtYWI3NDAzZmI1OTg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDMuNjE5ODc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3MGVlMGRkODE1M2Q0YWIzYWYyMDQ3MDli
+        ZTBkYmJhZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjAzLjY3
+        MjY1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6MDMuOTY2
+        NzQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMjk5
+        OGNiYWYtNTEzNS00MTE2LWE3ODUtMzE0YzY5ODU4Y2IwLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/2998cbaf-5135-4116-a785-314c69858cb0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 66d199a0eb7a4b76906c399170e18084
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzI5OThjYmFmLTUxMzUtNDExNi1hNzg1LTMxNGM2OTg1OGNiMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMzOjAzLjkzMjczOFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNjUzN2RjZDEtNzdmZC00MDQ5LWEzYWQt
+        YmE4MzUyNjNkZTAxLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:33:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:33:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3a0a64b5c87d4743be8d16b2e7aa88e4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
-        LyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5
-        MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkz
-        OWQ1N2ZjODQyNjAyZTE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiB0cm91dCIsImxvY2F0aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy83YmQyN2U4NC1jYjQwLTRlODktOGQ4
-        MS1jZTYwZDE2NmQyMmEvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFj
-        ZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsInN1bW1hcnkiOiJG
-        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsImxvY2F0aW9uX2hyZWYiOiJl
-        bGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVs
-        ZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDVhMmYxYWQtMDQyYS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIm5hbWUi
-        OiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4xIiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
-        bGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZjMxZDlkZC02OTc4LTQwYWIt
-        YTI4ZC0xMzVlMDI4MDcyMjkvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlh
-        MjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJzdW1tYXJ5
-        IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJl
-        ZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8i
-        LCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAu
-        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiYWY0
-        NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJi
-        YTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9y
-        IGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMS0x
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMS0x
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
+        LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
+        MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
+        MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
+        NDhiNzdlMDE4OThlN2MzMSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
+        OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
+        d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
+        bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
+        d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
+        OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
+        MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
+        NDYxZGZkIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
         LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyIsIm5hbWUiOiJ3YWxydXMiLCJl
-        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4yMSIsInJlbGVhc2UiOiIxIiwiYXJj
-        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFj
-        YmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsInN1
-        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwibG9jYXRpb25f
-        aHJlZiI6IndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy85YWQwN2U2MS1hOWIzLTRiMWEtOTliZC0zNTRmYWU4YmQwNjEvIiwi
-        bmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjcxIiwi
-        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1MTZhMjJj
-        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
-        M2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJl
-        LTcyMjNiNjk4NWUyOC8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZi
-        ZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2Fs
-        cnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxy
-        dXMtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI4
-        NDA0N2Q4LTVhYzYtNDZhYi05NWU4LWIyNTA5YzI4ZTI5YS8iLCJuYW1lIjoi
-        c3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFz
-        ZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjMtMC44LnNyYy5y
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUtNmJlMS00NTIz
-        LThhNjctYTljZGZkNmU1YmYwLyIsIm5hbWUiOiJwZW5ndWluIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4
-        YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0Iiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwibG9jYXRpb25faHJl
-        ZiI6InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
-        bSI6InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzk2Zjk5ZDkyLTM3NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8i
-        LCJuYW1lIjoibW9ua2V5IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIs
-        InJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIwZThm
-        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
-        OGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVmIjoibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJtb25rZXktMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMx
-        OC04YjRiLTM5ZWFjOTI2M2M0Yy8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNk
-        M2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsImxvY2F0aW9uX2hyZWYiOiJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJsaW9u
-        LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRl
-        ZjI2Zi00ZjQ4LTRhMTItYjY3OS01Y2QzZGRkYTlhNTcvIiwibmFtZSI6Imth
-        bmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
-        OiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODY1YTRjODk0ODViZGQ5
-        NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2
-        YjJmZCIsInN1bW1hcnkiOiJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3Ry
-        YWxpYSIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0wLjMtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAuMy0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNzllMzY1NC02OTZlLTQ2MzMtYWJk
-        NC1kY2VlZTJlZjc4YzIvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
-        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVmIjoi
-        a2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJr
-        YW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6dHJ1ZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YmViM2JiNGYtZmVjYS00ZmZmLTlkMDgtYTI0ZmEwYWMyM2ZkLyIsIm5hbWUi
-        OiJnaXJhZmZlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVh
-        c2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJh
-        ZmZlIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U2NmZjODQ2LTM0OGMtNDM1MC04
-        NmUxLWMzMmJkY2E0MWQzZS8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2Qx
-        NjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMTNhMjRkZjQtN2NjMi00NWYzLWI1YjAtNTY4ZTZlZDI2M2Y1
-        LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNyIs
-        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWJkMzYz
-        Yjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMy
-        MDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBsaWtlIGEgZHVjayBh
-        dCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjctMS5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjYt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QxYzI5MjA2LTQxMTAtNDIw
-        OC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6
-        Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZh
-        MjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsInN1bW1h
-        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0aW9uX2hy
-        ZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:20 GMT
+      - Fri, 29 Jul 2022 11:33:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1e6c4660441410eb69ef353112cf903
+      - 82142f2700884be980d8280a1dbf1f7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2324'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzQ5NTg2
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kZDI5
-        OGM5ZC0zMzVhLTRhN2EtOGExYS1jZTJkMTk5ZDUyZDQvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjk5NmNmYWQtMmY0
-        OC00ZWM2LWIyMjEtN2U5N2MzNjg5MWI3LyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3
-        Zi00ZjZiLTlmODgtNTFkZWEzMDBkZTg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTU6MjkuMzQ0MDA2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy9jM2IzZGY2OC01YWRkLTQ5NDQtOTQ2ZS1h
-        NzI0NDUxMWQxMmYvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvOWFkMDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJk
-        MDYxLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgxLWFmYWYtNjlhYzVlNWZk
-        YzAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM2
-        MTEwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9m
-        ZTYxZTFiMy1kMWZjLTQyNmYtODhmNS02MWFlZTY4YWIzZWYvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYt
-        NGY0OC00YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAwYjU1YzYt
-        OTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MTU6MjkuMzM0OTA1WiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy83NDFlNDQxYi0zZjcxLTQxNzQtOTc3
-        Yy0wNTFiNjc2YTU3MTMvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMDc5ZTM2NTQtNjk2ZS00NjMzLWFiZDQtZGNlZWUy
-        ZWY3OGMyLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvZTMzOGZjMTEtN2Y4Ny00OGIyLTgxNDMtYTYxOTBk
-        YmViOGM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6Mjku
-        MzI2NzQwWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8wYmNiMjAyZS1jYzFjLTQ0YjItOTRiMS0xYzExNmRmMWU2MzMvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzEzYTI0ZGY0LTdjYzIt
-        NDVmMy1iNWIwLTU2OGU2ZWQyNjNmNS8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2U3NDEzZmUwLTMwNjct
-        NDU2ZC05NWZjLTA2YjJiZGEyNzJhYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjE1OjI5LjMyNTQxMloiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvYTA2ODMyY2QtYzAzZC00ZDQyLWE5M2QtZWU4
-        ZWU5NDQ2MjQxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8zZGU0NzliMS1lN2FjLTRkMWQtYWY1NC00ZjExYWQwY2Y0ZTQvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:20 GMT
+      - Fri, 29 Jul 2022 11:33:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b9cb206ac5134ea5a08ae3d9e8e9399d
+      - b8de445f308d4fb996125d301bb5a8eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy84YWE1NTcxNC0xZjk2LTRkYjMtOGEzMS0zNTMy
-        NWZkNzdjYzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToz
-        OS4zMTg1NjFaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c07dbd3e1d5744e190fb333cdb174d4c
+      - cc385479361f45c6a711aa4d8ef75c16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '573'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1
-        NDA0NloiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1l
-        MGFmY2E5Zjg5MGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzox
-        NTozOS4zMjM0MjNaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e2793424e1fa4bcdb6593dba5d23537e
+      - 55da460e5b524c72b7f910189ab069f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '07921fc9e9a14b5ab60d0d0ab4e03c8f'
+      - d4b896339f1a47f9ae31b5383dae4e33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 810ffe453cd74b20aa601fbabc20d5c0
+      - 673da788a3e148fcae6cd936af9490a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/a9898fa9-d8cc-4a39-99bf-4962bcc0fe05/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6aef5815a48842459ffa2a0d3614821f
+      - 77e7ec5b849c4848b6f7ccad75cec246
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '436'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9hOTg5OGZhOS1kOGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zNTQwNDZa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e9968a8975c465f8ff4b6fc1e64d8c0
+      - e68ce5080dde4bbe98587a2d7c8b4e7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/680daab2-aa5c-44bd-8667-e0afca9f890b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 79bb953340594bb38f5deba51015cd88
+      - f87fd8f82b864ff28203a907e1ade14d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '322'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy82ODBkYWFiMi1hYTVjLTQ0YmQtODY2Ny1lMGFmY2E5Zjg5MGIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4zMjM0MjNa
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8c2928de28741bab0a67000d60b1470
+      - 2578a2b4a5f64ae4a5275d61e97169e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '535'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2QyNDQxZWFhLTNmYzEtNDc3NS05MjBlLWE2
-        ZDc2OGQ2YzIxNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjM2NjQ0OVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvYWIzMGRiODYtODM2ZS00ZWE5LWFhYjMtNzg1YzQ1NGY2YWM4LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1442ddd8f644a2d86af5cfbd814f15b
+      - 54a9b91b1ccf42e9a4dd10f036d163ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39d0fc367c814d7cb50411c50258da3c
+      - c16722b9159244329373d3e3a5ee840c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1123'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy8wYjYwOTg4My1lZjMxLTRkYzYtODk3ZC05OTIx
-        Mzg1MzJhZmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNToy
-        OS4zMTY4MTVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2Y4NDVmYTRkLWVkNzktNGRmYi1iNTJkLWM1YWNiOTBhYzUzMS8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvM2JhNjY0OTItOTdmZS00ZjhjLTg1NzctNjc4
-        MTRkNjg0ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTU6
-        MjkuMzE0NDY5WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9jNjM5OGJmZC0wN2YwLTQ3NGYtOTcyMy0yMmY5NTQwY2I3NzUvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4
-        ZC1kYzU2ZTE4NGQ5MmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoxNToyOS4zMTMxNTBaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzg5MDc3YTg5LTZiMWItNDU3My1hMTJlLWI2Y2UzM2JiYzQy
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0e10c807-1af4-47b1-a281-a5affa93646a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d91e0bd8-e35b-4d11-9bb9-da18689b10a1/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 506193157c7f4aac99d191efaa5dac5f
+      - b54a74bc834e4341aa6ad53ddb1c83f7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzLzEyNDgzOTY4LWI1YzYtNGI3My1hZTRhLTg3
-        YmNhOGViMzllMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1
-        OjM5LjMzODUzNloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 04b41585fe3d46bd896b4a69ca65b7d6
+      - c5a0117857c447248b0f07ac987009ed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjYzQwMjUwLTg5ZTEtNDhi
-        NS04OGMyLWM4OWFkZmUyZDNkZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2YjdhMjBjLWM4NDItNDE5
+        Mi04NGMzLTQxZTQ1MzUwNmQ2Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjQ4Mzk2OC1iNWM2LTRiNzMtYWU0
-        YS04N2JjYThlYjM5ZTEvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a57c9b2b67b9473c8c7fb8666732ffe0
+      - 54453da3686f483bb120bfe7494209a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2ZjJjOTM4LTRjNjQtNDcx
-        Ni1hYWNjLWEyZTEyOTlhMzQzZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5MTkwZTRlLTliYWYtNGIz
+        YS1iZmZlLTQ0ZjZiNzM2NzFjZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMGI2MDk4ODMtZWYzMS00ZGM2LTg5N2Qt
-        OTkyMTM4NTMyYWZiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy8zNTc4NzNjZi1iYmNkLTQxNDQtYTg4ZC1kYzU2ZTE4
-        NGQ5MmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzLzNiYTY2NDkyLTk3ZmUtNGY4Yy04NTc3LTY3ODE0ZDY4NDg0YS8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,92 +3935,92 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a60f7fc973148778cb7f7f0b6dd7758
+      - 4d1a23fe2a314db883afb36d4f094d62
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjMjBjN2ZjLWEyOGMtNDFh
-        MS05Yjk3LWQ1YWIxZDNkZWM4Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE3ZDYwZTdiLTRmNWUtNDVl
+        OS1iZWNiLTE5M2NmN2QwYmJhOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:07 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGUxMGM4MDctMWFmNC00N2IxLWEy
-        ODEtYTVhZmZhOTM2NDZhL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzczMGQxYTkzLWI3NDct
-        NDBjZS05YjM5LWYyMzdiNWY0ZDA1Mi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJm
-        Ny04MzIyLTdhOWRkZDVhOGE3OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82YTEwYmJiZi01MWUxLTQxNWEtYTAwZi03OWI3MWFl
-        MWQzZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        N2ZmZDYwNzYtZjdkZC00NWQzLThmMTctN2ZjNDE4ZDFhZGYzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2IzZDM1MGIxLWYwNzEt
-        NGRhMC05YjlmLWU0ZDczYThhYjBiZS8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjky
-        MDRhNTU5YjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvZWY4MjdkZDctYTJhOS00Mzg1LTgwMjEtYmUyY2Q5OGZlOGMwLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvYzdl
-        MzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJkNjM1YjNlZWJhLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYy
-        LWJiMWMtOTg0YzU2ZmIzMDQzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNjhkYzRiZTQtODM3Zi00ZjZiLTlmODgtNTFkZWEzMDBk
-        ZTg3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvODAw
-        YjU1YzYtOTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYjEyYTIxNmYtNWU1Ni00ODgx
-        LWFmYWYtNjlhYzVlNWZkYzAyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvZTc0MTNmZTAtMzA2Ny00NTZkLTk1ZmMtMDZiMmJkYTI3
-        MmFjLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBz
-        LzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZjYTlmODkwYi8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy9hOTg5OGZhOS1k
-        OGNjLTRhMzktOTliZi00OTYyYmNjMGZlMDUvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzA3OWUzNjU0LTY5NmUtNDYzMy1hYmQ0LWRj
-        ZWVlMmVmNzhjMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMjM5MjhjODYtNjJhZC00ZjJlLThmZWQtZTViZWY0OTUxMDdlLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdkOC01YWM2
-        LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJhZTdiOGMzLTk5ZTctNDliMC05OGJlLTcyMjNi
-        Njk4NWUyOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        M2RlNDc5YjEtZTdhYy00ZDFkLWFmNTQtNGYxMWFkMGNmNGU0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zZTRlZjI2Zi00ZjQ4LTRh
-        MTItYjY3OS01Y2QzZGRkYTlhNTcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzVlMjQwZjczLTcxZTgtNGMxOC04YjRiLTM5ZWFjOTI2
-        M2M0Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWYz
-        MWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82OTk2Y2ZhZC0yZjQ4LTRlYzYt
-        YjIyMS03ZTk3YzM2ODkxYjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzZkNjBkYTJmLTBhYTctNDZhZi1iZjZmLWE5YTNkODZlZTE0
-        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2JkMjdl
-        ODQtY2I0MC00ZTg5LThkODEtY2U2MGQxNjZkMjJhLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NmY5OWQ5Mi0zNzUwLTRhNDktOThm
-        ZS00NjZhMTUyMTc5NzEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzlhZDA3ZTYxLWE5YjMtNGIxYS05OWJkLTM1NGZhZThiZDA2MS8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYtOWQwOC1h
-        MjRmYTBhYzIzZmQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2QxYzI5MjA2LTQxMTAtNDIwOC1hMjBjLWMzODU1Y2Q0ZjQwYy8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDVhMmYxYWQtMDQy
-        YS00MDVlLWFjNDQtMGM0YjE0ZGJiZWNhLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9kZmJlNjJhYi04Nzg5LTQ2MjAtYTUyYy03ZmE2
-        YjQ0MDNiYmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U2NmZjODQ2LTM0OGMtNDM1MC04NmUxLWMzMmJkY2E0MWQzZS8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9kMjQ0
-        MWVhYS0zZmMxLTQ3NzUtOTIwZS1hNmQ3NjhkNmMyMTcvIl19XSwiZGVwZW5k
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxZTBiZDgtZTM1Yi00ZDExLTli
+        YjktZGExODY4OWIxMGExL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI4MDY5YzYxLTBkZTgt
+        NDgzNC1iYTIxLTUwMTFjZTY4NjM3ZS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvNGYy
+        NTJlY2UtMzE5NS00N2FiLWE1NjctZTljZGRkZDUwYTIzLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5
+        LTllN2YtMmNiMjc1NDI5MjkzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5
+        YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvNjI1MTVlODUtMDU1NS00YjU5
+        LTg0M2MtMDVlODA1NTY1ZDc0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0MC00ODE1LTg4ZGEtODQxZGE3YWMw
+        Mzg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBz
+        LzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYyMWNiZGJlOS8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy81ZTFkMGRiNC1k
+        MTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4
+        OWI3YjAxZDg0Ni8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3NmZmYTdlODI2LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zNWJiYTAwYi02ZjE2
+        LTQzYzEtODFhNS03ZWU5NjIxZGNlMjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ2MDE5MmZjLTdlZmYtNGVkYi1hMDhhLWJiYWE0
+        ODM1YWM1YS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NDgwNjA4YzEtYjZhYS00MDkwLTlhZmYtNzNhNDQ2Y2I2YjA0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRh
+        Y2MtOWUxOS04NGI5YzQ5NTRlZWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJh
+        NDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUt
+        OTQ0ZC00N2M2NWEyNThhYzcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEy
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVm
+        MmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUtOTM2
+        Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMt
+        NTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0y
+        MmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkxLTM2ZWM4ZmMzNTA0OC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVh
+        Mi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2ZkYjk1N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJm
+        NTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19XSwiZGVwZW5k
         ZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3608,7 +4033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:21 GMT
+      - Fri, 29 Jul 2022 11:33:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3626,21 +4051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b3b2c900cc04e578c2b43a118c42d8b
+      - f415de2fae1b4b3ca9a0b7edb850cba1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAzNjk2MjI2LTQxMGEtNGY2
-        Zi1iM2NhLWZhZTc5ZGE3ZmU1ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyYTZmYjA1LWFjMjMtNDE4
+        OC04NDI5LTkzNDAyMTljOWE2NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/acc40250-89e1-48b5-88c2-c89adfe2d3dd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b6b7a20c-c842-4192-84c3-41e453506d62/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3661,51 +4086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:22 GMT
+      - Fri, 29 Jul 2022 11:33:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbd7da4286e7436e9151516e11541d99
+      - 4f8bd59151da4e50b09f0f093644117e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNjNDAyNTAtODll
-        MS00OGI1LTg4YzItYzg5YWRmZTJkM2RkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuODI3NDE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjZiN2EyMGMtYzg0
+        Mi00MTkyLTg0YzMtNDFlNDUzNTA2ZDYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDYuODc3NDAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNGI0MTU4NWZlM2Q0NmJkODk2
-        YjRhNjljYTY1YjdkNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIxLjg1ODMwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjEuOTk1NzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjNWEwMTE3ODU3YzQ0NzI0OGIw
+        ZjA3YWM5ODcwMDllZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjA2Ljk1NTUxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDcuMjcyODQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0
-        Ny00MGNlLTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRl
+        OC00ODM0LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/acc40250-89e1-48b5-88c2-c89adfe2d3dd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/39190e4e-9baf-4b3a-bffe-44f6b73671ce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3726,118 +4151,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:22 GMT
+      - Fri, 29 Jul 2022 11:33:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 047fbc0ec93f40a782ec266d925bd30d
+      - ab7efcbded574a24a993383b048cdce5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNjNDAyNTAtODll
-        MS00OGI1LTg4YzItYzg5YWRmZTJkM2RkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuODI3NDE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzkxOTBlNGUtOWJh
+        Zi00YjNhLWJmZmUtNDRmNmI3MzY3MWNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDYuOTY2OTc1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNGI0MTU4NWZlM2Q0NmJkODk2
-        YjRhNjljYTY1YjdkNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIxLjg1ODMwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjEuOTk1NzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0
-        Ny00MGNlLTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d6f2c938-4c64-4716-aacc-a2e1299a343f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:22 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d3a98bddbd4c427a8e473e1d4f003f34
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDZmMmM5MzgtNGM2
-        NC00NzE2LWFhY2MtYTJlMTI5OWEzNDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuODc3NDc5WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNTdjOWIyYjY3Yjk0NzNjOGM3
-        ZmI4NjY2NzMyZmZlMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIyLjAyNTY0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjIuMTU2MjUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NDQ1M2RhMzY4NmY0ODNiYjEy
+        MGJmZTc0OTQyMDlhMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjA3LjMzNjQ1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDcuNjQzNTAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83MzBkMWE5My1iNzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIvdmVyc2lv
+        bS8yODA2OWM2MS0wZGU4LTQ4MzQtYmEyMS01MDExY2U2ODYzN2UvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0Ny00MGNl
-        LTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRlOC00ODM0
+        LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6c20c7fc-a28c-41a1-9b97-d5ab1d3dec87/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b6b7a20c-c842-4192-84c3-41e453506d62/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3858,118 +4218,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:22 GMT
+      - Fri, 29 Jul 2022 11:33:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ac60df67117480a933ce72c5f640bc8
+      - 74bc23800105484eb740fc8bef95502c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmMyMGM3ZmMtYTI4
-        Yy00MWExLTliOTctZDVhYjFkM2RlYzg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuOTI5MDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjZiN2EyMGMtYzg0
+        Mi00MTkyLTg0YzMtNDFlNDUzNTA2ZDYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDYuODc3NDAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYTYwZjdmYzk3MzE0ODc3OGNi
-        N2Y3ZjBiNmRkNzc1OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIyLjE4NTYyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjIuMzEzNTIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83MzBkMWE5My1iNzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIvdmVyc2lv
-        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0Ny00MGNl
-        LTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/acc40250-89e1-48b5-88c2-c89adfe2d3dd/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:16:22 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - a51ba6253e94486f9d885b2052f99857
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNjNDAyNTAtODll
-        MS00OGI1LTg4YzItYzg5YWRmZTJkM2RkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuODI3NDE2WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNGI0MTU4NWZlM2Q0NmJkODk2
-        YjRhNjljYTY1YjdkNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIxLjg1ODMwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjEuOTk1NzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjNWEwMTE3ODU3YzQ0NzI0OGIw
+        ZjA3YWM5ODcwMDllZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjA2Ljk1NTUxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDcuMjcyODQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0
-        Ny00MGNlLTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRl
+        OC00ODM0LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d6f2c938-4c64-4716-aacc-a2e1299a343f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/39190e4e-9baf-4b3a-bffe-44f6b73671ce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3990,53 +4283,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:22 GMT
+      - Fri, 29 Jul 2022 11:33:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e22bf8e5ec474e8b8bd9a34bb37a6b44
+      - 409295fcbc794d768cf50b08354308cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDZmMmM5MzgtNGM2
-        NC00NzE2LWFhY2MtYTJlMTI5OWEzNDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuODc3NDc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzkxOTBlNGUtOWJh
+        Zi00YjNhLWJmZmUtNDRmNmI3MzY3MWNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDYuOTY2OTc1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNTdjOWIyYjY3Yjk0NzNjOGM3
-        ZmI4NjY2NzMyZmZlMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIyLjAyNTY0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjIuMTU2MjUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NDQ1M2RhMzY4NmY0ODNiYjEy
+        MGJmZTc0OTQyMDlhMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjA3LjMzNjQ1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDcuNjQzNTAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83MzBkMWE5My1iNzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIvdmVyc2lv
+        bS8yODA2OWM2MS0wZGU4LTQ4MzQtYmEyMS01MDExY2U2ODYzN2UvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0Ny00MGNl
-        LTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRlOC00ODM0
+        LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6c20c7fc-a28c-41a1-9b97-d5ab1d3dec87/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/17d60e7b-4f5e-45e9-becb-193cf7d0bba9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4057,53 +4350,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:22 GMT
+      - Fri, 29 Jul 2022 11:33:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c0266627be0e4a4f94bd86843b49b2ef
+      - 22c98ad739d44974a325f80dcaeea297
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmMyMGM3ZmMtYTI4
-        Yy00MWExLTliOTctZDVhYjFkM2RlYzg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuOTI5MDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdkNjBlN2ItNGY1
+        ZS00NWU5LWJlY2ItMTkzY2Y3ZDBiYmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDcuMDU1MjAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYTYwZjdmYzk3MzE0ODc3OGNi
-        N2Y3ZjBiNmRkNzc1OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIyLjE4NTYyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjIuMzEzNTIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0ZDFhMjNmZTJhMzE0ZGI4ODNh
+        ZmIzNmQ0ZjA5NGQ2MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjA3LjY5NDk2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDguMDAyMzQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83MzBkMWE5My1iNzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIvdmVyc2lv
+        bS8yODA2OWM2MS0wZGU4LTQ4MzQtYmEyMS01MDExY2U2ODYzN2UvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0Ny00MGNl
-        LTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRlOC00ODM0
+        LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/acc40250-89e1-48b5-88c2-c89adfe2d3dd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b6b7a20c-c842-4192-84c3-41e453506d62/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4124,51 +4417,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:22 GMT
+      - Fri, 29 Jul 2022 11:33:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3de7b8a983ee41279b3fdd146c54b433
+      - 4fc8be597a3e4908850475fe7bb11014
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNjNDAyNTAtODll
-        MS00OGI1LTg4YzItYzg5YWRmZTJkM2RkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuODI3NDE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjZiN2EyMGMtYzg0
+        Mi00MTkyLTg0YzMtNDFlNDUzNTA2ZDYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDYuODc3NDAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNGI0MTU4NWZlM2Q0NmJkODk2
-        YjRhNjljYTY1YjdkNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIxLjg1ODMwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjEuOTk1NzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjNWEwMTE3ODU3YzQ0NzI0OGIw
+        ZjA3YWM5ODcwMDllZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjA2Ljk1NTUxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDcuMjcyODQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0
-        Ny00MGNlLTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRl
+        OC00ODM0LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d6f2c938-4c64-4716-aacc-a2e1299a343f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/39190e4e-9baf-4b3a-bffe-44f6b73671ce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4189,53 +4482,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:22 GMT
+      - Fri, 29 Jul 2022 11:33:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6034ba7f4d5a48bdbe88b8d42b3a356e
+      - 04e0d928464f48cfa9b88745b4d4db00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDZmMmM5MzgtNGM2
-        NC00NzE2LWFhY2MtYTJlMTI5OWEzNDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuODc3NDc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzkxOTBlNGUtOWJh
+        Zi00YjNhLWJmZmUtNDRmNmI3MzY3MWNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDYuOTY2OTc1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNTdjOWIyYjY3Yjk0NzNjOGM3
-        ZmI4NjY2NzMyZmZlMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIyLjAyNTY0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjIuMTU2MjUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NDQ1M2RhMzY4NmY0ODNiYjEy
+        MGJmZTc0OTQyMDlhMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjA3LjMzNjQ1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDcuNjQzNTAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83MzBkMWE5My1iNzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIvdmVyc2lv
+        bS8yODA2OWM2MS0wZGU4LTQ4MzQtYmEyMS01MDExY2U2ODYzN2UvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0Ny00MGNl
-        LTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRlOC00ODM0
+        LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6c20c7fc-a28c-41a1-9b97-d5ab1d3dec87/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/17d60e7b-4f5e-45e9-becb-193cf7d0bba9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4256,53 +4549,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:22 GMT
+      - Fri, 29 Jul 2022 11:33:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a03d20881a0543e7ae584544896bac6b
+      - 8572bc9c22464473917304fa11aa8653
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmMyMGM3ZmMtYTI4
-        Yy00MWExLTliOTctZDVhYjFkM2RlYzg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuOTI5MDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdkNjBlN2ItNGY1
+        ZS00NWU5LWJlY2ItMTkzY2Y3ZDBiYmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDcuMDU1MjAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYTYwZjdmYzk3MzE0ODc3OGNi
-        N2Y3ZjBiNmRkNzc1OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2
-        OjIyLjE4NTYyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTY6
-        MjIuMzEzNTIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0ZDFhMjNmZTJhMzE0ZGI4ODNh
+        ZmIzNmQ0ZjA5NGQ2MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMz
+        OjA3LjY5NDk2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzM6
+        MDguMDAyMzQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83MzBkMWE5My1iNzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIvdmVyc2lv
+        bS8yODA2OWM2MS0wZGU4LTQ4MzQtYmEyMS01MDExY2U2ODYzN2UvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0Ny00MGNl
-        LTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjljNjEtMGRlOC00ODM0
+        LWJhMjEtNTAxMWNlNjg2MzdlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/03696226-410a-4f6f-b3ca-fae79da7fe5d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2a6fb05-ac23-4188-8429-9340219c9a65/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4323,55 +4616,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25e82421145d410db1113984888e4e4a
+      - 910729e73080466da66e623e427349c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '416'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDM2OTYyMjYtNDEw
-        YS00ZjZmLWIzY2EtZmFlNzlkYTdmZTVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTY6MjEuOTg3NDYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJhNmZiMDUtYWMy
+        My00MTg4LTg0MjktOTM0MDIxOWM5YTY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzM6MDcuMTY3MzMwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiNmIzYjJjOTAwY2MwNGU1NzhjMmI0M2ExMThj
-        NDJkOGIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxNjoyMi4zNDMy
-        NjhaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE2OjIyLjY4NjU4
-        NVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvM2ZhNmQwODItOTY4My00ZWZmLWFhNmQtMWVkMzQ1MTA3MmU1LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiZjQxNWRlMmZhZTFiNGIzY2E5YTBiN2VkYjg1
+        MGNiYTEiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMzowOC4wNTc2
+        NTFaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMzOjA4LjkwOTYx
+        MFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFh
-        OTMtYjc0Ny00MGNlLTliMzktZjIzN2I1ZjRkMDUyL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjgwNjlj
+        NjEtMGRlOC00ODM0LWJhMjEtNTAxMWNlNjg2MzdlL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzczMGQxYTkzLWI3NDctNDBjZS05YjM5LWYy
-        MzdiNWY0ZDA1Mi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzBlMTBjODA3LTFhZjQtNDdiMS1hMjgxLWE1YWZmYTkzNjQ2
-        YS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzI4MDY5YzYxLTBkZTgtNDgzNC1iYTIxLTUw
+        MTFjZTY4NjM3ZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2Q5MWUwYmQ4LWUzNWItNGQxMS05YmI5LWRhMTg2ODliMTBh
+        MS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4379,7 +4672,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4392,74 +4685,74 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1636'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b145323b8c8a4e1e8c9a1142b11223d4
+      - 322b3ed89f9945b58e66d9f9c9f04101
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '541'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTgsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04ZDgxLWNlNjBkMTY2ZDIyYS8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9kNWEyZjFhZC0wNDJhLTQwNWUtYWM0NC0wYzRiMTRkYmJlY2EvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNWYzMWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWFk
-        MDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJkMDYxLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdi
-        OGMzLTk5ZTctNDliMC05OGJlLTcyMjNiNjk4NWUyOC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdk
-        OC01YWM2LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2Zjk5ZDkyLTM3
-        NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZTI0MGY3My03MWU4
-        LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00
-        YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA3OWUzNjU0LTY5NmUtNDYz
-        My1hYmQ0LWRjZWVlMmVmNzhjMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYt
-        OWQwOC1hMjRmYTBhYzIzZmQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00MzUwLTg2
-        ZTEtYzMyYmRjYTQxZDNlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9kMWMyOTIwNi00MTEwLTQyMDgtYTIwYy1j
-        Mzg1NWNkNGY0MGMvIn1dfQ==
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMtNGFj
+        Yy05ZTE5LTg0YjljNDk1NGVlZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEyLTQxZDEt
+        YThkZi1mZDg0M2E3ZWQ1YTgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjkxMmM5MDUtNjFmNS00NzJiLThl
+        OTEtMzZlYzhmYzM1MDQ4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJk
+        LWQ4OWI3YjAxZDg0Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1i
+        Mjc2ZmZhN2U4MjYvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4467,7 +4760,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4480,49 +4773,49 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '496'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 505b1f91632f4ea7b770f500fb7a4029
+      - 7ef48af859e24a05ad3960da7de878f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '240'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmItOWY4OC01MWRlYTMwMGRlODcv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVmZGMwMi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvODAwYjU1YzYtOTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy9lNzQxM2ZlMC0zMDY3LTQ1NmQtOTVmYy0wNmIyYmRhMjcyYWMvIn1d
+        ZW1kcy82MjUxNWU4NS0wNTU1LTRiNTktODQzYy0wNWU4MDU1NjVkNzQvIn1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4530,7 +4823,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4543,37 +4836,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '7483'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a95ef0a7c5c948a9a4a349db67cc492e
+      - 6d86eb0f508d46f0b9bc086c32aee5f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4646,9 +4939,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -4664,8 +4957,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -4683,9 +4976,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -4707,9 +5000,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -4725,9 +5018,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -4737,10 +5030,10 @@ http_interactions:
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4748,7 +5041,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4761,43 +5054,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4731ab0c643f4a38900830ef9700b73d
+      - f00b71912d6f46a690d21212948c035a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4805,7 +5098,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4818,41 +5111,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10c5247344194de3818b5ac91c7c9bb2
+      - 5c702b953d1642699754a282c8df5cb8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4860,7 +5153,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4873,36 +5166,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b845492bd1f4decbc719e5733bb48e1
+      - bbdfe801e7124472b89406da37caed22
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4924,10 +5217,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4935,7 +5228,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4948,74 +5241,74 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1636'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c99339dc7b6d41e4ae1637cf6e863a6d
+      - 36e7a30df02242a4964237f9329ac99c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '541'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTgsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvZGZiZTYyYWItODc4OS00NjIwLWE1MmMtN2ZhNmI0NDAzYmJm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdiZDI3ZTg0LWNiNDAtNGU4OS04ZDgxLWNlNjBkMTY2ZDIyYS8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9kNWEyZjFhZC0wNDJhLTQwNWUtYWM0NC0wYzRiMTRkYmJlY2EvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNWYzMWQ5ZGQtNjk3OC00MGFiLWEyOGQtMTM1ZTAyODA3MjI5LyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzIzOTI4Yzg2LTYyYWQtNGYyZS04ZmVkLWU1YmVmNDk1MTA3ZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
-        OTk2Y2ZhZC0yZjQ4LTRlYzYtYjIyMS03ZTk3YzM2ODkxYjcvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWFk
-        MDdlNjEtYTliMy00YjFhLTk5YmQtMzU0ZmFlOGJkMDYxLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJhZTdi
-        OGMzLTk5ZTctNDliMC05OGJlLTcyMjNiNjk4NWUyOC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yODQwNDdk
-        OC01YWM2LTQ2YWItOTVlOC1iMjUwOWMyOGUyOWEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTUzMjZmZmUt
-        NmJlMS00NTIzLThhNjctYTljZGZkNmU1YmYwLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2Zjk5ZDkyLTM3
-        NTAtNGE0OS05OGZlLTQ2NmExNTIxNzk3MS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZTI0MGY3My03MWU4
-        LTRjMTgtOGI0Yi0zOWVhYzkyNjNjNGMvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2U0ZWYyNmYtNGY0OC00
-        YTEyLWI2NzktNWNkM2RkZGE5YTU3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA3OWUzNjU0LTY5NmUtNDYz
-        My1hYmQ0LWRjZWVlMmVmNzhjMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iZWIzYmI0Zi1mZWNhLTRmZmYt
-        OWQwOC1hMjRmYTBhYzIzZmQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvZTY2ZmM4NDYtMzQ4Yy00MzUwLTg2
-        ZTEtYzMyYmRjYTQxZDNlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNkZTQ3OWIxLWU3YWMtNGQxZC1hZjU0
-        LTRmMTFhZDBjZjRlNC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9kMWMyOTIwNi00MTEwLTQyMDgtYTIwYy1j
-        Mzg1NWNkNGY0MGMvIn1dfQ==
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMtNGFj
+        Yy05ZTE5LTg0YjljNDk1NGVlZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEyLTQxZDEt
+        YThkZi1mZDg0M2E3ZWQ1YTgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjkxMmM5MDUtNjFmNS00NzJiLThl
+        OTEtMzZlYzhmYzM1MDQ4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJk
+        LWQ4OWI3YjAxZDg0Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8xMDgwNDgyNy02NGM4LTQ1OTItODM4NC1i
+        Mjc2ZmZhN2U4MjYvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5023,7 +5316,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5036,49 +5329,49 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '496'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d6823c02f18453fb86946bd0b470937
+      - 3bbadf0877a44281bcbd470148620f16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '240'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvMDg3NzY0MjYtM2YzZi00YTYyLWJiMWMtOTg0YzU2ZmIzMDQz
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy82OGRjNGJlNC04MzdmLTRmNmItOWY4OC01MWRlYTMwMGRlODcv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzL2IxMmEyMTZmLTVlNTYtNDg4MS1hZmFmLTY5YWM1ZTVmZGMwMi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvODAwYjU1YzYtOTc1My00MzgxLTlkNzgtMGZkZTJkZGZlZTQyLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy9lNzQxM2ZlMC0zMDY3LTQ1NmQtOTVmYy0wNmIyYmRhMjcyYWMvIn1d
+        ZW1kcy82MjUxNWU4NS0wNTU1LTRiNTktODQzYy0wNWU4MDU1NjVkNzQvIn1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5086,7 +5379,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5099,37 +5392,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '7483'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b21dc3ff31c42538a4c27facb6a5a81
+      - 964c31e9c6d64ab19d9cf26afa81e9a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzQ2NGY3NDUyLTg4OGItNDJmNy04MzIyLTdhOWRkZDVhOGE3
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM1NTI4
-        N1oiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -5202,9 +5495,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2ZmZDYwNzYtZjdkZC00NWQzLThmMTct
-        N2ZjNDE4ZDFhZGYzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzUwODU5WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -5220,8 +5513,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzZhMTBiYmJmLTUxZTEtNDE1YS1hMDBmLTc5YjcxYWUxZDNkNC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5LjM0MTA5NVoi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -5239,9 +5532,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy9lZTcyYTllNi0zYWZmLTQyNzctYjMyYi1hYjkyMDRh
-        NTU5YjkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNTozOS4z
-        MjYyMjZaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -5263,9 +5556,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzL2VmODI3ZGQ3LWEyYTktNDM4NS04MDIxLWJlMmNk
-        OThmZThjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE1OjM5
-        LjMyNTExMVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -5281,9 +5574,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYjNkMzUwYjEtZjA3MS00ZGEwLTliOWYt
-        ZTRkNzNhOGFiMGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MTU6MzkuMzE5ODUzWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -5293,10 +5586,10 @@ http_interactions:
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5304,7 +5597,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5317,43 +5610,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43ab3d594f5c4a72b9277e058b9e7527
+      - ae9ef21de6ca42e3b0800441416f768f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '169'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2E5ODk4ZmE5LWQ4Y2MtNGEzOS05OWJmLTQ5NjJiY2Mw
-        ZmUwNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzLzY4MGRhYWIyLWFhNWMtNDRiZC04NjY3LWUwYWZj
-        YTlmODkwYi8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5361,7 +5654,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5374,41 +5667,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dcfd85a42ee94b30bbeab521dca4c614
+      - 648c2f94c9fc4a528c0d28116ec45b66
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82ZDYwZGEyZi0wYWE3LTQ2YWYtYmY2Zi1hOWEzZDg2ZWUxNDkv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/28069c61-0de8-4834-ba21-5011ce68637e/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5416,7 +5709,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5429,36 +5722,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:16:23 GMT
+      - Fri, 29 Jul 2022 11:33:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f9391724d84843608be1ba912ba2910f
+      - 48758823e6404e79829915e27bec605f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvYzdlMzU0MTctOWQ4Ny00OGRlLTk4ZDgtNTJk
-        NjM1YjNlZWJhLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5480,5 +5773,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:16:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:33:10 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_environment_repository/all_package_environments_are_copied_by_default.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_environment_repository/all_package_environments_are_copied_by_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:55 GMT
+      - Fri, 29 Jul 2022 11:28:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e7a720fb43424d589373875b315bbc45
+      - 66c49f23ba2c43cb80f74ff6ec3d4b7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85MDVjOWZiMi1lNWE1LTQ0MDgtOGEwZS04NjE0MTg4ZDc4Y2Qv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1NC45MzQ5ODFa
+        cnBtL3JwbS83MzBkNmFiYy02MjA4LTQ3YzgtODY0MS1jOWJmYjkzZGU5MDIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyODoyMy43NDEzMzJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85MDVjOWZiMi1lNWE1LTQ0MDgtOGEwZS04NjE0MTg4ZDc4Y2Qv
+        cnBtL3JwbS83MzBkNmFiYy02MjA4LTQ3YzgtODY0MS1jOWJmYjkzZGU5MDIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzkwNWM5
-        ZmIyLWU1YTUtNDQwOC04YTBlLTg2MTQxODhkNzhjZC92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzczMGQ2
+        YWJjLTYyMDgtNDdjOC04NjQxLWM5YmZiOTNkZTkwMi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:37 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/905c9fb2-e5a5-4408-8a0e-8614188d78cd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:55 GMT
+      - Fri, 29 Jul 2022 11:28:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f54ef14f85e4f388fc96644990e7229
+      - abcee3a511ed4585b9be32b97447d804
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyNDYzMGI1LTU5OGYtNGZi
-        Ni04MDM2LWJjZTY0MzU3MmU2Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0MTVkYjRhLTZkYmMtNDQz
+        ZS04YTc4LWZlYjM2MzgyNjc5Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,51 +143,218 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:55 GMT
+      - Fri, 29 Jul 2022 11:28:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b587092a7e77405ea8a671e3570c950a
+      - a792fbf9ff57424196a2cdf87c197211
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '348'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a415db4a-6dbc-443e-8a78-feb36382679c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '607'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8e868f4971aa41c5be34df83970d6c1e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQxNWRiNGEtNmRi
+        Yy00NDNlLThhNzgtZmViMzYzODI2NzljLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzcuMjA3MzE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhYmNlZTNhNTExZWQ0NTg1YjliZTMyYjk3
+        NDQ3ZDgwNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjM3LjI5
+        MDQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MzcuNTY5
+        NDg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDZhYmMtNjIwOC00N2M4
+        LTg2NDEtYzliZmI5M2RlOTAyLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2e516c98fb2b4b6f9adf9bcb31a30eff
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - adc72fb415d3450e8275a195e58fd90a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZjJlYjdmMmYtOGM1YS00MTRiLWExZWMtZmJlMjU5YmRjNTc2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTQuNzgwMDA4WiIsIm5h
-        bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9teXJlcG8uY29tIiwi
-        Y2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0
-        aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwi
-        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU0Ljc4MDAy
-        NloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMi
-        Om51bGwsInBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2
-        MDAuMCwiY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGlt
-        ZW91dCI6NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVy
-        cyI6bnVsbCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxs
-        fV19
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNjE0YWU3OGEtMWQ0OC00N2I0LWE3ZWQtYjllODYxNjg1YjZk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6MjkuMTQyMjcz
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:37 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/f2eb7f2f-8c5a-414b-a1ec-fbe259bdc576/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/614ae78a-1d48-47b4-a7ed-b9e861685b6d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -195,7 +362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -208,7 +375,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:55 GMT
+      - Fri, 29 Jul 2022 11:28:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -226,21 +393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8ab58925a4a54b9a8a343e723d3240ed
+      - ed82a61a0841443f993b2cf62bf05c1c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkN2JlMWZlLWRjOWUtNDMx
-        Ny05ODRhLWMwYWY1Nzc1ODg1OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmYmU5OTUzLWE2YzQtNDVh
+        Ny1hNGFmLTZhNmYyMmEwY2EwNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/424630b5-598f-4fb6-8036-bce643572e6f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1fbe9953-a6c4-45a7-a4af-6a6f22a0ca05/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -261,51 +428,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:55 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6dcfd35bb6624152be37ca08953e68f2
+      - 8f36ab3fea49411595f5dd44590809d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDI0NjMwYjUtNTk4
-        Zi00ZmI2LTgwMzYtYmNlNjQzNTcyZTZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTUuNzUwODQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWZiZTk5NTMtYTZj
+        NC00NWE3LWE0YWYtNmE2ZjIyYTBjYTA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzcuODk1NzAwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZjU0ZWYxNGY4NWU0ZjM4OGZjOTY2NDQ5
-        OTBlNzIyOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI2OjU1Ljc4
-        MjE1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjY6NTUuODM5
-        MzYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlZDgyYTYxYTA4NDE0NDNmOTkzYjJjZjYy
+        YmYwNWMxYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjM3Ljk0
+        MjI3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MzcuOTg4
+        MjE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTA1YzlmYjItZTVhNS00NDA4
-        LThhMGUtODYxNDE4OGQ3OGNkLyJdfQ==
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6d7be1fe-dc9e-4317-984a-c0af57758858/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -313,7 +479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -326,72 +492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:55 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0315fb019f9840f3b76666b59ac40ae2
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmQ3YmUxZmUtZGM5
-        ZS00MzE3LTk4NGEtYzBhZjU3NzU4ODU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTUuODU1MDMyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4YWI1ODkyNWE0YTU0YjlhOGEzNDNlNzIz
-        ZDMyNDBlZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI2OjU1Ljg4
-        NjYwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjY6NTUuOTIx
-        NjMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2YyZWI3ZjJmLThjNWEtNDE0Yi1hMWVj
-        LWZiZTI1OWJkYzU3Ni8iXX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:55 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:26:55 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -409,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0dff34863d6b4155aa48b61dd4baa094
+      - 731c24058be2438fa61045180ad766c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -431,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -444,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -462,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 91f10a7822004bcea365b37b2613359e
+      - a44dd48a4c3a4293839fcf3e3b445744
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -484,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -497,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -515,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7df7b061fc8c46b3ad5537e6234c62d3
+      - '0599a6b138a848f79b93aea6fb5abda3'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -537,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -550,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -568,127 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31905d36fd794700ab5f179d2bc9d471
+      - 9b052fd43bbb4ae3be88747aa41d3880
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:26:56 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 7d7a7e1539304c76b682848da3982c81
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:26:56 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - ac82b007281b4bc6a4ceeee87d3ecfe7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -705,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -718,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/83c2bfa7-7aed-42c7-85e5-7f28f11bf264/"
+      - "/pulp/api/v3/remotes/rpm/rpm/f60e2300-6cc4-4424-9aa8-2c51b5e8901c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -738,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 47508a0ec4134eb4b81de0a0aff03116
+      - 7d35aa0ee79c4a0a8fa2f565a9389cb5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzgz
-        YzJiZmE3LTdhZWQtNDJjNy04NWU1LTdmMjhmMTFiZjI2NC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU2LjI1MDk5NFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y2
+        MGUyMzAwLTZjYzQtNDQyNC05YWE4LTJjNTFiNWU4OTAxYy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI4OjM4LjUwMjk0OVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI2OjU2LjI1MTAxM1oiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjI4OjM4LjUwMjk3NloiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -773,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -786,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/"
+      - "/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -806,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d95681a853664a338a149881128c453f
+      - 90a16c4973c94a82bcb3772386526d59
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMGQ3NzMxNGItOWQ0Ny00ZjdmLWJiODAtYTZkMjY0YTc1ODMxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTYuMzgwNjMxWiIsInZl
+        cG0vODMyMTI5OTgtZDE5ZC00M2MyLTliMDUtZGRkZjZmM2Y1YTMyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6MzguNjc4NzEyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMGQ3NzMxNGItOWQ0Ny00ZjdmLWJiODAtYTZkMjY0YTc1ODMxL3ZlcnNp
+        cG0vODMyMTI5OTgtZDE5ZC00M2MyLTliMDUtZGRkZjZmM2Y1YTMyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wZDc3MzE0Yi05
-        ZDQ3LTRmN2YtYmI4MC1hNmQyNjRhNzU4MzEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84MzIxMjk5OC1k
+        MTlkLTQzYzItOWIwNS1kZGRmNmYzZjVhMzIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -830,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -841,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -854,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86bb0f64677d4315a794e1f9bb21031d
+      - b7282335f19449e1a080f13bb904243b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNTUxNGVjNi03MWI0LTRhNmYtOWVmMS0xM2MzOGZkODZmMjMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNTozNi43NjEwOTVa
+        cnBtL3JwbS8wYTY4YmQzYy1kOWIxLTRiMDQtYjM1Yi04YTZhNDVhMmM2N2Yv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyODoyNC43NjY3MTJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNTUxNGVjNi03MWI0LTRhNmYtOWVmMS0xM2MzOGZkODZmMjMv
+        cnBtL3JwbS8wYTY4YmQzYy1kOWIxLTRiMDQtYjM1Yi04YTZhNDVhMmM2N2Yv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM1NTE0
-        ZWM2LTcxYjQtNGE2Zi05ZWYxLTEzYzM4ZmQ4NmYyMy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBhNjhi
+        ZDNjLWQ5YjEtNGIwNC1iMzViLThhNmE0NWEyYzY3Zi92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -896,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -907,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -920,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -938,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e0995babc2f94173979c02863e03df3e
+      - f33e7899251544ec9c09172773e8d25a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2OTYxNjQ4LWNkYjctNGZk
-        YS04YTYwLWMyZGJmZTZlNmNkNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmNTIxZDkzLWUxMjAtNDAw
+        OC1hMWU5LTFiZjM1YTE5OTY5NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -960,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -973,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46b9e0293e484ce7925d9330a430f836
+      - 7628447876d94a748f9c3c9bf9724be0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNWVhNDExZDAtZTk4ZS00ZjE2LWJlYmMtYjY4NDA3ZWM3ODNhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MzUuODQ4ODE3WiIsIm5h
-        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
-        ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
-        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
-        cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNTozNy4xMzk5ODRaIiwiZG93bmxv
-        YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
-        Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
-        Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
-        InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
-        dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+        cG0vMzExMDE1ZTMtYmE1ZC00NDJiLTk1MGItNTM0NzUyMjljNzk5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6MjMuNTQzMTEzWiIsIm5h
+        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
+        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
+        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
+        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        Mi0wNy0yOVQxMToyODoyNS4zMTk0NjZaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
+        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
+        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
+        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5ea411d0-e98e-4f16-bebc-b68407ec783a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/311015e3-ba5d-442b-950b-53475229c799/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1025,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1038,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1056,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4f8d3b70e8f446a88fa87fe48fcaf9b1
+      - 9a8f94bf458b4d169b859b4013480391
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4YjQxYzI3LTBlMGEtNDc5
-        NS1iODg4LTZiNzlkZDYxZTVhNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlMjZjYjNmLTAzOTctNDFh
+        Ni1hM2JhLTM1Y2I1YjFjNTlhMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/86961648-cdb7-4fda-8a60-c2dbfe6e6cd6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3f521d93-e120-4008-a1e9-1bf35a199695/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1091,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb6bcd21285a47faa98b5515216d2052
+      - b38dc602e9384b13aa35af905ad0a5b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODY5NjE2NDgtY2Ri
-        Ny00ZmRhLThhNjAtYzJkYmZlNmU2Y2Q2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTYuNTU0MDQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Y1MjFkOTMtZTEy
+        MC00MDA4LWExZTktMWJmMzVhMTk5Njk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzguOTQ2MDE1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlMDk5NWJhYmMyZjk0MTczOTc5YzAyODYz
-        ZTAzZGYzZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI2OjU2LjU4
-        MzUyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjY6NTYuNjQz
-        ODkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmMzNlNzg5OTI1MTU0NGVjOWMwOTE3Mjc3
+        M2U4ZDI1YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjM4Ljk5
+        MTg0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MzkuMTE3
+        MjkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzU1MTRlYzYtNzFiNC00YTZm
-        LTllZjEtMTNjMzhmZDg2ZjIzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDliMS00YjA0
+        LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/48b41c27-0e0a-4795-b888-6b79dd61e5a4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ce26cb3f-0397-41a6-a3ba-35cb5b1c59a2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1156,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2af95a0e7bc24da7b085ca3cd88f5b37
+      - ca0aea027a064c6490d3ec0810e0d16e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDhiNDFjMjctMGUw
-        YS00Nzk1LWI4ODgtNmI3OWRkNjFlNWE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTYuNjQwMjc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2UyNmNiM2YtMDM5
+        Ny00MWE2LWEzYmEtMzVjYjViMWM1OWEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzkuMDg5OTY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0ZjhkM2I3MGU4ZjQ0NmE4OGZhODdmZTQ4
-        ZmNhZjliMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI2OjU2LjY3
-        MjAyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjY6NTYuNzE0
-        MDQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5YThmOTRiZjQ1OGI0ZDE2OWI4NTliNDAx
+        MzQ4MDM5MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjM5LjE2
+        MjkxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MzkuMjQw
+        NDM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVlYTQxMWQwLWU5OGUtNGYxNi1iZWJj
-        LWI2ODQwN2VjNzgzYS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzMxMTAxNWUzLWJhNWQtNDQyYi05NTBi
+        LTUzNDc1MjI5Yzc5OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1208,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1221,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1239,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb87af083d82402d92f0e17e2d0a589f
+      - 517fda2b5e41425c879c50c2ea8fe757
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1261,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1274,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1292,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f818112ed7a94ca798a948ae5574da84
+      - a40d00862cf24ffdaaabd0b41d7b2a14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1314,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1327,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1345,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 14e47edf035148a492e45ff8c6865144
+      - 28812b2f55894d728d8afb6af4dcd9a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1367,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1380,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1398,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 87d5b57d6b364ea08a3c0d76f03b2a96
+      - 72e8311ade7e441faeff237895c9be3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1420,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1433,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1451,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5fb85a6cdf5840c6850ee80384d673cf
+      - fe7e9f9ad5494220aa38e771d18d9f81
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1473,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1486,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:56 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1504,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aec2f7ccbada47bebc0befeddf51cd69
+      - 930d8f6efb3549d490b7fce33b811244
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1528,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1541,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:57 GMT
+      - Fri, 29 Jul 2022 11:28:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1561,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 89b11f1583a447adbbfbf286f57cd4fd
+      - f9e1c3dfd0c243bd8ae97b84a76e7e29
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTcyYjU1ZWYtNmY5Yi00ODUzLTllZTUtOWMzZDBlYzZhMWJkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTcuMTgyNzI5WiIsInZl
+        cG0vZDdhOWEzMzUtZTJiYy00ODgwLTlmZjctZDZlYTgwMjgyYWYwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6MzkuODI5NDY3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTcyYjU1ZWYtNmY5Yi00ODUzLTllZTUtOWMzZDBlYzZhMWJkL3ZlcnNp
+        cG0vZDdhOWEzMzUtZTJiYy00ODgwLTlmZjctZDZlYTgwMjgyYWYwL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lNzJiNTVlZi02
-        ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kN2E5YTMzNS1l
+        MmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1584,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:39 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/83c2bfa7-7aed-42c7-85e5-7f28f11bf264/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/f60e2300-6cc4-4424-9aa8-2c51b5e8901c/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1604,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1617,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:57 GMT
+      - Fri, 29 Jul 2022 11:28:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1635,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d591adb8b9bc4e3982d09a9cbdbf21e9
+      - f32f0394942e40a3b770161681dbef30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlM2ZmNGVhLTIyNWYtNGQ2
-        ZC05Mzg5LWZhMTQ1YmM0NDAzNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0YWUzYjg4LWQ1MjUtNDZk
+        ZC04ODIxLWQwMWY1MTZiYTc2My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4e3ff4ea-225f-4d6d-9389-fa145bc44034/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/34ae3b88-d525-46dd-8821-d01f516ba763/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1670,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:57 GMT
+      - Fri, 29 Jul 2022 11:28:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - edeb003f33454aaaa93153b8d313b5de
+      - 138187933c274a51bba8fcfaf3f828b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGUzZmY0ZWEtMjI1
-        Zi00ZDZkLTkzODktZmExNDViYzQ0MDM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTcuNDg3NTgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzRhZTNiODgtZDUy
+        NS00NmRkLTg4MjEtZDAxZjUxNmJhNzYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDAuMzE2ODg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJkNTkxYWRiOGI5YmM0ZTM5ODJkMDlhOWNi
-        ZGJmMjFlOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI2OjU3LjUy
-        MTgzOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjY6NTcuNTQz
-        OTY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmMzJmMDM5NDk0MmU0MGEzYjc3MDE2MTY4
+        MWRiZWYzMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjQwLjM3
+        OTk4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6NDAuNDE3
+        NTUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzgzYzJiZmE3LTdhZWQtNDJjNy04NWU1
-        LTdmMjhmMTFiZjI2NC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y2MGUyMzAwLTZjYzQtNDQyNC05YWE4
+        LTJjNTFiNWU4OTAxYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:40 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzgzYzJi
-        ZmE3LTdhZWQtNDJjNy04NWU1LTdmMjhmMTFiZjI2NC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y2MGUy
+        MzAwLTZjYzQtNDQyNC05YWE4LTJjNTFiNWU4OTAxYy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1739,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:57 GMT
+      - Fri, 29 Jul 2022 11:28:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1757,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c7f07caf1f004339a2a7cf137e028f1e
+      - 8257936389244108abde9527b5471552
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4MWRjNWUyLTI2MjItNGJj
-        NC04Njg1LTZkMDk0YjNhY2FhNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3ZTYwODRlLTUwMmItNGM5
+        OC1iN2I5LTNhODllMzVmZWRlMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d81dc5e2-2622-4bc4-8685-6d094b3acaa6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b7e6084e-502b-4c98-b7b9-3a89e35fede0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1792,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:58 GMT
+      - Fri, 29 Jul 2022 11:28:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d912324860e4026a2d5ffafdf538cf6
+      - 59bed96bb8774f5a9bb18847f28cc0dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '656'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDgxZGM1ZTItMjYy
-        Mi00YmM0LTg2ODUtNmQwOTRiM2FjYWE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTcuNjY2ODMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjdlNjA4NGUtNTAy
+        Yi00Yzk4LWI3YjktM2E4OWUzNWZlZGUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDAuNTMyMDkzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJjN2YwN2NhZjFmMDA0MzM5YTJh
-        N2NmMTM3ZTAyOGYxZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU3LjY5OTI0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguNTA5MTQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI4MjU3OTM2Mzg5MjQ0MTA4YWJk
+        ZTk1MjdiNTQ3MTU1MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQwLjU4NzAzMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDIuMDY2OTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
-        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
-        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
-        ZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5nLm1l
-        dGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9u
-        ZSI6Nywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBB
-        cnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFjdHMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMSwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50
-        IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBs
-        ZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo0Miwic3VmZml4IjpudWxsfSx7
-        Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQiLCJjb2RlIjoic3luYy5wYXJz
-        aW5nLm1vZHVsZW1kcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjYs
-        ImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1v
-        ZHVsZW1kLWRlZmF1bHRzIiwiY29kZSI6InN5bmMucGFyc2luZy5tb2R1bGVt
-        ZF9kZWZhdWx0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
-        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2th
-        Z2VzIiwiY29kZSI6InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjIwLCJzdWZmaXgiOm51
-        bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBDb21wcyIsImNvZGUiOiJzeW5jLnBh
-        cnNpbmcuY29tcHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJk
-        b25lIjo0LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBBZHZp
-        c29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5hZHZpc29yaWVzIiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NywiZG9uZSI6Nywic3VmZml4Ijpu
-        dWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wZDc3MzE0Yi05ZDQ3LTRmN2YtYmI4MC1hNmQy
-        NjRhNzU4MzEvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3Jl
-        Y29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGQ3
-        NzMxNGItOWQ0Ny00ZjdmLWJiODAtYTZkMjY0YTc1ODMxLyIsInNoYXJlZDov
-        cHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzgzYzJiZmE3LTdhZWQtNDJj
-        Ny04NWU1LTdmMjhmMTFiZjI2NC8iXX0=
+        IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
+        bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS84MzIxMjk5OC1kMTlkLTQzYzItOWIwNS1kZGRmNmYz
+        ZjVhMzIvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODMyMTI5
+        OTgtZDE5ZC00M2MyLTliMDUtZGRkZjZmM2Y1YTMyLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y2MGUyMzAwLTZjYzQtNDQyNC05
+        YWE4LTJjNTFiNWU4OTAxYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMGQ3NzMxNGItOWQ0Ny00ZjdmLWJiODAtYTZkMjY0YTc1
-        ODMxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vODMyMTI5OTgtZDE5ZC00M2MyLTliMDUtZGRkZjZmM2Y1
+        YTMyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1888,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:58 GMT
+      - Fri, 29 Jul 2022 11:28:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1906,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a732d87151e14c5892576ab4b0a0af4c
+      - 2ab968dda1c84781b9f6b04d6663e0c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3Y2NkOThiLTRiMDUtNDZj
-        NC04OGQ0LWIzN2MxMzQxMjViMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2MTVlMWVmLTRiZjktNDMy
+        MC05Mjg2LWQ0MGVjN2E0MTAwYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/07ccd98b-4b05-46c4-88d4-b37c134125b0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e615e1ef-4bf9-4320-9286-d40ec7a4100c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1941,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:59 GMT
+      - Fri, 29 Jul 2022 11:28:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e15f7e7b1caf498a8aacab8252d63608
+      - 919f890e84284cde880c4763d717c186
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDdjY2Q5OGItNGIw
-        NS00NmM0LTg4ZDQtYjM3YzEzNDEyNWIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguOTg1NDQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTYxNWUxZWYtNGJm
+        OS00MzIwLTkyODYtZDQwZWM3YTQxMDBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDIuNjA3NDY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImE3MzJkODcxNTFlMTRjNTg5MjU3NmFiNGIw
-        YTBhZjRjIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjY6NTkuMDE1
-        Mjc2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNjo1OS4yNTE5
-        NTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjJhYjk2OGRkYTFjODQ3ODFiOWY2YjA0ZDY2
+        NjNlMGM2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6NDIuNjc0
+        NjkzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyODo0My4zMjkz
+        NDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTEwYzc5
-        MWItMWNmNy00ZTZmLWE1ZjUtOWEyOGRhMTU2OGJjLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDE1NGMx
+        NTAtNjk3ZC00NTEyLTg4NzQtMDE5ZDc4ODk3ZmI4LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMGQ3NzMxNGItOWQ0Ny00ZjdmLWJiODAtYTZkMjY0
-        YTc1ODMxLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vODMyMTI5OTgtZDE5ZC00M2MyLTliMDUtZGRkZjZm
+        M2Y1YTMyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1998,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2011,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:59 GMT
+      - Fri, 29 Jul 2022 11:28:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57931d907ac248639be30696daccdc0e
+      - 9762a8d5eed74505aad5903ab6f622bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:43 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/4154c150-697d-4512-8874-019d78897fb8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9e21a592e17444beb7e1eb6a389ee39a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNDE1NGMxNTAtNjk3ZC00NTEyLTg4NzQtMDE5ZDc4ODk3ZmI4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6NDIuNzA5MDk4WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84MzIxMjk5OC1kMTlkLTQzYzItOWIwNS1kZGRmNmYzZjVhMzIv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzgzMjEyOTk4LWQxOWQtNDNjMi05YjA1LWRkZGY2
+        ZjNmNWEzMi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:43 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS80MTU0YzE1MC02OTdkLTQ1MTItODg3NC0wMTlkNzg4OTdmYjgv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bd0c66d742604646aa384dbc89f18f18
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmYWFhMWJmLWIzMGYtNDcz
+        Yy1iNTRmLWMzZWFkZDIzYmVkYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:43 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bfaaa1bf-b30f-473c-b54f-c3eadd23beda/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c948f37de9ec4253b44de35e9211971c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmZhYWExYmYtYjMw
+        Zi00NzNjLWI1NGYtYzNlYWRkMjNiZWRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDMuNjU4NjMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiZDBjNjZkNzQyNjA0NjQ2YWEzODRkYmM4
+        OWYxOGYxOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjQzLjcx
+        MTg1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6NDQuMDkz
+        NTg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNmVh
+        NDRlMjItYTZlMS00NDdhLWFjMzItYzYwMjc2MDQ5YTFjLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:44 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/6ea44e22-a6e1-447a-ac32-c60276049a1c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ecb186014f6f4517a082639c35d2a1b9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzZlYTQ0ZTIyLWE2ZTEtNDQ3YS1hYzMyLWM2MDI3NjA0OWExYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI4OjQ0LjA3MzE0N1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNDE1NGMxNTAtNjk3ZC00NTEyLTg4NzQt
+        MDE5ZDc4ODk3ZmI4LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:44 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 165659a1ba434aecbe821c3a9ed88076
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -2047,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -2064,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2212,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2225,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:59 GMT
+      - Fri, 29 Jul 2022 11:28:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74fe532c9dad4c648007e025cce4ebd4
+      - e70c7489fc274bd09b4d47c4748203ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2265,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2286,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2306,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2327,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2348,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2368,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2387,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2400,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:59 GMT
+      - Fri, 29 Jul 2022 11:28:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 89fa4f4f5cf54326ba426c803bfead92
+      - dee62aa28c064ddb9e4b9cddac9a0968
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2503,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2521,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2540,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2564,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2582,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2593,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2624,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2635,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2648,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:59 GMT
+      - Fri, 29 Jul 2022 11:28:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73a75c3fd6b4488faecc27f86f8dd2fb
+      - 967389e852c74a9ca5f98c994884c2f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2715,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2727,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2738,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2751,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:59 GMT
+      - Fri, 29 Jul 2022 11:28:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - edf1c4f4e1434dd2bdac24d7a59b50d7
+      - 58f0583a8fc74154a16ca3091aea956a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2787,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2798,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2811,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:26:59 GMT
+      - Fri, 29 Jul 2022 11:28:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d97f81f26874d448725b897c478c6f5
+      - 9c0cf5a3c77b478bbe6521f64e386461
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2862,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:26:59 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2873,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2886,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e87443ba456e41c0a3fc948aa660475c
+      - 35ba6e072e614aa3952b80a8109e26b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2953,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2964,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2977,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dfb280048f284ba4a6b0f091ebe3e743
+      - f4c5065251f74c5c905c8eca06df190a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -3044,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3055,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3068,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 40a186a4fbf249f585bc227ee8d42bb6
+      - 2b2f52c092c54971bc4f12d5ce500501
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3107,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3118,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3131,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 69e54150362c445b9d48f5f274b927e1
+      - c50bb278b44f4929877cce45948aecd8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3170,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3181,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3194,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1af9a19af57b47e7b7a009c64fbdefb6
+      - ce86cc9f04594cda8cfbdcc1ee4a5d83
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3235,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3243,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3254,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3267,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bcdc47a66d444a69b43e0d5939f507c1
+      - ebdfdfffefa44bf4856713146039aa8a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3318,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3329,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3342,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56078d9f342f4e5e977622f07a1bdaa1
+      - e2d29d28637d43c7a8f29ae688bfae7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3383,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3399,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3415,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3430,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3443,47 +3738,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f942fe7754d743efa4b9e2bacdddb7ef
+      - 7d023abbc7ed43588ad8b2e1e5fa55bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3493,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3506,7 +3801,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3524,32 +3819,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b44535d962aa447a90244cd0b7f22c79
+      - 5601e5814f234d778955f249b391898e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiYWM4NjRjLTc0ZGItNDky
-        Ni1iMDZhLTVhZTRkNmQwMjhmNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VjZTdiYzBiLTQ0MjMtNDFh
+        My05MGQ5LWM4ODlhMTI2Mzg5Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3562,7 +3857,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3580,36 +3875,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 54218b8ab11a4cfc8308006609b49292
+      - 6d468c27466e4e3e9feb63ebea2ddc8f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RmNzhlYWI2LWNmOTItNDNm
-        Zi1iMDViLWE4ODNhODgyNDRhNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlMjViNjE1LWM5MzUtNGZm
+        My04ODRmLTlkODMzNGY2N2YwNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3622,7 +3917,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3640,97 +3935,97 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 109a83d4375b4a8987838bbac2068118
+      - 16236b7d10cd4fc1b3832024eac2d9ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiMDQ1ZjVmLWU5ZTMtNGEz
-        OS1iYmM0LTZjYjkyNDY3N2ZlMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4OTJlNjgzLWJiYTgtNDk1
+        OC04NGY0LTVhOWZiNGY0MjEyZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGQ3NzMxNGItOWQ0Ny00ZjdmLWJi
-        ODAtYTZkMjY0YTc1ODMxL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U3MmI1NWVmLTZmOWIt
-        NDg1My05ZWU1LTljM2QwZWM2YTFiZC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        Mjk2ZTUwNTQtODIyNS00MzNjLWEzY2QtNjQxYzEwMDk1MTEzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM4NTMwYWU2LTRiYzYt
-        NDE2Zi1iYmVlLTk2MTA2YTRjZjk1MC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQtZDcxNTNhZDc4NDIyLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQy
-        M2QtNDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1
-        ZC1iODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRk
-        NGFhYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRl
-        NTYxMGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhk
-        YS04Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNl
-        YzY5Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5
-        YTY1ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3
-        MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJj
-        ODZhZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
-        cm91cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01
-        YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3Yi1iY2MzLTQ2
-        MzNhMmM3OTkwZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNGI5ZTFkMS1mYWUy
-        LTQ0NWQtYTg3Ny05Mzk5ZjhlNjVjMGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzI5ZTZhMjFkLTJmNjktNGNkMi1iNzExLTYxY2M4
-        OWNmNzBjZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MzdjMzgwYTAtYWFmZi00M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQy
-        YzAtODhmMy0xNTI4OTBlZmE3ZWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzQ5NDNkMTlkLWM1NTItNDVkMi04NTYwLWM3MGFmOTEz
-        N2NjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNTBj
-        ODJlOWQtYWY4OS00MzEzLWJmZWQtZDRjNGE2YzgwZjllLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NjQ2NWZmYS05NTFlLTRlZDUt
-        YjNjMy1hODA2ZWVkZmM4NWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzc2MDhjZTM3LTFjNzEtNGFkMC05MGFjLWVlZDc0NjBjNTYx
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2EzYzU3
-        OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJkNDg4LyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5
-        YS1mMGFjOTY2MjVkZmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzhmNGMwNDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4Zi8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1MjI4ODAt
-        OGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0
-        NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJkLTQ3MGMtYTI2MC1iZWJh
-        NjIwMDM0OWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2ZjMmFlODJlLWI3YTEtNGQ2Zi1iNjNkLWNlNzFlZmU1NmM1YS8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9mNDdh
-        M2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19XSwiZGVwZW5k
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODMyMTI5OTgtZDE5ZC00M2MyLTli
+        MDUtZGRkZjZmM2Y1YTMyL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q3YTlhMzM1LWUyYmMt
+        NDg4MC05ZmY3LWQ2ZWE4MDI4MmFmMC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYy
+        YWItNGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQy
+        OTI5My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1
+        ZWE3ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBl
+        NS1hZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFk
+        MTkxOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYy
+        NTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgx
+        NS04OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJm
+        MjFjYmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
+        cm91cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0y
+        OTFhLTQzMzYtYWRiZC1kODliN2IwMWQ4NDYvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0YzgtNDU5Mi04Mzg0LWIy
+        NzZmZmE3ZTgyNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzViYmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0
+        NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0OTU0ZWVkLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81YTMyODQyNi0yYmFmLTQx
+        ODktOWNjNS02ZDhkYzM1YzEwZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQtNGU0Ni04ZmMzLTFiZmY3OTlm
+        YjYxZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjVm
+        YmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NmQwMjRjMi0xMGZjLTQwMWMt
+        YWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEy
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVm
+        MmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUtOTM2
+        Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMt
+        NTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0y
+        MmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkxLTM2ZWM4ZmMzNTA0OC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVh
+        Mi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2ZkYjk1N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJm
+        NTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19XSwiZGVwZW5k
         ZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3743,7 +4038,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3761,21 +4056,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66b20f96d3fc4027b3dd9d5091d94106
+      - de6b619dbb474304bc09e51c781d6960
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlNWI4M2RjLTE1MjQtNGI3
-        My04ZjhiLTRlODg3NTVmNGY5Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxYTQ4NjVlLWZmMWUtNGRj
+        Ny1hZTkyLWUyMDk4MWIzNWU5My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3bac864c-74db-4926-b06a-5ae4d6d028f5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ece7bc0b-4423-41a3-90d9-c889a1263892/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3796,51 +4091,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:00 GMT
+      - Fri, 29 Jul 2022 11:28:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e8ab00834fe483798129490438099a7
+      - 2c4559b51b6e44369848e1824fb8d615
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2JhYzg2NGMtNzRk
-        Yi00OTI2LWIwNmEtNWFlNGQ2ZDAyOGY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuNjgwODcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWNlN2JjMGItNDQy
+        My00MWEzLTkwZDktYzg4OWExMjYzODkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNTU2Nzk2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiNDQ1MzVkOTYyYWE0NDdhOTAy
-        NDRjZDBiN2YyMmM3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAwLjczNDM3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDAuODk4MDI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NjAxZTU4MTRmMjM0ZDc3ODk1
+        NWYyNDliMzkxODk4ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ2LjYwNDI5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDYuOTE4ODkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5
-        Yi00ODUzLTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJi
+        Yy00ODgwLTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3bac864c-74db-4926-b06a-5ae4d6d028f5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ae25b615-c935-4ff3-884f-9d8334f67f06/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3861,118 +4156,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:01 GMT
+      - Fri, 29 Jul 2022 11:28:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d09543378b384a518f2b83b508b32f09
+      - 43cf815f08584d24a7e775a1bedffdb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2JhYzg2NGMtNzRk
-        Yi00OTI2LWIwNmEtNWFlNGQ2ZDAyOGY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuNjgwODcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWUyNWI2MTUtYzkz
+        NS00ZmYzLTg4NGYtOWQ4MzM0ZjY3ZjA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNjM1Njc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiNDQ1MzVkOTYyYWE0NDdhOTAy
-        NDRjZDBiN2YyMmM3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAwLjczNDM3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDAuODk4MDI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5
-        Yi00ODUzLTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/df78eab6-cf92-43ff-b05b-a883a88244a6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - b69e331aaa65496686815fb628e099af
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGY3OGVhYjYtY2Y5
-        Mi00M2ZmLWIwNWItYTg4M2E4ODI0NGE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuNzU3Mzk3WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NDIxOGI4YWIxMWE0Y2ZjODMw
-        ODAwNjYwOWI0OTI5MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAwLjkzMzY2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDEuMDY1NDEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZDQ2OGMyNzQ2NmU0ZTNlOWZl
+        YjYzZWJlYTJkZGM4ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ2Ljk5NzA2NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDcuMjk4MzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lNzJiNTVlZi02ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQvdmVyc2lv
+        bS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5Yi00ODUz
-        LTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJiYy00ODgw
+        LTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3b045f5f-e9e3-4a39-bbc4-6cb924677fe0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ece7bc0b-4423-41a3-90d9-c889a1263892/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3993,118 +4223,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:01 GMT
+      - Fri, 29 Jul 2022 11:28:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a530d353e71494a800a892aca1e73bf
+      - 1cad6fb92a7047d49f68d296f2d79a32
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2IwNDVmNWYtZTll
-        My00YTM5LWJiYzQtNmNiOTI0Njc3ZmUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuODExNjMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWNlN2JjMGItNDQy
+        My00MWEzLTkwZDktYzg4OWExMjYzODkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNTU2Nzk2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxMDlhODNkNDM3NWI0YTg5ODc4
-        MzhiYmFjMjA2ODExOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAxLjA5NjY4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDEuMjI3OTcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lNzJiNTVlZi02ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQvdmVyc2lv
-        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5Yi00ODUz
-        LTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3bac864c-74db-4926-b06a-5ae4d6d028f5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 002cb03562f647c3894b50e7ebf9190d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2JhYzg2NGMtNzRk
-        Yi00OTI2LWIwNmEtNWFlNGQ2ZDAyOGY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuNjgwODcyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiNDQ1MzVkOTYyYWE0NDdhOTAy
-        NDRjZDBiN2YyMmM3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAwLjczNDM3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDAuODk4MDI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NjAxZTU4MTRmMjM0ZDc3ODk1
+        NWYyNDliMzkxODk4ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ2LjYwNDI5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDYuOTE4ODkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5
-        Yi00ODUzLTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJi
+        Yy00ODgwLTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/df78eab6-cf92-43ff-b05b-a883a88244a6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ae25b615-c935-4ff3-884f-9d8334f67f06/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4125,53 +4288,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:01 GMT
+      - Fri, 29 Jul 2022 11:28:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd7f19f96baf4646ab89b86948db81a6
+      - 1d9ece7f14684f90b49bf178edacc2e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGY3OGVhYjYtY2Y5
-        Mi00M2ZmLWIwNWItYTg4M2E4ODI0NGE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuNzU3Mzk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWUyNWI2MTUtYzkz
+        NS00ZmYzLTg4NGYtOWQ4MzM0ZjY3ZjA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNjM1Njc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NDIxOGI4YWIxMWE0Y2ZjODMw
-        ODAwNjYwOWI0OTI5MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAwLjkzMzY2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDEuMDY1NDEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZDQ2OGMyNzQ2NmU0ZTNlOWZl
+        YjYzZWJlYTJkZGM4ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ2Ljk5NzA2NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDcuMjk4MzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lNzJiNTVlZi02ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQvdmVyc2lv
+        bS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5Yi00ODUz
-        LTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJiYy00ODgw
+        LTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3b045f5f-e9e3-4a39-bbc4-6cb924677fe0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0892e683-bba8-4958-84f4-5a9fb4f4212f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4192,53 +4355,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:01 GMT
+      - Fri, 29 Jul 2022 11:28:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bbaea86e67f14138ace827b1efd868c1
+      - 8714146f51dd459bb6c4263672d70295
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2IwNDVmNWYtZTll
-        My00YTM5LWJiYzQtNmNiOTI0Njc3ZmUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuODExNjMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDg5MmU2ODMtYmJh
+        OC00OTU4LTg0ZjQtNWE5ZmI0ZjQyMTJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNzIxMDk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxMDlhODNkNDM3NWI0YTg5ODc4
-        MzhiYmFjMjA2ODExOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAxLjA5NjY4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDEuMjI3OTcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNjIzNmI3ZDEwY2Q0ZmMxYjM4
+        MzIwMjRlYWMyZDllZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ3LjM4NDg0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDcuNzA1NTQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lNzJiNTVlZi02ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQvdmVyc2lv
+        bS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5Yi00ODUz
-        LTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJiYy00ODgw
+        LTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3bac864c-74db-4926-b06a-5ae4d6d028f5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ece7bc0b-4423-41a3-90d9-c889a1263892/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4259,51 +4422,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:01 GMT
+      - Fri, 29 Jul 2022 11:28:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d2fcf62a38d24290aec68718dbdb809e
+      - 76d0e3b62e46406b8cdd77bebad893d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2JhYzg2NGMtNzRk
-        Yi00OTI2LWIwNmEtNWFlNGQ2ZDAyOGY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuNjgwODcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWNlN2JjMGItNDQy
+        My00MWEzLTkwZDktYzg4OWExMjYzODkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNTU2Nzk2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiNDQ1MzVkOTYyYWE0NDdhOTAy
-        NDRjZDBiN2YyMmM3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAwLjczNDM3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDAuODk4MDI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NjAxZTU4MTRmMjM0ZDc3ODk1
+        NWYyNDliMzkxODk4ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ2LjYwNDI5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDYuOTE4ODkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5
-        Yi00ODUzLTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJi
+        Yy00ODgwLTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/df78eab6-cf92-43ff-b05b-a883a88244a6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ae25b615-c935-4ff3-884f-9d8334f67f06/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4324,53 +4487,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:01 GMT
+      - Fri, 29 Jul 2022 11:28:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a05629a07ed74beeb653dad4fd5504ca
+      - 549a445fc2f94d9bb31b104ff51c0bd8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGY3OGVhYjYtY2Y5
-        Mi00M2ZmLWIwNWItYTg4M2E4ODI0NGE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuNzU3Mzk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWUyNWI2MTUtYzkz
+        NS00ZmYzLTg4NGYtOWQ4MzM0ZjY3ZjA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNjM1Njc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NDIxOGI4YWIxMWE0Y2ZjODMw
-        ODAwNjYwOWI0OTI5MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAwLjkzMzY2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDEuMDY1NDEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZDQ2OGMyNzQ2NmU0ZTNlOWZl
+        YjYzZWJlYTJkZGM4ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ2Ljk5NzA2NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDcuMjk4MzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lNzJiNTVlZi02ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQvdmVyc2lv
+        bS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5Yi00ODUz
-        LTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJiYy00ODgw
+        LTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3b045f5f-e9e3-4a39-bbc4-6cb924677fe0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0892e683-bba8-4958-84f4-5a9fb4f4212f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4391,53 +4554,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:01 GMT
+      - Fri, 29 Jul 2022 11:28:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 468ffb3cab134a9f83c83d4583194d33
+      - aa5ab5e4962846aea7a21d804630e4e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2IwNDVmNWYtZTll
-        My00YTM5LWJiYzQtNmNiOTI0Njc3ZmUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuODExNjMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDg5MmU2ODMtYmJh
+        OC00OTU4LTg0ZjQtNWE5ZmI0ZjQyMTJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNzIxMDk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxMDlhODNkNDM3NWI0YTg5ODc4
-        MzhiYmFjMjA2ODExOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjAxLjA5NjY4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDEuMjI3OTcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNjIzNmI3ZDEwY2Q0ZmMxYjM4
+        MzIwMjRlYWMyZDllZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ3LjM4NDg0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDcuNzA1NTQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9lNzJiNTVlZi02ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQvdmVyc2lv
+        bS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5Yi00ODUz
-        LTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJiYy00ODgw
+        LTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ce5b83dc-1524-4b73-8f8b-4e88755f4f9b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ece7bc0b-4423-41a3-90d9-c889a1263892/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4458,55 +4621,254 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:01 GMT
+      - Fri, 29 Jul 2022 11:28:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dc23a82c83c647e1ba804c6a92daf71a
+      - 62cca97619524981ae6f36aea22f3416
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '418'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2U1YjgzZGMtMTUy
-        NC00YjczLThmOGItNGU4ODc1NWY0ZjliLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDAuODc3MjAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWNlN2JjMGItNDQy
+        My00MWEzLTkwZDktYzg4OWExMjYzODkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNTU2Nzk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NjAxZTU4MTRmMjM0ZDc3ODk1
+        NWYyNDliMzkxODk4ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ2LjYwNDI5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDYuOTE4ODkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJi
+        Yy00ODgwLTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ae25b615-c935-4ff3-884f-9d8334f67f06/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '697'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 85fc5f54dd5b447f8e3151fd1ed7f184
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWUyNWI2MTUtYzkz
+        NS00ZmYzLTg4NGYtOWQ4MzM0ZjY3ZjA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNjM1Njc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZDQ2OGMyNzQ2NmU0ZTNlOWZl
+        YjYzZWJlYTJkZGM4ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ2Ljk5NzA2NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDcuMjk4MzAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJiYy00ODgw
+        LTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0892e683-bba8-4958-84f4-5a9fb4f4212f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '697'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6428438feecf4f09a6a3e79dc269b17e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDg5MmU2ODMtYmJh
+        OC00OTU4LTg0ZjQtNWE5ZmI0ZjQyMTJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuNzIxMDk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNjIzNmI3ZDEwY2Q0ZmMxYjM4
+        MzIwMjRlYWMyZDllZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjQ3LjM4NDg0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NDcuNzA1NTQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAvdmVyc2lv
+        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJiYy00ODgw
+        LTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/01a4865e-ff1e-4dc7-ae92-e20981b35e93/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b383619fc0be4b259104a04025e9e644
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDFhNDg2NWUtZmYx
+        ZS00ZGM3LWFlOTItZTIwOTgxYjM1ZTkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NDYuODI2Nzc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiNjZiMjBmOTZkM2ZjNDAyN2IzZGQ5ZDUwOTFk
-        OTQxMDYiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNzowMS4yNTgx
-        MDdaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjAxLjYyMjY4
-        NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiZGU2YjYxOWRiYjQ3NDMwNGJjMDllNTFjNzgx
+        ZDY5NjAiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyODo0Ny43NjUz
+        MDNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjQ4LjY3MDA2
+        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1
-        ZWYtNmY5Yi00ODUzLTllZTUtOWMzZDBlYzZhMWJkL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEz
+        MzUtZTJiYy00ODgwLTlmZjctZDZlYTgwMjgyYWYwL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2U3MmI1NWVmLTZmOWItNDg1My05ZWU1LTlj
-        M2QwZWM2YTFiZC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzBkNzczMTRiLTlkNDctNGY3Zi1iYjgwLWE2ZDI2NGE3NTgz
-        MS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2Q3YTlhMzM1LWUyYmMtNDg4MC05ZmY3LWQ2
+        ZWE4MDI4MmFmMC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzgzMjEyOTk4LWQxOWQtNDNjMi05YjA1LWRkZGY2ZjNmNWEz
+        Mi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4514,7 +4876,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4527,76 +4889,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:02 GMT
+      - Fri, 29 Jul 2022 11:28:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - efe241ba2d04480fb1707d910a7c72b2
+      - 18f610fe2c814670ab9138541a8c761f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '566'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
-        NTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2Ji
-        Mzg0ODctOTY3Ny00YTQzLTgzZTMtNDM5MGIzZDIwNWI0LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhiMjUx
-        NzM4LTZhNDgtNDNjYi1iNzlhLWYwYWM5NjYyNWRmZi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQt
-        MmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThj
-        NWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZm
-        LTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00
-        NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTViNzEtNDE1
-        NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkw
-        YWMtZWVkNzQ2MGM1NjFiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YwNzc5MmMzLWE0MmQtNDcwYy1hMjYw
-        LWJlYmE2MjAwMzQ5Zi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00YjY2LWFlYWQtZmY4
-        NTBiOTI2ZTVjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4604,7 +4966,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4617,50 +4979,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:02 GMT
+      - Fri, 29 Jul 2022 11:28:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 992b6ed6238144659e9ebf996960a9f9
+      - 2a18a26592604922af4c9978b514c063
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4668,7 +5030,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4681,37 +5043,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:02 GMT
+      - Fri, 29 Jul 2022 11:28:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3504cb206d724cc081474fcbb13e6dcd
+      - 990f0a8f37e9478c928cf1102b59b516
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4784,9 +5146,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -4802,8 +5164,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -4821,9 +5183,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -4845,9 +5207,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -4863,9 +5225,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -4874,9 +5236,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -4905,10 +5267,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4916,7 +5278,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4929,43 +5291,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:02 GMT
+      - Fri, 29 Jul 2022 11:28:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4c5c241acaba42039ef93e707bb7d5b9
+      - 0ca76b9e0fd1410f805e2c039f8afa2b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4973,7 +5335,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4986,41 +5348,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:02 GMT
+      - Fri, 29 Jul 2022 11:28:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed7ce0087dc2489b85b7cbf9cc1d0853
+      - 37ca42544d714ebdbef3e624caa05f0e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5028,7 +5390,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5041,36 +5403,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:02 GMT
+      - Fri, 29 Jul 2022 11:28:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6745ce7e33ff47479e4a9c11f7bfbf7a
+      - a075083dc1424bd9a868f91dee985327
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5092,10 +5454,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5103,7 +5465,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5116,47 +5478,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:02 GMT
+      - Fri, 29 Jul 2022 11:28:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 67c5e1b6f95343ac836526a96da28566
+      - 10e59330b0fe4c2d98f8eb7eee45f30c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5164,7 +5526,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5177,42 +5539,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:02 GMT
+      - Fri, 29 Jul 2022 11:28:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf7c54104a014362b59e8c411f509f66
+      - e3bed0d91ecb44b0a57fb49ef6f52296
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:50 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_environment_repository/all_package_environments_are_copied_even_if_no_groups_match.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_environment_repository/all_package_environments_are_copied_even_if_no_groups_match.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d368c1c5c024357812440c8b376860b
+      - a7f42b8182074da9b1dbf8a204eb1a46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wZDc3MzE0Yi05ZDQ3LTRmN2YtYmI4MC1hNmQyNjRhNzU4MzEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1Ni4zODA2MzFa
+        cnBtL3JwbS83YTRkZTJkOC00NjUyLTQ3YjgtOGYxYi1mZmE4ZjUzY2FjYjEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOToxMTo0OS43NDg5NzVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wZDc3MzE0Yi05ZDQ3LTRmN2YtYmI4MC1hNmQyNjRhNzU4MzEv
+        cnBtL3JwbS83YTRkZTJkOC00NjUyLTQ3YjgtOGYxYi1mZmE4ZjUzY2FjYjEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBkNzcz
-        MTRiLTlkNDctNGY3Zi1iYjgwLWE2ZDI2NGE3NTgzMS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdhNGRl
+        MmQ4LTQ2NTItNDdiOC04ZjFiLWZmYThmNTNjYWNiMS92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:22 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/0d77314b-9d47-4f7f-bb80-a6d264a75831/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7a4de2d8-4652-47b8-8f1b-ffa8f53cacb1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d2da798524404a16831d8a21a05468f0
+      - 5b34876262df4124a6a14b94b61d0b6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZlMjFhNzYzLWE4ZGItNGM0
-        My1iYTgzLWFjOGUwYjk1OTg5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmZDMzM2I2LTY2ZDMtNDU0
+        Ni1hYjJhLTEwYzFiNmI0ODk5My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -155,27 +155,92 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '588'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c229eafae87743868ceb711f5657c246
+      - eb2b3d2d4c914fd88b4897d9a3bc2391
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
+        cG0vNjdlMzhkOGYtODQwMC00YjAxLWI5ODItMDA3Y2IxMjRkYzQ1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMDk6MTE6NDkuNTg5MjM2WiIsIm5h
+        bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9teXJlcG8uY29tIiwi
+        Y2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0
+        aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwi
+        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDA5OjExOjQ5LjU4OTI3
+        M1oiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMi
+        Om51bGwsInBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2
+        MDAuMCwiY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGlt
+        ZW91dCI6NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVy
+        cyI6bnVsbCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxs
+        fV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:22 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/67e38d8f-8400-4b01-b982-007cb124dc45/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8ca14f8a2f0d4a01a553710ab4c7c0c0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiYmUwY2YwLTUzMmYtNGRl
+        NS1hYjcxLTg2NmNkYmVkYTJiOC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6e21a763-a8db-4c43-ba83-ac8e0b959899/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/efd333b6-66d3-4546-ab2a-10c1b6b48993/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +261,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bef63c85df3f4e798bd97a0d700a2f8c
+      - 0e98f507cca5465d95d34b926b9328f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmUyMWE3NjMtYThk
-        Yi00YzQzLWJhODMtYWM4ZTBiOTU5ODk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDMuMjkyMzU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWZkMzMzYjYtNjZk
+        My00NTQ2LWFiMmEtMTBjMWI2YjQ4OTkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MjIuNjY5NzMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkMmRhNzk4NTI0NDA0YTE2ODMxZDhhMjFh
-        MDU0NjhmMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjAzLjMy
-        NzM4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MDMuNDU1
-        MDY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1YjM0ODc2MjYyZGY0MTI0YTZhMTRiOTRi
+        NjFkMGI2YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjIyLjcy
+        MjIyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MjIuODI0
+        ODUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGQ3NzMxNGItOWQ0Ny00Zjdm
-        LWJiODAtYTZkMjY0YTc1ODMxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2E0ZGUyZDgtNDY1Mi00N2I4
+        LThmMWItZmZhOGY1M2NhY2IxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6bbe0cf0-532f-4de5-ab71-866cdbeda2b8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +313,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +326,72 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 38c05fea97ea429681c4fa96baffb4b8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmJiZTBjZjAtNTMy
+        Zi00ZGU1LWFiNzEtODY2Y2RiZWRhMmI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MjIuODYwMzcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4Y2ExNGY4YTJmMGQ0YTAxYTU1MzcxMGFi
+        NGM3YzBjMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjIyLjkx
+        MDUzOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MjIuOTg0
+        NzY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzY3ZTM4ZDhmLTg0MDAtNGIwMS1iOTgy
+        LTAwN2NiMTI0ZGM0NS8iXX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +409,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 922007e74d9c4ed7864628699b37fb5f
+      - a4459f1f155e4bafb2388525a28e915c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +431,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +444,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +462,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 05d525bd46a24bf9bf5c175ae8bb686b
+      - 9ac66f2634b649d8a1cb18f0fa8d8774
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +484,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +497,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +515,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce0efb1283e54218b0927876cf5a3768
+      - d4e9a02c49f747d694ee6a5019042466
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +537,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +550,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +568,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7f99a1d451854c38a3bc037b8c476b5b
+      - 9ae25800aad14f348e141d0ee1253741
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +590,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +603,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,21 +621,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e53961eaaae24091a2b60c9fa8439477
+      - a3d55785f8a04eb39a0a70636ebac306
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -513,7 +643,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -526,7 +656,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -544,21 +674,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 834e393ad09241b0a7aff8eed2b27b41
+      - 16d2549272464b39bdfd7f316f8fc721
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +705,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +718,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:03 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/c6c55b63-6662-4f54-81be-d32e0fbe9f79/"
+      - "/pulp/api/v3/remotes/rpm/rpm/311015e3-ba5d-442b-950b-53475229c799/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +738,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1eca67f2e7f3438d89e92ce6072eac56
+      - 8e9c4dd375014e5da30f1c4527466a39
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M2
-        YzU1YjYzLTY2NjItNGY1NC04MWJlLWQzMmUwZmJlOWY3OS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI3OjAzLjkwNzI1NVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzMx
+        MTAxNWUzLWJhNWQtNDQyYi05NTBiLTUzNDc1MjI5Yzc5OS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI4OjIzLjU0MzExM1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI3OjAzLjkwNzI3NloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjI4OjIzLjU0MzI3OFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +773,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +786,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +806,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6763c95c70384514bdcdfb70c2036691
+      - fa1196b0219649b2adf88c3acb6799ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDY3ZjBmMjMtNWI2Yy00ZWJmLWJjNTktYjA4NWE2N2U3NDVhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MDQuMDE3NjgwWiIsInZl
+        cG0vNzMwZDZhYmMtNjIwOC00N2M4LTg2NDEtYzliZmI5M2RlOTAyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6MjMuNzQxMzMyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDY3ZjBmMjMtNWI2Yy00ZWJmLWJjNTktYjA4NWE2N2U3NDVhL3ZlcnNp
+        cG0vNzMwZDZhYmMtNjIwOC00N2M4LTg2NDEtYzliZmI5M2RlOTAyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80NjdmMGYyMy01
-        YjZjLTRlYmYtYmM1OS1iMDg1YTY3ZTc0NWEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MzBkNmFiYy02
+        MjA4LTQ3YzgtODY0MS1jOWJmYjkzZGU5MDIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +830,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +841,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +854,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b66e39d0f174d4a9e8e08f2a33860d2
+      - 7dddc722c0d74dfdb3b2cd704fec63b2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lNzJiNTVlZi02ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1Ny4xODI3Mjla
+        cnBtL3JwbS83YjI0NmNkMy1jNDJkLTQzZTEtOGIxMS05NmVmMmZhZTVmYjAv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQwOToxMTo1MC42OTExNzla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lNzJiNTVlZi02ZjliLTQ4NTMtOWVlNS05YzNkMGVjNmExYmQv
+        cnBtL3JwbS83YjI0NmNkMy1jNDJkLTQzZTEtOGIxMS05NmVmMmZhZTVmYjAv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U3MmI1
-        NWVmLTZmOWItNDg1My05ZWU1LTljM2QwZWM2YTFiZC92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdiMjQ2
+        Y2QzLWM0MmQtNDNlMS04YjExLTk2ZWYyZmFlNWZiMC92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +896,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:23 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e72b55ef-6f9b-4853-9ee5-9c3d0ec6a1bd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/7b246cd3-c42d-43e1-8b11-96ef2fae5fb0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +907,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +920,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +938,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 51c8de86c67548009673d80b4d2398be
+      - 7df01cba77fa4a41bd8f0ea2318fccb3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhMjAyZGQ1LTU4MGQtNDRj
-        MC1hMTI0LTRiOTg2MWUxZTBmMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U4NWIyOTIxLTRhZWMtNDkz
+        ZS1iNDNiLTRiNTBhZDcwOGE2OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +960,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,72 +973,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e8808b45917040fcb8599abc3ad8a5a4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '368'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vODNjMmJmYTctN2FlZC00MmM3LTg1ZTUtN2YyOGYxMWJmMjY0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTYuMjUwOTk0WiIsIm5h
-        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
-        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
-        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
-        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyNjo1Ny41MzkzOTJaIiwiZG93bmxvYWRfY29uY3VycmVu
-        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
-        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
-        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
-        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
-        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/83c2bfa7-7aed-42c7-85e5-7f28f11bf264/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -916,31 +981,31 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '67'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 44da57c80f02463e881d92c50c17239c
+      - 82d3c992561448cc87f34e404537d2d6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1ZTgyMWU2LTQzNDQtNGE4
-        OC1iNGNhLTkxNjQyM2MxYmZjZC8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2a202dd5-580d-44c0-a124-4b9861e1e0f2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e85b2921-4aec-493e-b43b-4b50ad708a68/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1026,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1d21ba0d556a4d99ab2df6466ad8b37f
+      - b924c524eb9d4360ae16425dd4a213ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmEyMDJkZDUtNTgw
-        ZC00NGMwLWExMjQtNGI5ODYxZTFlMGYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDQuMjMwMjI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTg1YjI5MjEtNGFl
+        Yy00OTNlLWI0M2ItNGI1MGFkNzA4YTY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MjQuMDMyODYzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MWM4ZGU4NmM2NzU0ODAwOTY3M2Q4MGI0
-        ZDIzOThiZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjA0LjI1
-        OTQ3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MDQuMzIw
-        OTI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3ZGYwMWNiYTc3ZmE0YTQxYmQ4ZjBlYTIz
+        MThmY2NiMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjI0LjA4
+        NDY4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MjQuMTk0
+        MDM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTcyYjU1ZWYtNmY5Yi00ODUz
-        LTllZTUtOWMzZDBlYzZhMWJkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2IyNDZjZDMtYzQyZC00M2Ux
+        LThiMTEtOTZlZjJmYWU1ZmIwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/35e821e6-4344-4a88-b4ca-916423c1bfcd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1013,7 +1078,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1026,72 +1091,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 84319f17b4644c0abb56d73661c8946d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzVlODIxZTYtNDM0
-        NC00YTg4LWI0Y2EtOTE2NDIzYzFiZmNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDQuMzE0MjM0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0NGRhNTdjODBmMDI0NjNlODgxZDkyYzUw
-        YzE3MjM5YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjA0LjM0
-        NTc0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MDQuMzg3
-        ODI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzgzYzJiZmE3LTdhZWQtNDJjNy04NWU1
-        LTdmMjhmMTFiZjI2NC8iXX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1109,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 69bb152b0f62473ca14f71f14efd6d52
+      - b4a4ae1df61d4493af0cf19c6f861bcc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1131,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1144,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1162,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '0989517ad57b4a5c8aaae896500a7d34'
+      - 9094a5890b174165a1228e776bec8a3d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1184,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1197,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1215,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 40cdb185399c4518960c21ede83aafc7
+      - 89a0729eb7c046f8a697ec259dbf43ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1250,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1268,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 78cdb87f1fc74659afb3d97eb2c7e1e8
+      - c1419da2c2d441599f7f61fc2c9284b2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1290,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1303,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1321,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e6fa216484c04d778ef7a87ad37f5a1a
+      - f9dd7c53d8114bedb838673e41ed039a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1343,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1356,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1374,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94d9ed80cd1d4ab8b67a3a6ffabb397a
+      - 2849c3cf89a441f7935d249f28d851c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1398,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1411,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:04 GMT
+      - Fri, 29 Jul 2022 11:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1431,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9bcbf0e45f8a4d1f99d332792ed2c76d
+      - e6db8cdbaccb4d33b76cadd43e6c4b9f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTlhM2ViOGEtMjNjNy00ZGIzLWFkMDEtMGQ0OGE1NjE4NjRkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjc6MDQuNzQ4MzIyWiIsInZl
+        cG0vMGE2OGJkM2MtZDliMS00YjA0LWIzNWItOGE2YTQ1YTJjNjdmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6MjQuNzY2NzEyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTlhM2ViOGEtMjNjNy00ZGIzLWFkMDEtMGQ0OGE1NjE4NjRkL3ZlcnNp
+        cG0vMGE2OGJkM2MtZDliMS00YjA0LWIzNWItOGE2YTQ1YTJjNjdmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85OWEzZWI4YS0y
-        M2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wYTY4YmQzYy1k
+        OWIxLTRiMDQtYjM1Yi04YTZhNDVhMmM2N2YvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1454,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:24 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/c6c55b63-6662-4f54-81be-d32e0fbe9f79/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/311015e3-ba5d-442b-950b-53475229c799/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1474,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1487,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:05 GMT
+      - Fri, 29 Jul 2022 11:28:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1505,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b877db39c264771b06532d006f26ced
+      - 6c4acba6ef5c4bde8e87162745953be2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IxMWVmNjIyLWY1NjYtNDll
-        My1hOWE1LTkyYTRkM2Q4ODJkOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwYmQ2NDBhLTQ2ZWUtNDNi
+        Ni1iNmRkLTkyNDhjZDI5ZjU5Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b11ef622-f566-49e3-a9a5-92a4d3d882d8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/50bd640a-46ee-43b6-b6dd-9248cd29f597/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1540,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:05 GMT
+      - Fri, 29 Jul 2022 11:28:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa8e744b83fc46e6be1eff3020cdbd96
+      - 80058fd1359b4cb3bb293606882086a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjExZWY2MjItZjU2
-        Ni00OWUzLWE5YTUtOTJhNGQzZDg4MmQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDUuMDE3MDEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTBiZDY0MGEtNDZl
+        ZS00M2I2LWI2ZGQtOTI0OGNkMjlmNTk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MjUuMjE4MzczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI2Yjg3N2RiMzljMjY0NzcxYjA2NTMyZDAw
-        NmYyNmNlZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjA1LjA0
-        NjkxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MDUuMDcx
-        NDUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2YzRhY2JhNmVmNWM0YmRlOGU4NzE2Mjc0
+        NTk1M2JlMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjI1LjI4
+        Mzk3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MjUuMzI2
+        MDk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M2YzU1YjYzLTY2NjItNGY1NC04MWJl
-        LWQzMmUwZmJlOWY3OS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzMxMTAxNWUzLWJhNWQtNDQyYi05NTBi
+        LTUzNDc1MjI5Yzc5OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:25 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M2YzU1
-        YjYzLTY2NjItNGY1NC04MWJlLWQzMmUwZmJlOWY3OS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzMxMTAx
+        NWUzLWJhNWQtNDQyYi05NTBiLTUzNDc1MjI5Yzc5OS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1609,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:05 GMT
+      - Fri, 29 Jul 2022 11:28:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1627,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '099808ef2b4a4c1894f2ac2b13dea22b'
+      - eb3afed766aa4b83a0baf7a30e730ea2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiNzZhNTFkLTE1OTctNDc4
-        NC04NGE0LTZjYzAyZDk0YmY1ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3MWU5NzAzLWIwYzUtNDMy
+        Yi04ZWY5LTEwYjBmMGJjMDViYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2b76a51d-1597-4784-84a4-6cc02d94bf5d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c71e9703-b0c5-432b-8ef9-10b0f0bc05ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,90 +1662,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:06 GMT
+      - Fri, 29 Jul 2022 11:28:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 389ddb2b71184773b9d04627aca04728
+      - b254b5f1a2724dae898887953c00bed6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI3NmE1MWQtMTU5
-        Ny00Nzg0LTg0YTQtNmNjMDJkOTRiZjVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDUuMTg1OTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzcxZTk3MDMtYjBj
+        NS00MzJiLThlZjktMTBiMGYwYmMwNWJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MjUuNTM2NDY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwOTk4MDhlZjJiNGE0YzE4OTRm
-        MmFjMmIxM2RlYTIyYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA1LjIxNzA3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDUuOTgxNzY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJlYjNhZmVkNzY2YWE0YjgzYTBi
+        YWY3YTMwZTczMGVhMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjI1LjU4NTE3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MjcuMTYwNDA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
-        IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
-        bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
-        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
-        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
-        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
-        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
-        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        IlBhcnNlZCBNb2R1bGVtZCIsImNvZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxl
+        bWRzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQtZGVm
+        YXVsdHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLm1vZHVsZW1kX2RlZmF1bHRz
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3Vm
+        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBNZXRhZGF0YSBG
+        aWxlcyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5nLm1ldGFkYXRhIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Nywic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJj
+        b2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9
+        LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNz
+        b2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        Om51bGwsImRvbmUiOjQyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzQ2N2YwZjIzLTViNmMtNGViZi1iYzU5LWIwODVh
-        NjdlNzQ1YS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80Njdm
-        MGYyMy01YjZjLTRlYmYtYmM1OS1iMDg1YTY3ZTc0NWEvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYzZjNTViNjMtNjY2Mi00ZjU0
-        LTgxYmUtZDMyZTBmYmU5Zjc5LyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS83MzBkNmFiYy02MjA4LTQ3YzgtODY0MS1jOWJmYjkz
+        ZGU5MDIvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDZh
+        YmMtNjIwOC00N2M4LTg2NDEtYzliZmI5M2RlOTAyLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzMxMTAxNWUzLWJhNWQtNDQyYi05
+        NTBiLTUzNDc1MjI5Yzc5OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:27 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNDY3ZjBmMjMtNWI2Yy00ZWJmLWJjNTktYjA4NWE2N2U3
-        NDVhL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNzMwZDZhYmMtNjIwOC00N2M4LTg2NDEtYzliZmI5M2Rl
+        OTAyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1758,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:06 GMT
+      - Fri, 29 Jul 2022 11:28:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1776,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 50fbe1483f2044e0a15c6ac98f36cf33
+      - d63995f074064a06b1874379017047a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwZDgwNmVmLTY2NjItNDll
-        ZS1hMzM0LWMzMGM0ZDVhOWI4MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3YTIzNzI1LWI5NjMtNGI3
+        MC04MjFiLTUwY2E0ZjY4MTAwYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/60d806ef-6662-49ee-a334-c30c4d5a9b80/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/97a23725-b963-4b70-821b-50ca4f68100c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1811,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:06 GMT
+      - Fri, 29 Jul 2022 11:28:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3cb9766dbcd94a438a928752f3685f32
+      - 63410e0d4a3f4e9e94b722cf7bae877f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjBkODA2ZWYtNjY2
-        Mi00OWVlLWEzMzQtYzMwYzRkNWE5YjgwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDYuMjU2MTc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTdhMjM3MjUtYjk2
+        My00YjcwLTgyMWItNTBjYTRmNjgxMDBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MjcuNjQzMDU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjUwZmJlMTQ4M2YyMDQ0ZTBhMTVjNmFjOThm
-        MzZjZjMzIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6MDYuMjg1
-        ODMwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNzowNi42MDg3
-        MjVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImQ2Mzk5NWYwNzQwNjRhMDZiMTg3NDM3OTAx
+        NzA0N2E3Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MjcuNzAw
+        MDQ5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyODoyOC4zNTE2
+        NDJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZjM1MzBi
-        OWYtYTY0OS00MzBhLTg4MTMtMWZlMjkzMmNmMWY0LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYjVlNmFi
+        ZGItMzU0MC00OTUwLWFiMmEtODc0NTZjZjExZjE0LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNDY3ZjBmMjMtNWI2Yy00ZWJmLWJjNTktYjA4NWE2
-        N2U3NDVhLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNzMwZDZhYmMtNjIwOC00N2M4LTg2NDEtYzliZmI5
+        M2RlOTAyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1868,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +1881,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:06 GMT
+      - Fri, 29 Jul 2022 11:28:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7fa91af3670464ebf384158543d6f3a
+      - 03c562580279415aa4ba1253ec6f4117
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:28 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/b5e6abdb-3540-4950-ab2a-87456cf11f14/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5e8fcf0343d4482c844fca5d9a56666d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYjVlNmFiZGItMzU0MC00OTUwLWFiMmEtODc0NTZjZjExZjE0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6MjcuNzI5ODMxWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83MzBkNmFiYy02MjA4LTQ3YzgtODY0MS1jOWJmYjkzZGU5MDIv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzczMGQ2YWJjLTYyMDgtNDdjOC04NjQxLWM5YmZi
+        OTNkZTkwMi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:28 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9iNWU2YWJkYi0zNTQwLTQ5NTAtYWIyYS04NzQ1NmNmMTFmMTQv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 884be838e51a4362b3e99a085051f996
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4N2FkMDc2LWZhMWMtNDBm
+        Ny1hOGZiLTc5ODAzM2I1MzA5Zi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:28 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/887ad076-fa1c-40f7-a8fb-798033b5309f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 674cf45e548f4cc1adbd2150e389b258
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODg3YWQwNzYtZmEx
+        Yy00MGY3LWE4ZmItNzk4MDMzYjUzMDlmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MjguNjk5MDUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4ODRiZTgzOGU1MWE0MzYyYjNlOTlhMDg1
+        MDUxZjk5NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjI4Ljc0
+        ODA2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6MjkuMTYz
+        NTk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNjE0
+        YWU3OGEtMWQ0OC00N2I0LWE3ZWQtYjllODYxNjg1YjZkLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/614ae78a-1d48-47b4-a7ed-b9e861685b6d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2f7e17ae554b4646b7a014553c823449
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzYxNGFlNzhhLTFkNDgtNDdiNC1hN2VkLWI5ZTg2MTY4NWI2ZC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI4OjI5LjE0MjI3M1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYjVlNmFiZGItMzU0MC00OTUwLWFiMmEt
+        ODc0NTZjZjExZjE0LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - debc0ac1460f4845895dc62942b7bfb5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2217,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2234,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2382,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2395,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2190e67761aa45f58b281f7682a35bb3
+      - e28866e5c46343d6a6a27964f0acaac7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2435,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2456,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2476,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2497,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2518,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2538,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2557,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2570,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd2f161c439744fd971634582e71d931
+      - ab54e4893ba442b5afd7606e376d5ce5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2673,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2691,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2710,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2734,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2752,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2763,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2794,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2805,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2818,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 64670364beb04a30b78d29d423598fee
+      - c5a5b29c1457497ea6e90610fce6ddd6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +2885,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +2897,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +2908,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +2921,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - deddb7f904b4453d8305f110f9b41a78
+      - 659028b2f7ff4dd1a7f5e2430d270361
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +2957,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +2968,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +2981,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa63537303e142a78f6d15fcddc351f8
+      - 5f595663668f410ea68d34138eca474e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3032,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3043,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3056,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 938fb2c5a5d44f559cb0078a2cd07b6e
+      - ae636e39701a4e07b1e41fb68ec010d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2823,10 +3123,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +3134,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2847,35 +3147,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 946d3bf89f004ed993439ac7648520d4
+      - ccabf924cf5044f18bd522628ddf6db3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2914,10 +3214,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2925,7 +3225,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2938,35 +3238,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ccbf11b8474943d5868738922c7f0c3d
+      - e7d7ef71a58e4a9a9bd5b27678577451
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2977,10 +3277,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3288,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3301,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7814fd7c19dc48f987dd2d922be73b9d
+      - 46896d60f76f43cea0240b773a907c49
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3340,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3351,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,37 +3364,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f9655a106d974efc943964d0dcdc064e
+      - 91ce6de403cd44cf812d6ffd1b5b3422
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3105,7 +3405,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3113,10 +3413,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3124,7 +3424,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3137,36 +3437,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9dacf90122004930b3c2f0336ac6371f
+      - 54421af67723485b9e2f7c19f72252c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3188,10 +3488,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3499,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,37 +3512,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4320746cdaa0485891597fd2a4d0680e
+      - 21e0c4b402954bd49a40986c1ad1a339
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3253,12 +3553,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3269,12 +3569,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3285,14 +3585,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3300,7 +3600,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3313,47 +3613,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:07 GMT
+      - Fri, 29 Jul 2022 11:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb627eaa641b4bc3b55865559526b334
+      - 9e93f595baf84d7bbcc520027230c606
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:31 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3363,7 +3663,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,7 +3676,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,32 +3694,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 14922633cd8b4516be50011a11832f65
+      - 2665050324b7407e83f1a2d38d081571
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1Y2E5MDE3LTk4ZWItNDU1
-        MC1iYWFkLWViMTlhN2M0OGQzMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmMzYwYTA2LTBkN2UtNGEz
+        Ni1iOTI2LTc0NjE1NDNjNzU5NC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,7 +3732,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,36 +3750,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 995967d0c5954860801aaab71838a09a
+      - f1d2088d96cb4ef3abd22f68e9cb7af1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkY2MyNWZjLTYwMmQtNDBl
-        OC04ZDA1LTU2ZWI0NzE1ZTc5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE3ZGQ2NmVjLWQ3NjYtNDAz
+        My1iOWExLTBhN2JjYmY3YWVhOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3492,7 +3792,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3510,72 +3810,72 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ade99e19e884367837b46fe26d0efad
+      - 1e2e6e7e2a964dea8d4f59143cabe532
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0MGZkNDM2LTA5YjQtNDMy
-        Zi1hMTc2LTAxNGFkOWI4MTliYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkYzRjYjcyLTc4ZjEtNDFk
+        My04MTU0LTRiNDk5ZTMwZDU1OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY3ZjBmMjMtNWI2Yy00ZWJmLWJj
-        NTktYjA4NWE2N2U3NDVhL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk5YTNlYjhhLTIzYzct
-        NGRiMy1hZDAxLTBkNDhhNTYxODY0ZC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NjNmYmYwMmEtNDI1OS00M2FlLTlhNzYtMTJiZmI4Nzg5NTZmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2Qt
-        NDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1ZC1i
-        ODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRkNGFh
-        Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRlNTYx
-        MGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04
-        Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNlYzY5
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5YTY1
-        ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05
-        M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZh
-        ZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01Yjcx
-        LTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlm
-        OGU2NWMwZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        M2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1
-        ZDItODU2MC1jNzBhZjkxMzdjY2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTli
-        ZDQ4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIy
-        NTE3MzgtNmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQzZC03NDg3LTRhNzYt
-        ODUzMi03ZDdjZDlkZTg5OGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2U0ZTNiODZlLWZhNDQtNGI2Ni1hZWFkLWZmODUwYjkyNmU1
-        Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9m
-        aWxlcy9mNDdhM2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDZhYmMtNjIwOC00N2M4LTg2
+        NDEtYzliZmI5M2RlOTAyL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBhNjhiZDNjLWQ5YjEt
+        NGIwNC1iMzViLThhNmE0NWEyYzY3Zi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8zOWI0ZTRmNy1kNzdjLTQwNjYtOTJkMC05NTBmZjBl
+        MmJlNjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        YWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYyYWIt
+        NGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdhYi1h
+        NTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQyOTI5
+        My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1ZWE3
+        ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1h
+        ZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFkMTkx
+        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1
+        ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgxNS04
+        OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFj
+        YmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMtNGFjYy05ZTE5LTg0Yjlj
+        NDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUzNC0wZjE0LTRl
+        NDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAxYy1hZmU1LTU4NWIyOTkz
+        N2M1Ni8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTcy
+        MjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAt
+        YmQyYi05MDMzNmRkMzBjNGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2E3MjQwZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIw
+        ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9m
+        aWxlcy80YWJmNTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19
         XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3588,7 +3888,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3606,21 +3906,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da538635ea8c47c68894f378928ea3c6
+      - a7d974b7e964428fae33ebe85e317e6f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5ODRlODMxLTQ5ZTUtNDJh
-        Zi1hZGIyLTJjMTdlNWI5N2ZlZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4MDQyYWJiLWU0NTItNGMz
+        ZS05ZTg0LTg0Njk1NGQwYjM1My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/65ca9017-98eb-4550-baad-eb19a7c48d33/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7f360a06-0d7e-4a36-b926-7461543c7594/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3641,51 +3941,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4daf90c244ef431aa5e954a922bafc12
+      - 9ce9ade433dd415fa89aae481f0fe71d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjVjYTkwMTctOThl
-        Yi00NTUwLWJhYWQtZWIxOWE3YzQ4ZDMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMDE1OTU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2YzNjBhMDYtMGQ3
+        ZS00YTM2LWI5MjYtNzQ2MTU0M2M3NTk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMDE3NDI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNDkyMjYzM2NkOGI0NTE2YmU1
-        MDAxMWExMTgzMmY2NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjA1MTQyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguMTgxODgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyNjY1MDUwMzI0Yjc0MDdlODNm
+        MWEyZDM4ZDA4MTU3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjA3Njc3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzIuNDAyMjc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNj
-        Ny00ZGIzLWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDli
+        MS00YjA0LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/65ca9017-98eb-4550-baad-eb19a7c48d33/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7f360a06-0d7e-4a36-b926-7461543c7594/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3706,51 +4006,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e436bc05484c44f4887d8140f720f718
+      - 76966d05dd374788a27f930c561737ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjVjYTkwMTctOThl
-        Yi00NTUwLWJhYWQtZWIxOWE3YzQ4ZDMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMDE1OTU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2YzNjBhMDYtMGQ3
+        ZS00YTM2LWI5MjYtNzQ2MTU0M2M3NTk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMDE3NDI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNDkyMjYzM2NkOGI0NTE2YmU1
-        MDAxMWExMTgzMmY2NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjA1MTQyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguMTgxODgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyNjY1MDUwMzI0Yjc0MDdlODNm
+        MWEyZDM4ZDA4MTU3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjA3Njc3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzIuNDAyMjc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNj
-        Ny00ZGIzLWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDli
+        MS00YjA0LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cdcc25fc-602d-40e8-8d05-56eb4715e799/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/17dd66ec-d766-4033-b9a1-0a7bcbf7aea9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3771,53 +4071,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 770a996010434085bed4ac5dcd116fd4
+      - cf2dab8020204159830790d65a1bd811
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2RjYzI1ZmMtNjAy
-        ZC00MGU4LThkMDUtNTZlYjQ3MTVlNzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMDcxNzE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdkZDY2ZWMtZDc2
+        Ni00MDMzLWI5YTEtMGE3YmNiZjdhZWE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMTEzNjI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5OTU5NjdkMGM1OTU0ODYwODAx
-        YWFhYjcxODM4YTA5YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjIxNzQyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguMzQ0NjM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmMWQyMDg4ZDk2Y2I0ZWYzYWJk
+        MjJmNjhlOWNiN2FmMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjQ2ODc4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzIuNzQ2NjI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS85OWEzZWI4YS0yM2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQvdmVyc2lv
+        bS8wYTY4YmQzYy1kOWIxLTRiMDQtYjM1Yi04YTZhNDVhMmM2N2YvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNjNy00ZGIz
-        LWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDliMS00YjA0
+        LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e40fd436-09b4-432f-a176-014ad9b819bc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7f360a06-0d7e-4a36-b926-7461543c7594/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3838,118 +4138,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7fe73f301d594dfa94942a5f03b7bed4
+      - e285261c5fe74caa98a2f0f2335ed1c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTQwZmQ0MzYtMDli
-        NC00MzJmLWExNzYtMDE0YWQ5YjgxOWJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMTIzOTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2YzNjBhMDYtMGQ3
+        ZS00YTM2LWI5MjYtNzQ2MTU0M2M3NTk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMDE3NDI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYWRlOTllMTllODg0MzY3ODM3
-        YjQ2ZmUyNmQwZWZhZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjM3Nzg0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguNTA2MTA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS85OWEzZWI4YS0yM2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQvdmVyc2lv
-        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNjNy00ZGIz
-        LWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/65ca9017-98eb-4550-baad-eb19a7c48d33/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:27:08 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 76b0c28e3bcd42ada4a458d7e90177ae
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjVjYTkwMTctOThl
-        Yi00NTUwLWJhYWQtZWIxOWE3YzQ4ZDMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMDE1OTU4WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNDkyMjYzM2NkOGI0NTE2YmU1
-        MDAxMWExMTgzMmY2NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjA1MTQyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguMTgxODgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyNjY1MDUwMzI0Yjc0MDdlODNm
+        MWEyZDM4ZDA4MTU3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjA3Njc3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzIuNDAyMjc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNj
-        Ny00ZGIzLWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDli
+        MS00YjA0LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cdcc25fc-602d-40e8-8d05-56eb4715e799/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/17dd66ec-d766-4033-b9a1-0a7bcbf7aea9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3970,53 +4203,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5464658ff09e4fba893729cb43479a49
+      - 2013482a9ca9464dbd9b69ef3ae63d58
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2RjYzI1ZmMtNjAy
-        ZC00MGU4LThkMDUtNTZlYjQ3MTVlNzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMDcxNzE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdkZDY2ZWMtZDc2
+        Ni00MDMzLWI5YTEtMGE3YmNiZjdhZWE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMTEzNjI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5OTU5NjdkMGM1OTU0ODYwODAx
-        YWFhYjcxODM4YTA5YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjIxNzQyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguMzQ0NjM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmMWQyMDg4ZDk2Y2I0ZWYzYWJk
+        MjJmNjhlOWNiN2FmMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjQ2ODc4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzIuNzQ2NjI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS85OWEzZWI4YS0yM2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQvdmVyc2lv
+        bS8wYTY4YmQzYy1kOWIxLTRiMDQtYjM1Yi04YTZhNDVhMmM2N2YvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNjNy00ZGIz
-        LWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDliMS00YjA0
+        LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e40fd436-09b4-432f-a176-014ad9b819bc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/edc4cb72-78f1-41d3-8154-4b499e30d559/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4037,53 +4270,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8780a2791f004b6e980eb974a11a5659
+      - 4c116c8bfd9f48ed920b4deb53c1be9f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTQwZmQ0MzYtMDli
-        NC00MzJmLWExNzYtMDE0YWQ5YjgxOWJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMTIzOTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWRjNGNiNzItNzhm
+        MS00MWQzLTgxNTQtNGI0OTllMzBkNTU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMjEzOTA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYWRlOTllMTllODg0MzY3ODM3
-        YjQ2ZmUyNmQwZWZhZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjM3Nzg0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguNTA2MTA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxZTJlNmU3ZTJhOTY0ZGVhOGQ0
+        ZjU5MTQzY2FiZTUzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjc5ODE4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzMuMDcxMTg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS85OWEzZWI4YS0yM2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQvdmVyc2lv
+        bS8wYTY4YmQzYy1kOWIxLTRiMDQtYjM1Yi04YTZhNDVhMmM2N2YvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNjNy00ZGIz
-        LWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDliMS00YjA0
+        LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/65ca9017-98eb-4550-baad-eb19a7c48d33/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7f360a06-0d7e-4a36-b926-7461543c7594/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4104,51 +4337,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 872bb969b19e4f72be5a6c5ff7f6e448
+      - 1bdf4d955e2046969f9a032e2cd9c3f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjVjYTkwMTctOThl
-        Yi00NTUwLWJhYWQtZWIxOWE3YzQ4ZDMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMDE1OTU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2YzNjBhMDYtMGQ3
+        ZS00YTM2LWI5MjYtNzQ2MTU0M2M3NTk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMDE3NDI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNDkyMjYzM2NkOGI0NTE2YmU1
-        MDAxMWExMTgzMmY2NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjA1MTQyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguMTgxODgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyNjY1MDUwMzI0Yjc0MDdlODNm
+        MWEyZDM4ZDA4MTU3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjA3Njc3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzIuNDAyMjc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNj
-        Ny00ZGIzLWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDli
+        MS00YjA0LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cdcc25fc-602d-40e8-8d05-56eb4715e799/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/17dd66ec-d766-4033-b9a1-0a7bcbf7aea9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4169,53 +4402,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:08 GMT
+      - Fri, 29 Jul 2022 11:28:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 759dc7dc3b8c4c2b9b8915c428a12c40
+      - 9b1ee20a1d484c45a4f25163b65eb987
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2RjYzI1ZmMtNjAy
-        ZC00MGU4LThkMDUtNTZlYjQ3MTVlNzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMDcxNzE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdkZDY2ZWMtZDc2
+        Ni00MDMzLWI5YTEtMGE3YmNiZjdhZWE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMTEzNjI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5OTU5NjdkMGM1OTU0ODYwODAx
-        YWFhYjcxODM4YTA5YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjIxNzQyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguMzQ0NjM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmMWQyMDg4ZDk2Y2I0ZWYzYWJk
+        MjJmNjhlOWNiN2FmMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjQ2ODc4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzIuNzQ2NjI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS85OWEzZWI4YS0yM2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQvdmVyc2lv
+        bS8wYTY4YmQzYy1kOWIxLTRiMDQtYjM1Yi04YTZhNDVhMmM2N2YvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNjNy00ZGIz
-        LWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDliMS00YjA0
+        LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e40fd436-09b4-432f-a176-014ad9b819bc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/edc4cb72-78f1-41d3-8154-4b499e30d559/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4236,53 +4469,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ade61b0ecaef4cd7908ddc09783e2183
+      - f1279a6762774ef3bf5212b94f266c00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTQwZmQ0MzYtMDli
-        NC00MzJmLWExNzYtMDE0YWQ5YjgxOWJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMTIzOTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWRjNGNiNzItNzhm
+        MS00MWQzLTgxNTQtNGI0OTllMzBkNTU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMjEzOTA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYWRlOTllMTllODg0MzY3ODM3
-        YjQ2ZmUyNmQwZWZhZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3
-        OjA4LjM3Nzg0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjc6
-        MDguNTA2MTA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxZTJlNmU3ZTJhOTY0ZGVhOGQ0
+        ZjU5MTQzY2FiZTUzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjMyLjc5ODE4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        MzMuMDcxMTg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS85OWEzZWI4YS0yM2M3LTRkYjMtYWQwMS0wZDQ4YTU2MTg2NGQvdmVyc2lv
+        bS8wYTY4YmQzYy1kOWIxLTRiMDQtYjM1Yi04YTZhNDVhMmM2N2YvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2ViOGEtMjNjNy00ZGIz
-        LWFkMDEtMGQ0OGE1NjE4NjRkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJkM2MtZDliMS00YjA0
+        LWIzNWItOGE2YTQ1YTJjNjdmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0984e831-49e5-42af-adb2-2c17e5b97fed/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/88042abb-e452-4c3e-9e84-846954d0b353/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4303,55 +4536,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d3e53e7caf2b4355b1981e9006b8d4b7
+      - 9a9819f7eb9d4cf099a7fdfd3246ebd7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDk4NGU4MzEtNDll
-        NS00MmFmLWFkYjItMmMxN2U1Yjk3ZmVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjc6MDguMTczNTEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODgwNDJhYmItZTQ1
+        Mi00YzNlLTllODQtODQ2OTU0ZDBiMzUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6MzIuMzI2MjM0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiZGE1Mzg2MzVlYThjNDdjNjg4OTRmMzc4OTI4
-        ZWEzYzYiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNzowOC41Mzkw
-        NjBaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI3OjA4Ljk4ODc5
-        MloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiYTdkOTc0YjdlOTY0NDI4ZmFlMzNlYmU4NWUz
+        MTdlNmYiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyODozMy4xMzUy
+        MDNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjM0LjAyNDc2
+        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTlhM2Vi
-        OGEtMjNjNy00ZGIzLWFkMDEtMGQ0OGE1NjE4NjRkL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGE2OGJk
+        M2MtZDliMS00YjA0LWIzNWItOGE2YTQ1YTJjNjdmL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzk5YTNlYjhhLTIzYzctNGRiMy1hZDAxLTBk
-        NDhhNTYxODY0ZC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzQ2N2YwZjIzLTViNmMtNGViZi1iYzU5LWIwODVhNjdlNzQ1
-        YS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzBhNjhiZDNjLWQ5YjEtNGIwNC1iMzViLThh
+        NmE0NWEyYzY3Zi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzczMGQ2YWJjLTYyMDgtNDdjOC04NjQxLWM5YmZiOTNkZTkw
+        Mi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4359,7 +4592,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4372,64 +4605,64 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1196'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1bb61c3f362d4f5a99e542f6c6588639
+      - e86c11df7cea4edb9b051130a50d82ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '428'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTMsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8wYTc1Y2I2NS04NzMxLTRhYzMtYjRkNy02ZTY3ZTU5M2VkMzMvIn0s
+        YWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQyYi05MDMzNmRkMzBjNGMvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyJ9LHsi
+        ZXMvOWVjYTM4YTItNzhkZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFjOTY2MjVkZmYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGY0
-        YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5ZGU4OThmLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI5ZTZh
-        MjFkLTJmNjktNGNkMi1iNzExLTYxY2M4OWNmNzBjZS8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NjUyMjg4
-        MC04YzVhLTQ4MDEtYjU2Ny0xZjJiMWRiNzNkZWMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEt
-        ZmFlMi00NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTVi
-        NzEtNDE1NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2Ex
-        LTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00
-        YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyJ9XX0=
+        L2QxYzc5OWE2LWY3NjYtNDU4Ni1hMTliLTI0YzJmYmUzNzFmYy8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        OWU4M2FkNi0yNDI0LTRiOTAtODFlOS0zYTViMWFkODRhMjQvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJh
+        NDllMzQtMGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzVhMzI4
+        NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVjMTBkNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhj
+        MS1iNmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVmMmUt
+        YjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEw
+        ZmMtNDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEz
+        LTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00
+        MWQxLWE4ZGYtZmQ4NDNhN2VkNWE4LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4437,7 +4670,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4450,50 +4683,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 426f6739684346b98e828087e512a3ed
+      - 25a294380699413cb8add313c857787c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4501,7 +4734,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4514,37 +4747,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6131'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7de01002f3e4b7ca1635b715d7e473c
+      - 84bfd87608454fc2be880f41806f2d9a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1830'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4617,9 +4850,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -4636,9 +4869,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -4647,9 +4880,9 @@ http_interactions:
         c29sdXRpb24iOiIiLCJyZWxlYXNlIjoiMSIsInJpZ2h0cyI6IiIsInB1c2hj
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvNjNmYmYwMmEtNDI1OS00M2FlLTlh
-        NzYtMTJiZmI4Nzg5NTZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNU
-        MjM6MjY6NTguMjM4MjM3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
+        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvZWE1ZjA0NjItNjJhYi00YzFmLWE2
+        NGQtYjkxZDA2YzQ1YjZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhU
+        MTU6MDQ6MzQuMjcyMTg0WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
         OSIsInVwZGF0ZWRfZGF0ZSI6IjIwMTgtMDctMjAgMDY6MDA6MDEiLCJkZXNj
         cmlwdGlvbiI6IkR1Y2tfS2FuZ2Fyb19FcnJhdHVtIGRlc2NyaXB0aW9uIiwi
         aXNzdWVkX2RhdGUiOiIyMDE4LTAxLTI3IDE2OjA4OjA5IiwiZnJvbXN0ciI6
@@ -4678,10 +4911,10 @@ http_interactions:
         biI6IjAuNyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3Rl
         ZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4689,7 +4922,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4702,43 +4935,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd1b6149caf34c198b383069bd2d1dd3
+      - 055d01f1966741528202f0ec5e2d9c23
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4746,7 +4979,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4759,41 +4992,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08101da00b3a4132b60e127cbb0738cc'
+      - d7c52016c1a74bd89dc0cdcbcb619679
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4801,7 +5034,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4814,36 +5047,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 743d04b886bb4ad9a55752f565035562
+      - e0a81e0060f740a0996cb251bc40c6b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4865,10 +5098,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/467f0f23-5b6c-4ebf-bc59-b085a67e745a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/730d6abc-6208-47c8-8641-c9bfb93de902/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4876,7 +5109,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4889,47 +5122,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22853cb9e95f40538fe40bea10213628
+      - dbc83946b1104aee9982bd19d0238514
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/99a3eb8a-23c7-4db3-ad01-0d48a561864d/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0a68bd3c-d9b1-4b04-b35b-8a6a45a2c67f/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4937,7 +5170,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4950,42 +5183,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:27:09 GMT
+      - Fri, 29 Jul 2022 11:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 52d86c51b9bc43ba8252b1af844543b8
+      - 337a382a17184d2a99449d22b50d466b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:27:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:35 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_groups_repository/all_package_groups_copied_with_no_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_groups_repository/all_package_groups_copied_with_no_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,27 +35,94 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 26ff48a84bb3488c9b0c326c9ece5c5a
+      - 335823521aea4a7997754e5c78d45b30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80MzI1OTYzNi0xNzA4LTQxYzYtYWFkZC0wYTEyMzE5NzhhNzMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNTowMy4yNTQ1MTBa
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80MzI1OTYzNi0xNzA4LTQxYzYtYWFkZC0wYTEyMzE5NzhhNzMv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQzMjU5
+        NjM2LTE3MDgtNDFjNi1hYWRkLTBhMTIzMTk3OGE3My92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
+        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
+        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
+        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
+        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
+        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
+        ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - de3f119fc34b40caa7fa7e92c4288817
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJlNzkzMTVmLThiNWUtNDYx
+        NC1hZDYxLTAxZmMzMjU2YTBlMC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e5930b067a024544aeb0e7282b32a4c3
+      - eda1aa5310ea4c9894e8a0bd6bcb7c3a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2e79315f-8b5e-4614-ad61-01fc3256a0e0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -137,31 +204,43 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '00648bd07f42420db2ad70e2658be240'
+      - ff1818305a4c434294281ee1f8633919
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmU3OTMxNWYtOGI1
+        ZS00NjE0LWFkNjEtMDFmYzMyNTZhMGUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTQuMTgwNDA1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZTNmMTE5ZmMzNGI0MGNhYTdmYTdlOTJj
+        NDI4ODgxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjE0LjIy
+        NDY2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MTQuNDU3
+        ODU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDMyNTk2MzYtMTcwOC00MWM2
+        LWFhZGQtMGExMjMxOTc4YTczLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c75b130c79a243c8a3ffc95b904efc4e
+      - 6b0b54474ae843b492aa8e873fe09924
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -222,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -235,7 +314,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -247,27 +326,88 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '448'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ad0e1bb21a54a598b3719fd3e6048cc
+      - 5506defd27e143d0b99adf82330b8a72
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vN2I2ZTY1MzItYmI0ZS00MWMxLWIyNTYtNTI2MDUxMjViNmRj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MDcuNzA5NTQ4
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/7b6e6532-bb4e-41c1-b256-52605125b6dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6d7849dd4412420bbbc9f6f61f00c74d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1NDkwNjBiLTAyODUtNDhl
+        My1hNzFlLTAyYzJkNDVjMWNjNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2549060b-0285-48e3-a71e-02c2d45c1cc4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -275,7 +415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -288,7 +428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -296,31 +436,42 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 89017a489749427f9fd3546d68ac635e
+      - e091c21d4f214e77bc823a7f7bfda591
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjU0OTA2MGItMDI4
+        NS00OGUzLWE3MWUtMDJjMmQ0NWMxY2M0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTQuNjEzNTg3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZDc4NDlkZDQ0MTI0MjBiYmJjOWY2ZjYx
+        ZjAwYzc0ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjE0LjY1
+        MDU5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MTQuNjk0
+        NjQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -328,7 +479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -341,7 +492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -359,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46c099d34c61483a9161ac17bb9979d3
+      - 61b283d978a54965817bdb3c86097f62
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -381,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -412,21 +563,127 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e61ecc6397914b9294e67d6622c69b03
+      - ee437745930047ae9d07ef5864e618af
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4f64d292b9aa4c70853fd181e4de2d41
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:14 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e68a064006c24af0a8e567e1cda36707
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -443,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -456,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/54ff9e84-2726-4715-a85c-314616180cc9/"
+      - "/pulp/api/v3/remotes/rpm/rpm/ebdd3c95-35a5-4ed0-a2fc-b40480c684b1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -476,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f8d08ac69de45799547134073f95be8
+      - 893e2b306c1444cdb26ed413a940269d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0
-        ZmY5ZTg0LTI3MjYtNDcxNS1hODVjLTMxNDYxNjE4MGNjOS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI5OjA0LjMyODQ2MVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Vi
+        ZGQzYzk1LTM1YTUtNGVkMC1hMmZjLWI0MDQ4MGM2ODRiMS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM1OjE1LjEyNjE2OFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI5OjA0LjMyODQ4MVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjM1OjE1LjEyNjE4N1oiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -511,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -524,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -544,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d102dda176e04f09b9d65fb8e54b9766
+      - eb75ebf808c543089580106b56987b65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzgzMTk5NGMtY2RjNi00NjM2LThiNDYtYzY2MTg4YTMxNzc2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MDQuNDQ2MjY4WiIsInZl
+        cG0vZTE5NjI3ZmEtOWNkNi00ODg5LWJkMzYtZGQ5MDk2ODhkOTA1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MTUuMjgzMzU1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzgzMTk5NGMtY2RjNi00NjM2LThiNDYtYzY2MTg4YTMxNzc2L3ZlcnNp
+        cG0vZTE5NjI3ZmEtOWNkNi00ODg5LWJkMzYtZGQ5MDk2ODhkOTA1L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zODMxOTk0Yy1j
-        ZGM2LTQ2MzYtOGI0Ni1jNjYxODhhMzE3NzYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMTk2MjdmYS05
+        Y2Q2LTQ4ODktYmQzNi1kZDkwOTY4OGQ5MDUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -568,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -579,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -592,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 84e4a11079da4ac28ec80a038d885ef3
+      - 0714efc6bdeb497389a66e971c095b3c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82ZjkzYTdhNi1lZDU2LTRjNWQtOTdkOS04MmQzY2RiYTJhYWIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyODoyMC42OTEzNTVa
+        cnBtL3JwbS9lZjk4Y2U0Ni0zZDkwLTRhNGUtOWJmNC1hZWE5Y2ZkMWRhODUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNTowNC4xOTQ0MjBa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82ZjkzYTdhNi1lZDU2LTRjNWQtOTdkOS04MmQzY2RiYTJhYWIv
+        cnBtL3JwbS9lZjk4Y2U0Ni0zZDkwLTRhNGUtOWJmNC1hZWE5Y2ZkMWRhODUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzZmOTNh
-        N2E2LWVkNTYtNGM1ZC05N2Q5LTgyZDNjZGJhMmFhYi92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2VmOThj
+        ZTQ2LTNkOTAtNGE0ZS05YmY0LWFlYTljZmQxZGE4NS92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -634,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/6f93a7a6-ed56-4c5d-97d9-82d3cdba2aab/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -645,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -658,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -676,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1d479f44d0e84e8cbd71a0ca0386a790
+      - 2a00c3eb12d241fbbd18362045fe265c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RiNDA0N2ZjLTJiMWYtNGFl
-        Zi1hMzY2LWFlODYwYmYxYzcxZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU3NTY0NDMwLTNjZTUtNGM5
+        NS1hNzM2LTRmMGY2ZTcyZmIzMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -698,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -711,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e3a8caa8559249b5af0f82a99df21181
+      - a91a1b92cc364339b031755494effd51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vODhkZDg0MTMtYzdkMy00ZjNhLTliMTgtOTRhOWZhNjJjOGE4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6MTkuOTExNjAwWiIsIm5h
+        cG0vOTgwMDRjNDMtN2U5OS00N2M5LTg3MjEtOWRiZmY0MTU0OTdkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MDMuMTEzOTQyWiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyODoyMS4wMjI3ODVaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozNTowNC42Nzc2MzdaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/88dd8413-c7d3-4f3a-9b18-94a9fa62c8a8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/98004c43-7e99-47c9-8721-9dbff415497d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -763,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -776,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -794,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1c677aad799460283dbf032269431e6
+      - 5c648a962dd345b4a43886ff48a9c045
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4YjUyOGFiLWVlNjktNGVh
-        Ny1hYzVhLTAyNGMzMjY3MDRlMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkM2FjYjQzLTczZTktNDIx
+        OC04MzBkLWJlMTEwNTRlZGU1MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/db4047fc-2b1f-4aef-a366-ae860bf1c71e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/57564430-3ce5-4c95-a736-4f0f6e72fb33/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -829,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e6e0a43877dc4785986d676af42438c5
+      - e5e78e77a6314e3492fe8f52d371b736
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGI0MDQ3ZmMtMmIx
-        Zi00YWVmLWEzNjYtYWU4NjBiZjFjNzFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDQuNTk3OTA4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTc1NjQ0MzAtM2Nl
+        NS00Yzk1LWE3MzYtNGYwZjZlNzJmYjMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTUuNTIwNzk4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxZDQ3OWY0NGQwZTg0ZThjYmQ3MWEwY2Ew
-        Mzg2YTc5MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjA0LjYy
-        OTUwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDQuNjk4
-        MzA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyYTAwYzNlYjEyZDI0MWZiYmQxODM2MjA0
+        NWZlMjY1YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjE1LjU3
+        Mzc0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MTUuNjgx
+        OTQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNmY5M2E3YTYtZWQ1Ni00YzVk
-        LTk3ZDktODJkM2NkYmEyYWFiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5MC00YTRl
+        LTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b8b528ab-ee69-4ea7-ac5a-024c326704e3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2d3acb43-73e9-4218-830d-be11054ede51/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -894,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6d5954ad83b7495dacf934920e22f17f
+      - e128c941e6994dfbb96b748cb8ac4979
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjhiNTI4YWItZWU2
-        OS00ZWE3LWFjNWEtMDI0YzMyNjcwNGUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDQuNjg4NTI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQzYWNiNDMtNzNl
+        OS00MjE4LTgzMGQtYmUxMTA1NGVkZTUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTUuNjU4NDMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMWM2NzdhYWQ3OTk0NjAyODNkYmYwMzIy
-        Njk0MzFlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjA0Ljcy
-        NTE0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDQuNzcx
-        NDE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1YzY0OGE5NjJkZDM0NWI0YTQzODg2ZmY0
+        OGE5YzA0NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjE1Ljcw
+        OTg1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MTUuNzY2
+        MzM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg4ZGQ4NDEzLWM3ZDMtNGYzYS05YjE4
-        LTk0YTlmYTYyYzhhOC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4MDA0YzQzLTdlOTktNDdjOS04NzIx
+        LTlkYmZmNDE1NDk3ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -946,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -959,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -977,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea02a04d861943149c1a0b9ffb2a437d
+      - 6a068d4377af4283ab9927fd73a248e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -999,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1012,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1030,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d0e0d717bca44ee92dcdb9afebe2724
+      - 02553c640276406499cfb534b8f11d8f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1065,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1083,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8787445311f400fb19c9ae344daa4cf
+      - ca0ca1eec0fb40a0b83ffd31da884128
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1105,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1118,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1136,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b7b109f2d5fa43d69173f7c82251a586
+      - be888ea998144e099001a307d46068eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1158,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1171,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1189,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7804fb8ac22b45a1b9d2b994dfaf405e
+      - a4e2ff6946484c7583fd00d492a83416
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1211,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1224,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:04 GMT
+      - Fri, 29 Jul 2022 11:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1242,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9b0dbe0785e041b3a9abf84d6c6c23a6
+      - e638a2692a2f43ce8502336017928881
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:16 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1266,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1279,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:05 GMT
+      - Fri, 29 Jul 2022 11:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/"
+      - "/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1299,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ece5f22945954376b5905220cfffc117
+      - 6b59231c97244252924f03956221061b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmRhM2EwNTctODFlMS00NWViLWIwNzktZWM4YWU5ZDNmNDExLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MDUuMTI0OTc3WiIsInZl
+        cG0vNzI4ZDJmYTYtMDE1Ny00YzNlLTgxMzUtZTljZGI2NDhiNjU5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MTYuMjM5Mjg2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmRhM2EwNTctODFlMS00NWViLWIwNzktZWM4YWU5ZDNmNDExL3ZlcnNp
+        cG0vNzI4ZDJmYTYtMDE1Ny00YzNlLTgxMzUtZTljZGI2NDhiNjU5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZGEzYTA1Ny04
-        MWUxLTQ1ZWItYjA3OS1lYzhhZTlkM2Y0MTEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MjhkMmZhNi0w
+        MTU3LTRjM2UtODEzNS1lOWNkYjY0OGI2NTkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1322,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:16 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/54ff9e84-2726-4715-a85c-314616180cc9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/ebdd3c95-35a5-4ed0-a2fc-b40480c684b1/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1342,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1355,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:05 GMT
+      - Fri, 29 Jul 2022 11:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1373,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b9f02267b8d646d2ad166e8e355b5767
+      - d074437884044e178a591d652291a2b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjYTY1OWFjLTk4YzItNDMy
-        Zi05ZTE3LTJiNjU5MTVkMDQ1Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3MjRjMWZiLWMwMTAtNDVm
+        NC04NDE3LTdhZThhNDc4ZjA1Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8ca659ac-98c2-432f-9e17-2b65915d045c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b724c1fb-c010-45f4-8417-7ae8a478f05b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1408,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:05 GMT
+      - Fri, 29 Jul 2022 11:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 954b256e902a45038921bd0f6c4dc7b6
+      - d24eddc4ef1f4214991dc856f199e916
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGNhNjU5YWMtOThj
-        Mi00MzJmLTllMTctMmI2NTkxNWQwNDVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDUuNDIxMDY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjcyNGMxZmItYzAx
+        MC00NWY0LTg0MTctN2FlOGE0NzhmMDViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTYuNTk1MDgzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJiOWYwMjI2N2I4ZDY0NmQyYWQxNjZlOGUz
-        NTViNTc2NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjA1LjQ3
-        NDk5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDUuNDk5
-        MjMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkMDc0NDM3ODg0MDQ0ZTE3OGE1OTFkNjUy
+        MjkxYTJiOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjE2LjY0
+        MzIzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MTYuNjc0
+        MjM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0ZmY5ZTg0LTI3MjYtNDcxNS1hODVj
-        LTMxNDYxNjE4MGNjOS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ViZGQzYzk1LTM1YTUtNGVkMC1hMmZj
+        LWI0MDQ4MGM2ODRiMS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:16 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0ZmY5
-        ZTg0LTI3MjYtNDcxNS1hODVjLTMxNDYxNjE4MGNjOS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ViZGQz
+        Yzk1LTM1YTUtNGVkMC1hMmZjLWI0MDQ4MGM2ODRiMS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1477,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:05 GMT
+      - Fri, 29 Jul 2022 11:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1495,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 759c48a178a244609e5440a06c4d92da
+      - b03dafc805614defbedfc09d32514a64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiZmQ4OTRlLTExYjQtNDAy
-        Mi1hYTljLTI0YjAwOTY3NDE4My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhMjhkNzlhLTY4MmMtNGMz
+        ZS1hMTFmLTlmODlkOGM5ZGYxYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8bfd894e-11b4-4022-aa9c-24b009674183/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2a28d79a-682c-4c3e-a11f-9f89d8c9df1c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1530,90 +1787,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:06 GMT
+      - Fri, 29 Jul 2022 11:35:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d2e6c45b8718487ea056d9b7233ade59
+      - d4bc5fc736d147c2a40b808948d1f528
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '656'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGJmZDg5NGUtMTFi
-        NC00MDIyLWFhOWMtMjRiMDA5Njc0MTgzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDUuNjUxMzE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmEyOGQ3OWEtNjgy
+        Yy00YzNlLWExMWYtOWY4OWQ4YzlkZjFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTYuODMyMzM5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI3NTljNDhhMTc4YTI0NDYwOWU1
-        NDQwYTA2YzRkOTJkYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjA1LjY4MDgwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MDYuNDgyNzAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJiMDNkYWZjODA1NjE0ZGVmYmVk
+        ZmMwOWQzMjUxNGE2NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjE2Ljg2OTAxN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTcuODg0MDU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
-        cnNlZCBNb2R1bGVtZCIsImNvZGUiOiJzeW5jLnBhcnNpbmcubW9kdWxlbWRz
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3Vm
-        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgTW9kdWxlbWQtZGVmYXVs
-        dHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLm1vZHVsZW1kX2RlZmF1bHRzIiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
-        c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiUGFyc2VkIENvbXBzIiwiY29kZSI6InN5bmMucGFyc2luZy5jb21wcyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRl
-        ZCIsInRvdGFsIjo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
-        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4t
-        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNv
-        bnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25l
-        IjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjQyLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzM4MzE5OTRjLWNkYzYtNDYzNi04YjQ2LWM2NjE4
-        OGEzMTc3Ni92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zODMx
-        OTk0Yy1jZGM2LTQ2MzYtOGI0Ni1jNjYxODhhMzE3NzYvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNTRmZjllODQtMjcyNi00NzE1
-        LWE4NWMtMzE0NjE2MTgwY2M5LyJdfQ==
+        IjpudWxsLCJkb25lIjo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NDIsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIE1vZHVsZW1kIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo2LCJkb25lIjo2LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlBhcnNlZCBNb2R1bGVtZC1kZWZhdWx0cyIsImNvZGUiOiJzeW5jLnBhcnNp
+        bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9lMTk2MjdmYS05Y2Q2LTQ4ODktYmQzNi1kZDkwOTY4
+        OGQ5MDUvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTE5NjI3
+        ZmEtOWNkNi00ODg5LWJkMzYtZGQ5MDk2ODhkOTA1LyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ViZGQzYzk1LTM1YTUtNGVkMC1h
+        MmZjLWI0MDQ4MGM2ODRiMS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMzgzMTk5NGMtY2RjNi00NjM2LThiNDYtYzY2MTg4YTMx
-        Nzc2L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZTE5NjI3ZmEtOWNkNi00ODg5LWJkMzYtZGQ5MDk2ODhk
+        OTA1L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1626,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:06 GMT
+      - Fri, 29 Jul 2022 11:35:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1644,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 04f3de9568154640bccaa4ad3ae8fc32
+      - 4d0741199ce9404b9ac897db779d6289
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjYTM0NDE5LTJhYzctNDJk
-        Yy1hZDc3LTliNDQ1ZWFjMTkzYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1MTYzMWVmLWJiNDMtNDE0
+        Ni05ZGU3LTVjOWNkMzdmZTQ2MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:06 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/aca34419-2ac7-42dc-ad77-9b445eac193c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/151631ef-bb43-4146-9de7-5c9cd37fe461/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1679,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:07 GMT
+      - Fri, 29 Jul 2022 11:35:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6eb084a6ecc3437bae9d02d681b5cf53
+      - 85977b291b904269accd4cf9d199a98e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWNhMzQ0MTktMmFj
-        Ny00MmRjLWFkNzctOWI0NDVlYWMxOTNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDYuNzk1NDI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTUxNjMxZWYtYmI0
+        My00MTQ2LTlkZTctNWM5Y2QzN2ZlNDYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTguMzE5MDg0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjA0ZjNkZTk1NjgxNTQ2NDBiY2NhYTRhZDNh
-        ZThmYzMyIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDYuODI1
-        NDQzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOTowNy4xNTcz
-        NzhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjRkMDc0MTE5OWNlOTQwNGI5YWM4OTdkYjc3
+        OWQ2Mjg5Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MTguMzg2
+        NTQxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNToxOC43OTc4
+        NThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDNmNmMx
-        MzctYmIwMC00MTEyLTg2YjgtY2YzNjUwYzQ2MDE0LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYjc1Zjg2
+        NTgtMGQxMy00NDViLWIyNmItOWU0NWI1Y2JlYTQzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMzgzMTk5NGMtY2RjNi00NjM2LThiNDYtYzY2MTg4
-        YTMxNzc2LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZTE5NjI3ZmEtOWNkNi00ODg5LWJkMzYtZGQ5MDk2
+        ODhkOTA1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1736,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1749,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:07 GMT
+      - Fri, 29 Jul 2022 11:35:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10cbeb414fc341b3ba1d2f33e681f4bd
+      - ee4281c5b6774f87a2c99763cd989012
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:18 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/b75f8658-0d13-445b-b26b-9e45b5cbea43/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - da8db24ac1a3413781481855e9d57d0b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYjc1Zjg2NTgtMGQxMy00NDViLWIyNmItOWU0NWI1Y2JlYTQzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MTguNDExOTQ4WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMTk2MjdmYS05Y2Q2LTQ4ODktYmQzNi1kZDkwOTY4OGQ5MDUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2UxOTYyN2ZhLTljZDYtNDg4OS1iZDM2LWRkOTA5
+        Njg4ZDkwNS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:18 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9iNzVmODY1OC0wZDEzLTQ0NWItYjI2Yi05ZTQ1YjVjYmVhNDMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0c5d8a1a8e4947beb461db76946133ea
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiZTJjODc3LWYwMmUtNDBl
+        Ny04OGZjLTZlODNmODYzZmVlNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2be2c877-f02e-40e7-88fc-6e83f863fee5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 53250fcb92e845f0b6177b3f2cbe5357
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmJlMmM4NzctZjAy
+        ZS00MGU3LTg4ZmMtNmU4M2Y4NjNmZWU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTkuMDQ4NjgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwYzVkOGExYThlNDk0N2JlYjQ2MWRiNzY5
+        NDYxMzNlYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjE5LjEw
+        NDIxN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MTkuMzI3
+        MTc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNjE0
+        ZjQ1MjktMTFmOC00OTc2LTk5NmMtOGQ2N2YzOGQyYWRiLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/614f4529-11f8-4976-996c-8d67f38d2adb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1783db602c794bccbf96e2edf1184784
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzYxNGY0NTI5LTExZjgtNDk3Ni05OTZjLThkNjdmMzhkMmFkYi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM1OjE5LjMwNDQxMloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYjc1Zjg2NTgtMGQxMy00NDViLWIyNmIt
+        OWU0NWI1Y2JlYTQzLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - af598ff0328a4b77bd96d814332697ee
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1785,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1802,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1950,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1963,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:07 GMT
+      - Fri, 29 Jul 2022 11:35:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 44e6dd6d43c44e4b9cf4649192f327c6
+      - d9aae020ac3741ee84a8283643fd7701
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2003,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2024,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2044,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2065,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2086,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2106,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2125,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2138,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:07 GMT
+      - Fri, 29 Jul 2022 11:35:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43c7d158552e478fbbca520987372ea8
+      - 61df595514864d538614558e7f721c00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2241,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2259,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2278,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2302,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2320,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2331,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2362,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2373,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2386,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:07 GMT
+      - Fri, 29 Jul 2022 11:35:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f643d02acb38404aafdc8e28f25d5f4f
+      - b167d35e11a74e5a8ad2a0be6b8aafd9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2453,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2465,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2476,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2489,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:07 GMT
+      - Fri, 29 Jul 2022 11:35:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0da1c6ca79584ea381ba1a54d1111a04
+      - 935b7786986a460aa724bc5616b45741
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2525,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2536,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2549,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:07 GMT
+      - Fri, 29 Jul 2022 11:35:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 765884f41730458dacbd7b45624679c1
+      - 424193ee36864c91a027d9ca91bdc374
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2600,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2611,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2624,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25df4a57bf8c497186ffbb7431a11114
+      - 3e824a783c8243229bbba3d6e60f7368
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2691,10 +3248,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2702,7 +3259,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2715,35 +3272,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 40225bb97f8c478ab50dfa743b2031fa
+      - 97e7e4bb1a2d4ede9f1a3393564a64a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2782,10 +3339,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2793,7 +3350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2806,35 +3363,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 69e24d1d1592446cbfeeb0a61582de40
+      - 2e7c1fbdb8c8480986013ccf98964206
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2845,10 +3402,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2856,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2869,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ca0e8bbacf14afb879738471d854c6c
+      - bd5211e5e3254a59852e9880e50f9591
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2908,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2919,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2932,37 +3489,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 363faeda32954edaa76c793d5e79715d
+      - 20f6951a4d5640e5ab3f0ce3a493f949
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -2973,7 +3530,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -2981,10 +3538,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2992,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3005,36 +3562,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbd6b4b503964f9e97ca1205c86ee9c6
+      - 75a0e3f6bd434cdc80cc3a85f0729fb8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3056,10 +3613,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3067,7 +3624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3080,37 +3637,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a5e964a22cc43dea2bb99925ac084c4
+      - 551ac066b09e448ab542e0bda14355b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3121,12 +3678,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3137,12 +3694,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3153,14 +3710,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e19627fa-9cd6-4889-bd36-dd909688d905/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3168,7 +3725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3181,123 +3738,123 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 67122bdfa6294c5bbb0b73c495d80863
+      - 566a708b0d0344caa238df49f34b4ad6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzgzMTk5NGMtY2RjNi00NjM2LThi
-        NDYtYzY2MTg4YTMxNzc2L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JkYTNhMDU3LTgxZTEt
-        NDVlYi1iMDc5LWVjOGFlOWQzZjQxMS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        Mjk2ZTUwNTQtODIyNS00MzNjLWEzY2QtNjQxYzEwMDk1MTEzLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzM4NTMwYWU2LTRiYzYt
-        NDE2Zi1iYmVlLTk2MTA2YTRjZjk1MC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
-        ZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQtZDcxNTNhZDc4NDIyLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQy
-        M2QtNDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1
-        ZC1iODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRk
-        NGFhYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRl
-        NTYxMGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhk
-        YS04Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNl
-        YzY5Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5
-        YTY1ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3
-        MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJj
-        ODZhZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
-        cm91cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01
-        YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3Yi1iY2MzLTQ2
-        MzNhMmM3OTkwZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNGI5ZTFkMS1mYWUy
-        LTQ0NWQtYTg3Ny05Mzk5ZjhlNjVjMGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzI5ZTZhMjFkLTJmNjktNGNkMi1iNzExLTYxY2M4
-        OWNmNzBjZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MzdjMzgwYTAtYWFmZi00M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zYmY0MDNlMi1lNGNlLTQy
-        YzAtODhmMy0xNTI4OTBlZmE3ZWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzQ5NDNkMTlkLWM1NTItNDVkMi04NTYwLWM3MGFmOTEz
-        N2NjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNTBj
-        ODJlOWQtYWY4OS00MzEzLWJmZWQtZDRjNGE2YzgwZjllLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NjQ2NWZmYS05NTFlLTRlZDUt
-        YjNjMy1hODA2ZWVkZmM4NWQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzc2MDhjZTM3LTFjNzEtNGFkMC05MGFjLWVlZDc0NjBjNTYx
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2EzYzU3
-        OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJkNDg4LyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5
-        YS1mMGFjOTY2MjVkZmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzhmNGMwNDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4Zi8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTY1MjI4ODAt
-        OGM1YS00ODAxLWI1NjctMWYyYjFkYjczZGVjLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0
-        NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJkLTQ3MGMtYTI2MC1iZWJh
-        NjIwMDM0OWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2ZjMmFlODJlLWI3YTEtNGQ2Zi1iNjNkLWNlNzFlZmU1NmM1YS8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy9mNDdh
-        M2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19XSwiZGVwZW5k
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTE5NjI3ZmEtOWNkNi00ODg5LWJk
+        MzYtZGQ5MDk2ODhkOTA1L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcyOGQyZmE2LTAxNTct
+        NGMzZS04MTM1LWU5Y2RiNjQ4YjY1OS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8yMzlmN2Y5Yy1lNDBmLTQ2NTgtYThmYi1jMTVlM2Ni
+        ZDc2NGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        MzliNGU0ZjctZDc3Yy00MDY2LTkyZDAtOTUwZmYwZTJiZTY5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzcxMWY4Mzk5LTU0NjMt
+        NDVhYy1hZTYzLWY3OTMwMDVmZGY5Mi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vYWR2aXNvcmllcy85YTFjZGI2OC1lN2RkLTQ5MGEtODY4OS01MTRl
+        M2NkMGFmNGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYy
+        YWItNGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdh
+        Yi1hNTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQy
+        OTI5My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1
+        ZWE3ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBl
+        NS1hZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vbW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFk
+        MTkxOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYy
+        NTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgx
+        NS04OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJm
+        MjFjYmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vn
+        cm91cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0y
+        OTFhLTQzMzYtYWRiZC1kODliN2IwMWQ4NDYvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzEwODA0ODI3LTY0YzgtNDU5Mi04Mzg0LWIy
+        NzZmZmE3ZTgyNi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzViYmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0
+        NmNiNmIwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0OTU0ZWVkLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81YTMyODQyNi0yYmFmLTQx
+        ODktOWNjNS02ZDhkYzM1YzEwZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQtNGU0Ni04ZmMzLTFiZmY3OTlm
+        YjYxZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjVm
+        YmI5NzQtMTUyYy00OTZlLTk0NGQtNDdjNjVhMjU4YWM3LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NmQwMjRjMi0xMGZjLTQwMWMt
+        YWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEy
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2NmMDVm
+        MmUtYjJjMS00OGIwLTgxMzMtMWJmNzVmZGQyM2UxLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUtOTM2
+        Zi05YWEwMzU2MzlmMDUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMt
+        NTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0y
+        MmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkxLTM2ZWM4ZmMzNTA0OC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVh
+        Mi00NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2ZkYjk1N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy80YWJm
+        NTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19XSwiZGVwZW5k
         ZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3310,7 +3867,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:08 GMT
+      - Fri, 29 Jul 2022 11:35:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3328,21 +3885,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 80285d61aaf94ad08f5ae8d770b4cdb2
+      - 51d36c8adc0943bbadf426303926300b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxODNmZmU2LTkxOGQtNGI5
-        MS04Y2E0LTI2MzgzMjMxMDdiNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmNDM1N2M1LTc2ZTctNGEx
+        Yy1iMDU0LWYwN2MyYTYxMTU5ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e183ffe6-918d-4b91-8ca4-2638323107b5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6f4357c5-76e7-4a1c-b054-f07c2a61159e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3363,55 +3920,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:09 GMT
+      - Fri, 29 Jul 2022 11:35:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dec22dfa2c604cc38083ce461971f499
+      - 744813c22ce548808917d660ee1da3f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTE4M2ZmZTYtOTE4
-        ZC00YjkxLThjYTQtMjYzODMyMzEwN2I1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDguNTMwNDUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmY0MzU3YzUtNzZl
+        Ny00YTFjLWIwNTQtZjA3YzJhNjExNTllLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MjEuNjA2NzA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiODAyODVkNjFhYWY5NGFkMDhmNWFlOGQ3NzBi
-        NGNkYjIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOTowOC41ODAx
-        MzhaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjA5LjA0Njc3
-        MFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiNTFkMzZjOGFkYzA5NDNiYmFkZjQyNjMwMzky
+        NjMwMGIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNToyMS42NjM2
+        NDVaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjIyLjI5NjI0
+        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhM2Ew
-        NTctODFlMS00NWViLWIwNzktZWM4YWU5ZDNmNDExL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzI4ZDJm
+        YTYtMDE1Ny00YzNlLTgxMzUtZTljZGI2NDhiNjU5L3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2JkYTNhMDU3LTgxZTEtNDVlYi1iMDc5LWVj
-        OGFlOWQzZjQxMS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzM4MzE5OTRjLWNkYzYtNDYzNi04YjQ2LWM2NjE4OGEzMTc3
-        Ni8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzcyOGQyZmE2LTAxNTctNGMzZS04MTM1LWU5
+        Y2RiNjQ4YjY1OS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2UxOTYyN2ZhLTljZDYtNDg4OS1iZDM2LWRkOTA5Njg4ZDkw
+        NS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3419,7 +3976,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3432,76 +3989,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:09 GMT
+      - Fri, 29 Jul 2022 11:35:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1724'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 51b9210d07e94fa59e010be2865e98f2
+      - d1a1b7237dfd4543a9ed99d1778398f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '566'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy81MGM4MmU5ZC1hZjg5LTQzMTMtYmZlZC1kNGM0YTZjODBmOWUvIn0s
+        YWdlcy82NWZiYjk3NC0xNTJjLTQ5NmUtOTQ0ZC00N2M2NWEyNThhYzcvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvMGE3NWNiNjUtODczMS00YWMzLWI0ZDctNmU2N2U1OTNlZDMzLyJ9LHsi
+        ZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRmYzg1ZC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
-        NTYxYmMzMi1lMGY1LTRkN2ItYmNjMy00NjMzYTJjNzk5MGYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2Ji
-        Mzg0ODctOTY3Ny00YTQzLTgzZTMtNDM5MGIzZDIwNWI0LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhiMjUx
-        NzM4LTZhNDgtNDNjYi1iNzlhLWYwYWM5NjYyNWRmZi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84ZjRjMDQz
-        ZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQt
-        MmY2OS00Y2QyLWI3MTEtNjFjYzg5Y2Y3MGNlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk2NTIyODgwLThj
-        NWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zN2MzODBhMC1hYWZm
-        LTQzZjItOWE2ZC03YTI1MmIwOWFhOTYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEtZmFlMi00
-        NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTViNzEtNDE1
-        NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkw
-        YWMtZWVkNzQ2MGM1NjFiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YwNzc5MmMzLWE0MmQtNDcwYy1hMjYw
-        LWJlYmE2MjAwMzQ5Zi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hMTllNDdjYi1kNmQ2LTQyZWEtOTczMi0z
-        Mjg1MjE2NDI0MmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0NC00YjY2LWFlYWQtZmY4
-        NTBiOTI2ZTVjLyJ9XX0=
+        LzllY2EzOGEyLTc4ZGUtNGU2ZS05NDI3LWJlNzA5NjU5NDIwZS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
+        MWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY5ZTgz
+        YWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUz
+        NC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEzMjg0MjYt
+        MmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYwOGMxLWI2
+        YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYyZS1iMmMx
+        LTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzI0NzQyNTQtMTVhMi00
+        NDY0LTlkMTItMjQxZWY2ZDQ1M2IwLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAx
+        Yy1hZmU1LTU4NWIyOTkzN2M1Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MmQxODVhMi1kMTEzLTRhY2Mt
+        OWUxOS04NGI5YzQ5NTRlZWQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvZmRiOTU3YjEtYzkxMi00MWQxLWE4
+        ZGYtZmQ4NDNhN2VkNWE4LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I5MTJjOTA1LTYxZjUtNDcyYi04ZTkx
+        LTM2ZWM4ZmMzNTA0OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy8wNWUzNjhkNy0yOTFhLTQzMzYtYWRiZC1k
+        ODliN2IwMWQ4NDYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTkyLTgzODQtYjI3
+        NmZmYTdlODI2LyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3509,7 +4066,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3522,50 +4079,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:09 GMT
+      - Fri, 29 Jul 2022 11:35:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f3dd31431f324c16ae23481a9a6c2ba7
+      - 9a53333a470d41158bdbb987fe549a68
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3573,7 +4130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3586,37 +4143,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:09 GMT
+      - Fri, 29 Jul 2022 11:35:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0055fab7034a4189a7c0767c9f4215f1
+      - ac413c33a4864af8bebcbd6905b53d63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -3689,9 +4246,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3707,8 +4264,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -3726,9 +4283,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -3750,9 +4307,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -3768,9 +4325,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -3779,9 +4336,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -3810,10 +4367,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3821,7 +4378,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3834,43 +4391,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:09 GMT
+      - Fri, 29 Jul 2022 11:35:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5881db4fba11450793a1103a79648dbd
+      - '09df08b5c7b740ff8cff6eb676120e4d'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3878,7 +4435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3891,41 +4448,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:09 GMT
+      - Fri, 29 Jul 2022 11:35:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ecc3abcd5b0e4eef8652719e5bcbc9b2
+      - '058e7dfabd124de59df4b9ce1b2a1bd0'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3933,7 +4490,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3946,36 +4503,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:09 GMT
+      - Fri, 29 Jul 2022 11:35:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 969bce1690054a0889038320f13198f2
+      - d8f4da60962a44b9826ece424c06b812
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3997,10 +4554,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/728d2fa6-0157-4c3e-8135-e9cdb648b659/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4008,7 +4565,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4021,38 +4578,38 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:09 GMT
+      - Fri, 29 Jul 2022 11:35:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 030035bd26d44501bbb5ce2030702ef4
+      - 27317a7e098a439bbbce30c60d6bd284
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:23 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_groups_repository/package_groups_as_a_filter_rule.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_groups_repository/package_groups_as_a_filter_rule.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:10 GMT
+      - Fri, 29 Jul 2022 11:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 492affc9c3ec4af79661953dede893f5
+      - c4da1891a96243f8b7eb0c47e36e31a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zODMxOTk0Yy1jZGM2LTQ2MzYtOGI0Ni1jNjYxODhhMzE3NzYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOTowNC40NDYyNjha
+        cnBtL3JwbS8wMGNiZWNlYS01Yzg3LTQ4ZDUtYTg1ZS00MmIxNWFlMDk0NWMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDo1Mi4wNDgxMTla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zODMxOTk0Yy1jZGM2LTQ2MzYtOGI0Ni1jNjYxODhhMzE3NzYv
+        cnBtL3JwbS8wMGNiZWNlYS01Yzg3LTQ4ZDUtYTg1ZS00MmIxNWFlMDk0NWMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM4MzE5
-        OTRjLWNkYzYtNDYzNi04YjQ2LWM2NjE4OGEzMTc3Ni92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAwY2Jl
+        Y2VhLTVjODctNDhkNS1hODVlLTQyYjE1YWUwOTQ1Yy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3831994c-cdc6-4636-8b46-c66188a31776/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:10 GMT
+      - Fri, 29 Jul 2022 11:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da53bf1935684a68b24060d172df1499
+      - f7f9f6e279be4b31a469e1d43d91206a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjNDk2ZTM0LWJiYjYtNDVi
-        ZC04MzFjLWJkYmY2NzVlN2NhZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjYzRjYjNkLWVjZGYtNGM1
+        Ni1hYjI0LWVhNGE4ZGRmNGY4Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:10 GMT
+      - Fri, 29 Jul 2022 11:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 27c202b0471c4f4381eef9f01d531d2a
+      - f8c9a18b56664b57a2ebec3ab3844289
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0c496e34-bbb6-45bd-831c-bdbf675e7caf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/dcc4cb3d-ecdf-4c56-ab24-ea4a8ddf4f8c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 688acab08aca45d88aab4e6bd3e60f92
+      - c72d32bd913b40e98a991d2618063c9f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGM0OTZlMzQtYmJi
-        Ni00NWJkLTgzMWMtYmRiZjY3NWU3Y2FmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTAuNjQ1NDIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNjNGNiM2QtZWNk
+        Zi00YzU2LWFiMjQtZWE0YThkZGY0ZjhjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDIuMTcwNjc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkYTUzYmYxOTM1Njg0YTY4YjI0MDYwZDE3
-        MmRmMTQ5OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjEwLjY3
-        Nzk0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MTAuOTE2
-        MDg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmN2Y5ZjZlMjc5YmU0YjMxYTQ2OWUxZDQz
+        ZDkxMjA2YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjAyLjIz
+        NTY0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MDIuNDM3
+        NTU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzgzMTk5NGMtY2RjNi00NjM2
-        LThiNDYtYzY2MTg4YTMxNzc2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDBjYmVjZWEtNWM4Ny00OGQ1
+        LWE4NWUtNDJiMTVhZTA5NDVjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 62236a076fb04247aaeb69da29b228b6
+      - c81982a9dac34248865b280f9b87b799
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ffc650658b6744d9895eeae2304bf0f4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMDlmYmQyMGYtMDdiNC00MmY1LWI0NzYtZGU2YjMxNTc1Y2Jk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NTYuMjYxMTEy
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/09fbd20f-07b4-42f5-b476-de6b31575cbd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - dd0d1124cdca44bea29c63a161694d2c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmZjdiY2M2LTQ5MDYtNDA1
+        Ny05MmNmLWU5ZTI4MzVkOTBkYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/eff7bcc6-4906-4057-92cf-e9e2835d90db/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 28f76791967c405788314554c916d2a1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWZmN2JjYzYtNDkw
+        Ni00MDU3LTkyY2YtZTllMjgzNWQ5MGRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDIuNjA3MDUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZDBkMTEyNGNkY2E0NGJlYTI5YzYzYTE2
+        MTY5NGQyYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjAyLjY1
+        MzQ3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MDIuNjg5
+        NjI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ff246ac182848f897b9b412762c0ef9
+      - 1318727c7d064e1188e456207bea39e0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a075f10c80504d6b86b4b18b62f78121
+      - e65a65db47a746ca8ca767be9d804bc3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f91a529e76441548a946c62c4312eec
+      - 6a225daef4584ab4be7044bd9e21e8bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e55f551285ba40008c7204ab7d4d0f69
+      - ba536b50329c4c3aa42756a7ae7ad6aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:29:11 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 126427ea2d2f47bfbee6ed041e1a0f97
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/f37dc4df-4f65-450b-8506-008fe03526bf/"
+      - "/pulp/api/v3/remotes/rpm/rpm/98004c43-7e99-47c9-8721-9dbff415497d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f4b6e05ef85d48c18e351715dc152115
+      - d61db269fdea4edc9e134fe055d7497a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Yz
-        N2RjNGRmLTRmNjUtNDUwYi04NTA2LTAwOGZlMDM1MjZiZi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI5OjExLjQ1OTMzNFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4
+        MDA0YzQzLTdlOTktNDdjOS04NzIxLTlkYmZmNDE1NDk3ZC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM1OjAzLjExMzk0MloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI5OjExLjQ1OTM1NVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjM1OjAzLjExMzk2N1oiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/"
+      - "/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e221fce102b14a61a0141bb5cef3d18e
+      - e899342cdb524ab3b9b61eefc0f5a02f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOGRlODRjZDUtY2NiYS00MmRlLTkwZmMtOGUwNTk2MjRlZWUwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MTEuNTczMDMzWiIsInZl
+        cG0vNDMyNTk2MzYtMTcwOC00MWM2LWFhZGQtMGExMjMxOTc4YTczLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MDMuMjU0NTEwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOGRlODRjZDUtY2NiYS00MmRlLTkwZmMtOGUwNTk2MjRlZWUwL3ZlcnNp
+        cG0vNDMyNTk2MzYtMTcwOC00MWM2LWFhZGQtMGExMjMxOTc4YTczL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84ZGU4NGNkNS1j
-        Y2JhLTQyZGUtOTBmYy04ZTA1OTYyNGVlZTAvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80MzI1OTYzNi0x
+        NzA4LTQxYzYtYWFkZC0wYTEyMzE5NzhhNzMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c2e08d3e78042bc8e0bba1fa2c59fad
+      - c99183a95ae44ff69da87d509693dd50
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iZGEzYTA1Ny04MWUxLTQ1ZWItYjA3OS1lYzhhZTlkM2Y0MTEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOTowNS4xMjQ5Nzda
+        cnBtL3JwbS83MGFmZjBlMi02MGJlLTQxYTAtOWU0Mi0xOTkxMWM3OGZiOTcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDo1Mi45NzA5ODJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iZGEzYTA1Ny04MWUxLTQ1ZWItYjA3OS1lYzhhZTlkM2Y0MTEv
+        cnBtL3JwbS83MGFmZjBlMi02MGJlLTQxYTAtOWU0Mi0xOTkxMWM3OGZiOTcv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JkYTNh
-        MDU3LTgxZTEtNDVlYi1iMDc5LWVjOGFlOWQzZjQxMS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcwYWZm
+        MGUyLTYwYmUtNDFhMC05ZTQyLTE5OTExYzc4ZmI5Ny92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/bda3a057-81e1-45eb-b079-ec8ae9d3f411/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3fc32337b508411aa7372db8eb90babb
+      - d6bcef05fc7a45d4b1879925fdb643e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiM2YyNzM5LTI3M2EtNGQ2
-        NS1iZWIwLTZkOGQ4ZjBkNWI0Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyOTY3MWUyLWI1NjAtNDVl
+        Ny04NmZlLWI3OGMzMTgwMmRkZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7df1c6faf3b64a169597f7b010dac3fe
+      - b3150098ad04456089c2ce003ff76cbe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNTRmZjllODQtMjcyNi00NzE1LWE4NWMtMzE0NjE2MTgwY2M5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MDQuMzI4NDYxWiIsIm5h
+        cG0vNWUwZTczNTMtYzM2MC00OGMxLWE1Y2MtM2Y4YTA4NWQyNGY3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NTEuOTAxNjY2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyOTowNS40OTQ3ODhaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozNDo1My40MjUzNjRaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/54ff9e84-2726-4715-a85c-314616180cc9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/5e0e7353-c360-48c1-a5cc-3f8a085d24f7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96394394eba641f9be50b93f25a5c0b5
+      - a07eae4383214660a5a19602ccea7fcd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwN2NjNWFiLWVjYWItNGE5
-        Mi1iMWEyLTgyZDNiNGUxZmJiMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlMzc1MDIxLTZkYWQtNDNl
+        Yi1iZGRiLWE3NGYzM2QyZTFkNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4b3f2739-273a-4d65-beb0-6d8d8f0d5b4f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/829671e2-b560-45e7-86fe-b78c31802ddf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c5b991f7b9a469bb0dcd31be0bdef08
+      - 527305c1100b48af90c40171f8c62255
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGIzZjI3MzktMjcz
-        YS00ZDY1LWJlYjAtNmQ4ZDhmMGQ1YjRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTEuNzUzOTAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODI5NjcxZTItYjU2
+        MC00NWU3LTg2ZmUtYjc4YzMxODAyZGRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDMuNTA3MTI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzZmMzMjMzN2I1MDg0MTFhYTczNzJkYjhl
-        YjkwYmFiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjExLjc4
-        NTc4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MTEuODUx
-        Nzc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkNmJjZWYwNWZjN2E0NWQ0YjE4Nzk5MjVm
+        ZGI2NDNlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjAzLjU1
+        MzU3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MDMuNjU3
+        NTExWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmRhM2EwNTctODFlMS00NWVi
-        LWIwNzktZWM4YWU5ZDNmNDExLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBiZS00MWEw
+        LTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/107cc5ab-ecab-4a92-b1a2-82d3b4e1fbb2/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/de375021-6dad-43eb-bddb-a74f33d2e1d7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b022669f8fa64fdfa9de79a7f12bb06b
+      - 8f7767d3a720489b80b96a65dbf41111
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTA3Y2M1YWItZWNh
-        Yi00YTkyLWIxYTItODJkM2I0ZTFmYmIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTEuODQwNjg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGUzNzUwMjEtNmRh
+        ZC00M2ViLWJkZGItYTc0ZjMzZDJlMWQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDMuNjI3Mzk4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NjM5NDM5NGViYTY0MWY5YmU1MGI5M2Yy
-        NWE1YzBiNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjExLjg3
-        Mzk3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MTEuOTE3
-        MjQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhMDdlYWU0MzgzMjE0NjYwYTVhMTk2MDJj
+        Y2VhN2ZjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjAzLjY5
+        MTE4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MDMuNzQ4
+        ODU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0ZmY5ZTg0LTI3MjYtNDcxNS1hODVj
-        LTMxNDYxNjE4MGNjOS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVlMGU3MzUzLWMzNjAtNDhjMS1hNWNj
+        LTNmOGEwODVkMjRmNy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:11 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7fbe1ee71c7c40dc807016679d5eee85
+      - 0d0ca5d37c5341b384a821fcb9ac72ab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a8076df4362b4430b6ef1acfd3042a7c
+      - fb680c44857f4b358a220b3bfd6da58a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1caf6ccd101c41659a1c31b9ee36316d
+      - 8d7cfb65fa424f9e9a49e11989490da3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 67d4909d00bb415aa25833cb43ac4fcb
+      - 93c6048f346c4f80b0d344bff00db6ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94fcf29a7d8b423d8698d4453b107171
+      - 3cdb3c3b5f0d4955b6c402c420357d31
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae2cf0f1bc1a403e95162c41f6e5f5a1
+      - 99078b7f082644e6b9d90cdab7079a77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/"
+      - "/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90ac6679b680442f9d40bb7a6f7898e4
+      - f1f3b5eb931f48709352bdc027c3c137
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYWRiNTg0OGItNTI3Yi00M2M1LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MTIuMzM1MTMzWiIsInZl
+        cG0vZWY5OGNlNDYtM2Q5MC00YTRlLTliZjQtYWVhOWNmZDFkYTg1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MDQuMTk0NDIwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYWRiNTg0OGItNTI3Yi00M2M1LTk0ZWUtOWNkMDM1Yjc2Y2Q2L3ZlcnNp
+        cG0vZWY5OGNlNDYtM2Q5MC00YTRlLTliZjQtYWVhOWNmZDFkYTg1L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hZGI1ODQ4Yi01
-        MjdiLTQzYzUtOTRlZS05Y2QwMzViNzZjZDYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lZjk4Y2U0Ni0z
+        ZDkwLTRhNGUtOWJmNC1hZWE5Y2ZkMWRhODUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:04 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/f37dc4df-4f65-450b-8506-008fe03526bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/98004c43-7e99-47c9-8721-9dbff415497d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f12318e508024435acae9f96419d89a1
+      - 01eec2e087d14b5084dc20340424121a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5ZWY5YWM4LThkNWQtNGQy
-        ZC1iMGY5LTYxYzRhMGE0ZTE1MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzYTZmN2E3LWUxNTUtNGQx
+        NS1hOGY3LTI4YzIxZDNmZDY4Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/79ef9ac8-8d5d-4d2d-b0f9-61c4a0a4e150/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e3a6f7a7-e155-4d15-a8f7-28c21d3fd687/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 452e89a626934a29962e8a7bf8d81737
+      - 3c6de31d1e69446a95620771f90c6459
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzllZjlhYzgtOGQ1
-        ZC00ZDJkLWIwZjktNjFjNGEwYTRlMTUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTIuNjAwMzcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTNhNmY3YTctZTE1
+        NS00ZDE1LWE4ZjctMjhjMjFkM2ZkNjg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDQuNTkwMDQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmMTIzMThlNTA4MDI0NDM1YWNhZTlmOTY0
-        MTlkODlhMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjEyLjYz
-        NDExMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MTIuNjU5
-        ODYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwMWVlYzJlMDg3ZDE0YjUwODRkYzIwMzQw
+        NDI0MTIxYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjA0LjYz
+        Mjg4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MDQuNjg4
+        NTkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2YzN2RjNGRmLTRmNjUtNDUwYi04NTA2
-        LTAwOGZlMDM1MjZiZi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4MDA0YzQzLTdlOTktNDdjOS04NzIx
+        LTlkYmZmNDE1NDk3ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2YzN2Rj
-        NGRmLTRmNjUtNDUwYi04NTA2LTAwOGZlMDM1MjZiZi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4MDA0
+        YzQzLTdlOTktNDdjOS04NzIxLTlkYmZmNDE1NDk3ZC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:12 GMT
+      - Fri, 29 Jul 2022 11:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3aa8a4d39f3e4a20af9d7067d184010d
+      - 18596dcd6c6e488197853b2b9558250e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzZTExYmI5LTUzYjItNDI3
-        NS05ODY4LTM0OTc4NDZjMjM2ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiNmE2NjU2LTI4M2YtNDZj
+        OC05ZjVkLTFhZDg4YWVhNzJjYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d3e11bb9-53b2-4275-9868-3497846c236e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2b6a6656-283f-46c8-9f5d-1ad88aea72ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:13 GMT
+      - Fri, 29 Jul 2022 11:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f48297a1f442498bb3e62523152ef4ea
+      - 8ca94138cade4dd6a9e757d81b9e6cf5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '655'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDNlMTFiYjktNTNi
-        Mi00Mjc1LTk4NjgtMzQ5Nzg0NmMyMzZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTIuNzc1NDAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI2YTY2NTYtMjgz
+        Zi00NmM4LTlmNWQtMWFkODhhZWE3MmNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDQuODQxODU4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzYWE4YTRkMzlmM2U0YTIwYWY5
-        ZDcwNjdkMTg0MDEwZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjEyLjgxNDM0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTMuNTc2MTQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxODU5NmRjZDZjNmU0ODgxOTc4
+        NTNiMmI5NTU4MjUwZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjA0LjkwNTU0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MDYuMDcwMjcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzhkZTg0Y2Q1LWNjYmEtNDJkZS05MGZjLThlMDU5
-        NjI0ZWVlMC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84ZGU4
-        NGNkNS1jY2JhLTQyZGUtOTBmYy04ZTA1OTYyNGVlZTAvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZjM3ZGM0ZGYtNGY2NS00NTBi
-        LTg1MDYtMDA4ZmUwMzUyNmJmLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS80MzI1OTYzNi0xNzA4LTQxYzYtYWFkZC0wYTEyMzE5
+        NzhhNzMvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDMyNTk2
+        MzYtMTcwOC00MWM2LWFhZGQtMGExMjMxOTc4YTczLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4MDA0YzQzLTdlOTktNDdjOS04
+        NzIxLTlkYmZmNDE1NDk3ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOGRlODRjZDUtY2NiYS00MmRlLTkwZmMtOGUwNTk2MjRl
-        ZWUwL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNDMyNTk2MzYtMTcwOC00MWM2LWFhZGQtMGExMjMxOTc4
+        YTczL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:13 GMT
+      - Fri, 29 Jul 2022 11:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 515f49d40bb442c9aa9d9db09cbd9c87
+      - 32834b8a9edf4f6c93786eb053b0f3e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5YTU4ZjM5LTM4ZDQtNDNk
-        MC1iZTIzLWU2ZTc3YTFhYTBmMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwMjA0Y2I1LTM3MmUtNDIz
+        OS1iOTUyLTEyMjg3YjM0M2ExOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:13 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/69a58f39-38d4-43d0-be23-e6e77a1aa0f3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d0204cb5-372e-4239-b952-12287b343a18/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:14 GMT
+      - Fri, 29 Jul 2022 11:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e9734353d67438ea925e052974846e8
+      - 61141c4e05e04ab89deb9ed92d7bfa05
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjlhNThmMzktMzhk
-        NC00M2QwLWJlMjMtZTZlNzdhMWFhMGYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTMuODY0OTI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDAyMDRjYjUtMzcy
+        ZS00MjM5LWI5NTItMTIyODdiMzQzYTE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDYuNzcyNzg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjUxNWY0OWQ0MGJiNDQyYzlhYTlkOWRiMDlj
-        YmQ5Yzg3Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MTMuODk1
-        Mjg4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOToxNC4yMzUz
-        MDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjMyODM0YjhhOWVkZjRmNmM5Mzc4NmViMDUz
+        YjBmM2U1Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MDYuODEx
+        MDIxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNTowNy4yMDg0
+        MDRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjdlM2Ez
-        OGUtOWVlNy00YWE5LTk5YTgtMzIxMWJmYzcyZWVmLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOWIzMmUy
+        NzktM2IzYi00OGY2LWJkM2EtNzRiNDhhMGY3MzVjLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOGRlODRjZDUtY2NiYS00MmRlLTkwZmMtOGUwNTk2
-        MjRlZWUwLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNDMyNTk2MzYtMTcwOC00MWM2LWFhZGQtMGExMjMx
+        OTc4YTczLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:14 GMT
+      - Fri, 29 Jul 2022 11:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e0e06938bcf5481ca3bf2760a5c1c551
+      - bc6a9f36b8354222a5123c979bcee038
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/9b32e279-3b3b-48f6-bd3a-74b48a0f735c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9cadec0e56ff4326a47341f07a11ee28
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vOWIzMmUyNzktM2IzYi00OGY2LWJkM2EtNzRiNDhhMGY3MzVjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzU6MDYuODM2NDAwWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80MzI1OTYzNi0xNzA4LTQxYzYtYWFkZC0wYTEyMzE5NzhhNzMv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzQzMjU5NjM2LTE3MDgtNDFjNi1hYWRkLTBhMTIz
+        MTk3OGE3My8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:07 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS85YjMyZTI3OS0zYjNiLTQ4ZjYtYmQzYS03NGI0OGEwZjczNWMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8abd1db2c04a4f32bfc3f948157ea4bd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VjZGQyYjZjLTU1ZWMtNGE1
+        NC1hOGVlLTNkN2M4OGE1MDE3Yi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ecdd2b6c-55ec-4a54-a8ee-3d7c88a5017b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 95a3de8bc7304134a8f15b96ebc2b8ef
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWNkZDJiNmMtNTVl
+        Yy00YTU0LWE4ZWUtM2Q3Yzg4YTUwMTdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDcuNDY2MTcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4YWJkMWRiMmMwNGE0ZjMyYmZjM2Y5NDgx
+        NTdlYTRiZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjA3LjUx
+        NzgzNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6MDcuNzMw
+        Njk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vN2I2
+        ZTY1MzItYmI0ZS00MWMxLWIyNTYtNTI2MDUxMjViNmRjLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/7b6e6532-bb4e-41c1-b256-52605125b6dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3868233988454232850ce8ceab4d6dba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzdiNmU2NTMyLWJiNGUtNDFjMS1iMjU2LTUyNjA1MTI1YjZkYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM1OjA3LjcwOTU0OFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vOWIzMmUyNzktM2IzYi00OGY2LWJkM2Et
+        NzRiNDhhMGY3MzVjLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:35:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:35:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7299fc580b9a4403bd0a41b3299b8879
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:14 GMT
+      - Fri, 29 Jul 2022 11:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0daa67c8916044a1877f4c0d1a95f071
+      - 1cdceec593de46d1b4cf7d30a907a975
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:14 GMT
+      - Fri, 29 Jul 2022 11:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 909eea47f44c431b99c03d1f04fbd94a
+      - 944776d0a5ed4c10b75c40844b6d5bbd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:14 GMT
+      - Fri, 29 Jul 2022 11:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f51e210307ce4c2aa0727a0b6991728b
+      - 1af44f7a35c94aaa8911ee284fa33357
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:14 GMT
+      - Fri, 29 Jul 2022 11:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71fa8932f15b4906814dd30774190d6d
+      - 2a7932f2a9da44d28a21499bc2b97a50
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0676b4c2b17e4e508d529d8335c2a8c2
+      - 208a3a800c78419cbb2385cff5bb5d43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43e97282d1f24fc9b72acf3ac842eff0
+      - e16749e3384e4b5c98e1be54ce6049fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2795,10 +3220,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2806,7 +3231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2819,35 +3244,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3bd8209fe37c40c98c307c063154c8bf
+      - 8f5ae73629b64482a776055546174b3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2886,10 +3311,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2897,7 +3322,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2910,35 +3335,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a2da9bb085a42c5a94cb42c9240cdae
+      - e84177307e1c471cb035687a85104032
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2977,10 +3402,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 87f4f7358d7a42efaf63f7c8b29f11ab
+      - 97ae0a80ba7444539e59ddc72271cc4b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,35 +3489,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 92bcf17e1e5847c4bc64fa1e1f952e36
+      - bb8e4663d91e4391876f0412bc2ea72b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3103,10 +3528,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3114,7 +3539,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3127,37 +3552,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa4d6f51ec6e4af78208020df818e152
+      - 1f4189cd662f4604812327e23425c603
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3168,7 +3593,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3176,10 +3601,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3187,7 +3612,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3200,36 +3625,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9eb9930c2feb4944aa1ae6e19755311b
+      - 7f83bacb58694972bc397b1a0eb1055e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3251,10 +3676,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3262,7 +3687,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3275,37 +3700,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2e71a31d29804e78a44af0a0500cfbd5
+      - 0ccd324c5b484fd7af0f395fa544e464
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3316,12 +3741,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3332,12 +3757,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3348,14 +3773,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/43259636-1708-41c6-aadd-0a1231978a73/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,47 +3801,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68b26eb42904407f8732721b01447b78
+      - aca25513895f408a9496154e5de63fc8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3426,7 +3851,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3439,7 +3864,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3457,32 +3882,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 63526d0967064747926147f25262b3bb
+      - 2317ab3e361e4499aa505cdcb4b4859e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyYTVkZTgzLTM5ZWMtNGI5
-        Yi1iYWM4LWM2ODdkNTU1Y2EyZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3YzExNGI1LThhYmItNGE1
+        ZC1hZTM4LWJhYjZmNGViMGU1Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3495,7 +3920,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3513,36 +3938,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f38034fa04b40428d2270f3c97bb725
+      - 7573c2cf34e34adcbd50172d7f886351
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhNWVlMzI0LTA5YmMtNGFl
-        ZS05MDlkLTMyMjBkMTk5N2YwZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyNDUyYzFhLTlkZTEtNDhk
+        ZS04Njc5LWQ3YmNiYTc3NjJkZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:09 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3555,7 +3980,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:15 GMT
+      - Fri, 29 Jul 2022 11:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3573,52 +3998,52 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c6be90dc2cde4a7cb7e22145171bcd05
+      - a7bad808594c439b90f57ee37c2ecabe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcwZDRmMjNlLWNlNjItNGM4
-        Mi05YjkxLTM0ZjJhNjJjMmE2ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RhM2VmNzBlLTg1YzgtNDA0
+        YS04MWIxLWQwYTg3MDFkYWUyNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGRlODRjZDUtY2NiYS00MmRlLTkw
-        ZmMtOGUwNTk2MjRlZWUwL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2FkYjU4NDhiLTUyN2It
-        NDNjNS05NGVlLTljZDAzNWI3NmNkNi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        ZjE3ODkzMDgtZDIzZC00NDgwLThmMjEtMmM5MjAxMDcxM2Y3LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvNTg5Nzkw
-        OTktNTZjZS00MTVkLWI4NzMtMjE0YTczNTZkMTAwLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkw
-        ZC1hYjk2LWZkMmU3MWE2ZGFhMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMDNmOGVlNGYtNWI3MS00MTU1LWE0NzMtZjc5YzU1MDQz
-        MWUzLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNGI5
-        ZTFkMS1mYWUyLTQ0NWQtYTg3Ny05Mzk5ZjhlNjVjMGQvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ5NDNkMTlkLWM1NTItNDVkMi04
-        NTYwLWM3MGFmOTEzN2NjYy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVk
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDMyNTk2MzYtMTcwOC00MWM2LWFh
+        ZGQtMGExMjMxOTc4YTczL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2VmOThjZTQ2LTNkOTAt
+        NGE0ZS05YmY0LWFlYTljZmQxZGE4NS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8zOWI0ZTRmNy1kNzdjLTQwNjYtOTJkMC05NTBmZjBl
+        MmJlNjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        YWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvNGYyNTJl
+        Y2UtMzE5NS00N2FiLWE1NjctZTljZGRkZDUwYTIzLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZh
+        ZC1iNTVmLTE0YmYyMWNiZGJlOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNTJkMTg1YTItZDExMy00YWNjLTllMTktODRiOWM0OTU0
+        ZWVkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82NmQw
+        MjRjMi0xMGZjLTQwMWMtYWZlNS01ODViMjk5MzdjNTYvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E3MjQwZDI2LTkwZjgtNGFjMi1h
+        OTlhLTIyZmEyMjljOWIwZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZj
         LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRhX2Zp
-        bGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQzMTI0NDExYmQyNC8iXX1d
+        bGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUxMzAzYmZkZmE1Zi8iXX1d
         LCJkZXBlbmRlbmN5X3NvbHZpbmciOmZhbHNlfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3631,7 +4056,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:16 GMT
+      - Fri, 29 Jul 2022 11:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3649,21 +4074,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eca1b5c39e454253979e6a294efdea4c
+      - 0ec4dea10a8b4e24a63d6be535b3780b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkMWJkYTFkLTI1YjctNDBk
-        NS1iN2ZiLTU5ZTVjYTU4ZTMwNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxZGZmMGI1LTdjMTAtNGYw
+        Yi05OTU2LTdhZGQyZmRkZjJmMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d2a5de83-39ec-4b9b-bac8-c687d555ca2f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a7c114b5-8abb-4a5d-ae38-bab6f4eb0e56/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3684,51 +4109,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:16 GMT
+      - Fri, 29 Jul 2022 11:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ec341ff853c477a8e5e412a9a587aa6
+      - 6d9f466555034508b57d149574b14688
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJhNWRlODMtMzll
-        Yy00YjliLWJhYzgtYzY4N2Q1NTVjYTJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuODUyNjQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTdjMTE0YjUtOGFi
+        Yi00YTVkLWFlMzgtYmFiNmY0ZWIwZTU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDkuODc4MDgyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2MzUyNmQwOTY3MDY0NzQ3OTI2
-        MTQ3ZjI1MjYyYjNiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE1Ljg4NDY5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuMTM4NzgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMzE3YWIzZTM2MWU0NDk5YWE1
+        MDVjZGNiNGI0ODU5ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjA5Ljk1Mjc1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTAuMjcwODQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3
-        Yi00M2M1LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5
+        MC00YTRlLTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d2a5de83-39ec-4b9b-bac8-c687d555ca2f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b2452c1a-9de1-48de-8679-d7bcba7762df/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3749,118 +4174,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:16 GMT
+      - Fri, 29 Jul 2022 11:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c20e7f7bfb2472ba91500b9f02121a4
+      - a21cff40a47244c68323f39f8bb000a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJhNWRlODMtMzll
-        Yy00YjliLWJhYzgtYzY4N2Q1NTVjYTJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuODUyNjQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjI0NTJjMWEtOWRl
+        MS00OGRlLTg2NzktZDdiY2JhNzc2MmRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDkuOTYzMDI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2MzUyNmQwOTY3MDY0NzQ3OTI2
-        MTQ3ZjI1MjYyYjNiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE1Ljg4NDY5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuMTM4NzgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3
-        Yi00M2M1LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:16 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8a5ee324-09bc-4aee-909d-3220d1997f0d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:29:16 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d7791317e70d4314ab5720abad55bd13
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGE1ZWUzMjQtMDli
-        Yy00YWVlLTkwOWQtMzIyMGQxOTk3ZjBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuOTAyOTQzWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzZjM4MDM0ZmEwNGI0MDQyOGQy
-        MjcwZjNjOTdiYjcyNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE2LjE3NTcyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuNDE5MTMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3NTczYzJjZjM0ZTM0YWRjYmQ1
+        MDE3MmQ3Zjg4NjM1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjEwLjMxNTU1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTAuNTcwMzY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hZGI1ODQ4Yi01MjdiLTQzYzUtOTRlZS05Y2QwMzViNzZjZDYvdmVyc2lv
+        bS9lZjk4Y2U0Ni0zZDkwLTRhNGUtOWJmNC1hZWE5Y2ZkMWRhODUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3Yi00M2M1
-        LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5MC00YTRl
+        LTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d2a5de83-39ec-4b9b-bac8-c687d555ca2f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a7c114b5-8abb-4a5d-ae38-bab6f4eb0e56/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3881,51 +4241,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:16 GMT
+      - Fri, 29 Jul 2022 11:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68695d4ad6814633a178b1ffc7c8563a
+      - e4beab2bdbc34660ad7a2ce5014bb24f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJhNWRlODMtMzll
-        Yy00YjliLWJhYzgtYzY4N2Q1NTVjYTJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuODUyNjQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTdjMTE0YjUtOGFi
+        Yi00YTVkLWFlMzgtYmFiNmY0ZWIwZTU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDkuODc4MDgyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2MzUyNmQwOTY3MDY0NzQ3OTI2
-        MTQ3ZjI1MjYyYjNiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE1Ljg4NDY5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuMTM4NzgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMzE3YWIzZTM2MWU0NDk5YWE1
+        MDVjZGNiNGI0ODU5ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjA5Ljk1Mjc1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTAuMjcwODQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3
-        Yi00M2M1LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5
+        MC00YTRlLTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8a5ee324-09bc-4aee-909d-3220d1997f0d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b2452c1a-9de1-48de-8679-d7bcba7762df/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3946,53 +4306,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:16 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 52f652b8f0134935a1ec2c4c8a5a2459
+      - 53ad091384ae4599a6913897cca51670
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGE1ZWUzMjQtMDli
-        Yy00YWVlLTkwOWQtMzIyMGQxOTk3ZjBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuOTAyOTQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjI0NTJjMWEtOWRl
+        MS00OGRlLTg2NzktZDdiY2JhNzc2MmRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDkuOTYzMDI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzZjM4MDM0ZmEwNGI0MDQyOGQy
-        MjcwZjNjOTdiYjcyNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE2LjE3NTcyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuNDE5MTMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3NTczYzJjZjM0ZTM0YWRjYmQ1
+        MDE3MmQ3Zjg4NjM1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjEwLjMxNTU1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTAuNTcwMzY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hZGI1ODQ4Yi01MjdiLTQzYzUtOTRlZS05Y2QwMzViNzZjZDYvdmVyc2lv
+        bS9lZjk4Y2U0Ni0zZDkwLTRhNGUtOWJmNC1hZWE5Y2ZkMWRhODUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3Yi00M2M1
-        LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5MC00YTRl
+        LTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/70d4f23e-ce62-4c82-9b91-34f2a62c2a6e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/da3ef70e-85c8-404a-81b1-d0a8701dae24/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4013,53 +4373,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:16 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d102f4581e974804b21363aa56f267ae
+      - e45720b2e97f46fd88aae431ca528daf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzBkNGYyM2UtY2U2
-        Mi00YzgyLTliOTEtMzRmMmE2MmMyYTZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuOTUyODM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGEzZWY3MGUtODVj
+        OC00MDRhLTgxYjEtZDBhODcwMWRhZTI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTAuMDQ4NDQ3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjNmJlOTBkYzJjZGU0YTdjYjdl
-        MjIxNDUxNzFiY2QwNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE2LjQ1MzU0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuNjg4MTQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhN2JhZDgwODU5NGM0MzliOTBm
+        NTdlZTM3YzJlY2FiZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjEwLjYxNDY3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTAuODY0NTIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hZGI1ODQ4Yi01MjdiLTQzYzUtOTRlZS05Y2QwMzViNzZjZDYvdmVyc2lv
+        bS9lZjk4Y2U0Ni0zZDkwLTRhNGUtOWJmNC1hZWE5Y2ZkMWRhODUvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3Yi00M2M1
-        LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5MC00YTRl
+        LTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d2a5de83-39ec-4b9b-bac8-c687d555ca2f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a7c114b5-8abb-4a5d-ae38-bab6f4eb0e56/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4080,51 +4440,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:16 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a983684763014e6b893b72a6e7ccee45
+      - 3d39f1ee20784b8ab14bee2f36d62c15
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJhNWRlODMtMzll
-        Yy00YjliLWJhYzgtYzY4N2Q1NTVjYTJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuODUyNjQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTdjMTE0YjUtOGFi
+        Yi00YTVkLWFlMzgtYmFiNmY0ZWIwZTU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDkuODc4MDgyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2MzUyNmQwOTY3MDY0NzQ3OTI2
-        MTQ3ZjI1MjYyYjNiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE1Ljg4NDY5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuMTM4NzgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMzE3YWIzZTM2MWU0NDk5YWE1
+        MDVjZGNiNGI0ODU5ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjA5Ljk1Mjc1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTAuMjcwODQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3
-        Yi00M2M1LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5
+        MC00YTRlLTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8a5ee324-09bc-4aee-909d-3220d1997f0d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b2452c1a-9de1-48de-8679-d7bcba7762df/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4145,53 +4505,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0db0f9c1fa2f41a7a942bc9ab08c7a9f
+      - 33c5a74e218a4ed099d44234a1ab8564
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '391'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGE1ZWUzMjQtMDli
-        Yy00YWVlLTkwOWQtMzIyMGQxOTk3ZjBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuOTAyOTQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjI0NTJjMWEtOWRl
+        MS00OGRlLTg2NzktZDdiY2JhNzc2MmRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MDkuOTYzMDI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzZjM4MDM0ZmEwNGI0MDQyOGQy
-        MjcwZjNjOTdiYjcyNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE2LjE3NTcyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuNDE5MTMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3NTczYzJjZjM0ZTM0YWRjYmQ1
+        MDE3MmQ3Zjg4NjM1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjEwLjMxNTU1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTAuNTcwMzY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hZGI1ODQ4Yi01MjdiLTQzYzUtOTRlZS05Y2QwMzViNzZjZDYvdmVyc2lv
+        bS9lZjk4Y2U0Ni0zZDkwLTRhNGUtOWJmNC1hZWE5Y2ZkMWRhODUvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3Yi00M2M1
-        LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5MC00YTRl
+        LTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/70d4f23e-ce62-4c82-9b91-34f2a62c2a6e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/da3ef70e-85c8-404a-81b1-d0a8701dae24/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4212,53 +4572,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2b1521a9a8c463597846ebabecd6e9c
+      - ffb7f9bd2de446dc8694a40376884bdc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzBkNGYyM2UtY2U2
-        Mi00YzgyLTliOTEtMzRmMmE2MmMyYTZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTUuOTUyODM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGEzZWY3MGUtODVj
+        OC00MDRhLTgxYjEtZDBhODcwMWRhZTI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTAuMDQ4NDQ3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjNmJlOTBkYzJjZGU0YTdjYjdl
-        MjIxNDUxNzFiY2QwNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjE2LjQ1MzU0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MTYuNjg4MTQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhN2JhZDgwODU5NGM0MzliOTBm
+        NTdlZTM3YzJlY2FiZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1
+        OjEwLjYxNDY3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzU6
+        MTAuODY0NTIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hZGI1ODQ4Yi01MjdiLTQzYzUtOTRlZS05Y2QwMzViNzZjZDYvdmVyc2lv
+        bS9lZjk4Y2U0Ni0zZDkwLTRhNGUtOWJmNC1hZWE5Y2ZkMWRhODUvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3Yi00M2M1
-        LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNlNDYtM2Q5MC00YTRl
+        LTliZjQtYWVhOWNmZDFkYTg1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fd1bda1d-25b7-40d5-b7fb-59e5ca58e305/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f1dff0b5-7c10-4f0b-9956-7add2fddf2f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4279,55 +4639,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b1a05f82b9424bd3a010142902397960
+      - 016d208959f948b19028cfed4db6d6b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmQxYmRhMWQtMjVi
-        Ny00MGQ1LWI3ZmItNTllNWNhNThlMzA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTYuMDEwOTYzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjFkZmYwYjUtN2Mx
+        MC00ZjBiLTk5NTYtN2FkZDJmZGRmMmYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzU6MTAuMTQyMzI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiZWNhMWI1YzM5ZTQ1NDI1Mzk3OWU2YTI5NGVm
-        ZGVhNGMiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOToxNi43MjQx
-        MTNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjE3LjAxODEx
-        OFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiMGVjNGRlYTEwYThiNGUyNGE2M2Q2YmU1MzVi
+        Mzc4MGIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNToxMC45MTg4
+        ODhaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM1OjExLjI4NDMy
+        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0
-        OGItNTI3Yi00M2M1LTk0ZWUtOWNkMDM1Yjc2Y2Q2L3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY5OGNl
+        NDYtM2Q5MC00YTRlLTliZjQtYWVhOWNmZDFkYTg1L3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2FkYjU4NDhiLTUyN2ItNDNjNS05NGVlLTlj
-        ZDAzNWI3NmNkNi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzhkZTg0Y2Q1LWNjYmEtNDJkZS05MGZjLThlMDU5NjI0ZWVl
-        MC8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2VmOThjZTQ2LTNkOTAtNGE0ZS05YmY0LWFl
+        YTljZmQxZGE4NS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzQzMjU5NjM2LTE3MDgtNDFjNi1hYWRkLTBhMTIzMTk3OGE3
+        My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4335,7 +4695,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4348,44 +4708,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a1167f57ac964dc68d066615775eb70d
+      - a638a49643c944909c2e5c7910db7675
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '193'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82NjQ2NWZmYS05NTFlLTRlZDUtYjNjMy1hODA2ZWVkZmM4NWQv
+        YWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvMTRiOWUxZDEtZmFlMi00NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9
+        a2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3YzU2LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzAzZjhlZTRmLTViNzEtNDE1NS1hNDczLWY3OWM1NTA0MzFlMy8ifV19
+        Z2VzLzUyZDE4NWEyLWQxMTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4393,7 +4753,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4406,7 +4766,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4424,21 +4784,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef67b8390b4b4a9f98767d72c3368bc5
+      - e5637dbc27ab4afd839b2b55fadfb1e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4446,7 +4806,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4459,37 +4819,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4790'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2db43f6d20cd4328bb835de26a972c42
+      - 69cefd07e152410d8f0a7f0205dbf58f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1602'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4562,9 +4922,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -4581,9 +4941,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -4593,10 +4953,10 @@ http_interactions:
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4604,7 +4964,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4617,41 +4977,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f289c786f58d4a22b115a245c9519a11
+      - f02aa676be4f4c81921ce8558ef2c197
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3MWE2
-        ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYyMWNi
+        ZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4659,7 +5019,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4672,41 +5032,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e8414292e42a4d199c1b44a6eeee412d
+      - f7691da94c7c4ed8b7b07f42cac8b1eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4714,7 +5074,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4727,36 +5087,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 59f1a40288c74452bd6238a5e385aaf5
+      - e2155ab257114f11800039e5520536ed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -4778,10 +5138,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4789,7 +5149,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4802,44 +5162,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6fd8af5030dc40afa0d1b58c34434921
+      - c0157052bd9648f9870e89163cf61937
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '193'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy82NjQ2NWZmYS05NTFlLTRlZDUtYjNjMy1hODA2ZWVkZmM4NWQv
+        YWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMyZmJlMzcxZmMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvMTRiOWUxZDEtZmFlMi00NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9
+        a2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3YzU2LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzAzZjhlZTRmLTViNzEtNDE1NS1hNDczLWY3OWM1NTA0MzFlMy8ifV19
+        Z2VzLzUyZDE4NWEyLWQxMTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4847,7 +5207,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4860,7 +5220,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4878,21 +5238,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d971f573393747a2912221b38ff19909
+      - 809ecb6ef95346548cbd058bb22799b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4900,7 +5260,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4913,37 +5273,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4790'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 381192ebf8f643f0978ffb0553aeb887
+      - 2a05c6679795468ca14f91145fed24ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1602'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -5016,9 +5376,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -5035,9 +5395,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -5047,10 +5407,10 @@ http_interactions:
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5058,7 +5418,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5071,41 +5431,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '144'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 748286fec1e248aba71a7e3a0f7616f2
+      - fea632dc765c4d43b42e8dc62b1b8b7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '138'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3MWE2
-        ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYyMWNi
+        ZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5113,7 +5473,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5126,41 +5486,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:17 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bca20739e5154870a7beb6b22fba2a82
+      - 89871cce66674009aa6e7a298e2dc22b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ef98ce46-3d90-4a4e-9bf4-aea9cfd1da85/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5168,7 +5528,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5181,36 +5541,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:18 GMT
+      - Fri, 29 Jul 2022 11:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 676bd10cbdd14ae7915024750f041ce8
+      - 525bb5abee154d30bb935d380c44bc7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5232,5 +5592,5 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:12 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_groups_repository/package_groups_copied_if_indicated_by_copied_packages.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_package_groups_repository/package_groups_copied_if_indicated_by_copied_packages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:18 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc20be1c8435445cbd1d32485ce222eb
+      - 996bd3f503ab42fba0888d7e67420545
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84ZGU4NGNkNS1jY2JhLTQyZGUtOTBmYy04ZTA1OTYyNGVlZTAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOToxMS41NzMwMzNa
+        cnBtL3JwbS9iMmI1MzMwMC05Y2M4LTRhZWUtYjcyNC0wMDc3OWExNjJhODYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDo0MS41NDg3NDVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84ZGU4NGNkNS1jY2JhLTQyZGUtOTBmYy04ZTA1OTYyNGVlZTAv
+        cnBtL3JwbS9iMmI1MzMwMC05Y2M4LTRhZWUtYjcyNC0wMDc3OWExNjJhODYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzhkZTg0
-        Y2Q1LWNjYmEtNDJkZS05MGZjLThlMDU5NjI0ZWVlMC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IyYjUz
+        MzAwLTljYzgtNGFlZS1iNzI0LTAwNzc5YTE2MmE4Ni92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/8de84cd5-ccba-42de-90fc-8e059624eee0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b2b53300-9cc8-4aee-b724-00779a162a86/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:18 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7040e914c88c4726ba2e79a7df820c30
+      - 0a52f1c74b87468380df09d95558040c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczZTBlYWUwLTQ1YTgtNDcz
-        Zi05Y2UyLThkMjBjZWMxYjc1MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjMGYwYmY4LWNkNTctNGEw
+        Zi1hZjBmLWRiNzk0NTU4ZjNkZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:18 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ffa88237656641b5ae482682d556e2d2
+      - 59f884c9033940fa99b67c57f7c45172
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/73e0eae0-45a8-473f-9ce2-8d20cec1b750/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fc0f0bf8-cd57-4a0f-af0f-db794558f3df/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 45f79a601286494ea2de7e907cdd6409
+      - 5a57e829bb6042d9b7910b12cc49772b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzNlMGVhZTAtNDVh
-        OC00NzNmLTljZTItOGQyMGNlYzFiNzUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTguOTIzMTQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmMwZjBiZjgtY2Q1
+        Ny00YTBmLWFmMGYtZGI3OTQ1NThmM2RmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTEuMTEyNTEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MDQwZTkxNGM4OGM0NzI2YmEyZTc5YTdk
-        ZjgyMGMzMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjE4Ljk1
-        Mjc4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MTkuMTc4
-        NTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwYTUyZjFjNzRiODc0NjgzODBkZjA5ZDk1
+        NTU4MDQwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjUxLjE1
+        NjM4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NTEuMzc1
+        Mjc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGRlODRjZDUtY2NiYS00MmRl
-        LTkwZmMtOGUwNTk2MjRlZWUwLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjJiNTMzMDAtOWNjOC00YWVl
+        LWI3MjQtMDA3NzlhMTYyYTg2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11ff1421b3a441ae9ed808389c47184f
+      - 32255ed9ea9d46fda92bb6bd555775fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9dcad1cdeb1e4b46be3445d77ccc0817
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vOThiNDY5OTctZDQ3Ny00OGQyLTk5NzUtNDk5MjcxOTYxNTJj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NDUuNzc3MzUy
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/98b46997-d477-48d2-9975-49927196152c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - afaf6bd7e79443e08b5a2c02a3b24142
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0MzBiM2Y0LTNiNjEtNDBh
+        MC1iODQ3LTc5ZjBiZGI5NDVjYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4430b3f4-3b61-40a0-b847-79f0bdb945ca/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7659081efa42407093f868adf26da6be
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDQzMGIzZjQtM2I2
+        MS00MGEwLWI4NDctNzlmMGJkYjk0NWNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTEuNTQwNDQ4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZmFmNmJkN2U3OTQ0M2UwOGI1YTJjMDJh
+        M2IyNDE0MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjUxLjU3
+        NzM5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NTEuNjE1
+        NjkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c4167e09e9f427d869dca73d999a3aa
+      - d5fe387991ee458b8442e0e7b40af53f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad25e96ba57f496cbfe65631797a4f79
+      - bfdefbc8749d4ad0875009d667bf48e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce5588a4562148f49939bc2bedd9031c
+      - 24fc7aa4e9284a71a65b015f5306b4e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b665220d9c1447fc9080c8b59958b5db
+      - 5a57765599b841c7a8171c6ccfe269bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:29:19 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - dcae5d5ec1804117b749b0a41dec264b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/47443c84-6f98-4c2f-8bc5-f4f80e05a5cc/"
+      - "/pulp/api/v3/remotes/rpm/rpm/5e0e7353-c360-48c1-a5cc-3f8a085d24f7/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7decd4ebbc604f3c96fccbb275968a7f
+      - 04a1114b6c5f419cac80a6d4cb6d7728
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ3
-        NDQzYzg0LTZmOTgtNGMyZi04YmM1LWY0ZjgwZTA1YTVjYy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI5OjE5LjY5NTk3M1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVl
+        MGU3MzUzLWMzNjAtNDhjMS1hNWNjLTNmOGEwODVkMjRmNy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjUxLjkwMTY2NloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5j
         X2ltcG9ydHMvdGVzdF9yZXBvcy96b28vIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91
         cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIyLTA1LTIzVDIzOjI5OjE5LjY5NTk5MloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIyLTA3LTI5VDExOjM0OjUxLjkwMTY4N1oiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Imlt
         bWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1l
         b3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19y
         ZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1p
         dCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/"
+      - "/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5186e7e219df4eeca6e66c3ca8df671b
+      - 0d218d3e27d44f1784bbe25b10a954ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOWUwNjQ1ZWEtMTdjMS00YzJiLThiM2MtMTI3NDE3ODMxNWJhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MTkuODEyMTI1WiIsInZl
+        cG0vMDBjYmVjZWEtNWM4Ny00OGQ1LWE4NWUtNDJiMTVhZTA5NDVjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NTIuMDQ4MTE5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOWUwNjQ1ZWEtMTdjMS00YzJiLThiM2MtMTI3NDE3ODMxNWJhL3ZlcnNp
+        cG0vMDBjYmVjZWEtNWM4Ny00OGQ1LWE4NWUtNDJiMTVhZTA5NDVjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85ZTA2NDVlYS0x
-        N2MxLTRjMmItOGIzYy0xMjc0MTc4MzE1YmEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wMGNiZWNlYS01
+        Yzg3LTQ4ZDUtYTg1ZS00MmIxNWFlMDk0NWMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c02168df732747b58ed2152ae0bd8af1
+      - ce1b6cca85ad41cabb1d1c0dd625b3e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hZGI1ODQ4Yi01MjdiLTQzYzUtOTRlZS05Y2QwMzViNzZjZDYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOToxMi4zMzUxMzNa
+        cnBtL3JwbS9lYjcwNTY0Ni0yMDUyLTQxZTktYjZkMS1jODY2ZDFmOGJkZTIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozNDo0Mi40NTM4NzNa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hZGI1ODQ4Yi01MjdiLTQzYzUtOTRlZS05Y2QwMzViNzZjZDYv
+        cnBtL3JwbS9lYjcwNTY0Ni0yMDUyLTQxZTktYjZkMS1jODY2ZDFmOGJkZTIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2FkYjU4
-        NDhiLTUyN2ItNDNjNS05NGVlLTljZDAzNWI3NmNkNi92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ViNzA1
+        NjQ2LTIwNTItNDFlOS1iNmQxLWM4NjZkMWY4YmRlMi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/adb5848b-527b-43c5-94ee-9cd035b76cd6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/eb705646-2052-41e9-b6d1-c866d1f8bde2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:19 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bdbcc8d1bc484d25b1ff169af7a81d1f
+      - abb01a9df7984a2dbed303ba57b3a966
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzMzNjODdhLWJlYjctNDBi
-        Ny1iODQyLTJiMzUxNjE4MGVlYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlYmZkZTk4LTI5OTUtNGJm
+        My04MTU4LThiMTcwOGQ3NTE1My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 502ef3cc326a4a1ebab9a12add00b33d
+      - 55c32c64ca93478cae7549740138360a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZjM3ZGM0ZGYtNGY2NS00NTBiLTg1MDYtMDA4ZmUwMzUyNmJmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MTEuNDU5MzM0WiIsIm5h
+        cG0vOWIyZTI1ZDItNWFiNS00MjE3LWI4NTUtNDExNTE3YzFiMzI4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NDEuNDA3MDU2WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyOToxMi42NTM4ODFaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMTozNDo0Mi45NDQ2OTVaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/f37dc4df-4f65-450b-8506-008fe03526bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/9b2e25d2-5ab5-4217-b855-411517c1b328/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb9809ec5f614c708a0e101defa6d2d1
+      - ca45fc053a6943f490498b937c548e38
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyZjZjYjlkLTUyOGEtNDNh
-        ZS1iNTAxLTM3ODUyODE2NzNhOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjZmEzOWJhLTdiMTMtNDI4
+        Yy04NDJiLTEwYTE2ZjQyOWM2Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5333c87a-beb7-40b7-b842-2b3516180eec/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bebfde98-2995-4bf3-8158-8b1708d75153/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bfc818dee5894b7a8e0135960fbb50ee
+      - f6117b17ee7c4572b9d0e81bf42f0791
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTMzM2M4N2EtYmVi
-        Ny00MGI3LWI4NDItMmIzNTE2MTgwZWVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MTkuOTg0Njk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmViZmRlOTgtMjk5
+        NS00YmYzLTgxNTgtOGIxNzA4ZDc1MTUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTIuMjYzNDA4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZGJjYzhkMWJjNDg0ZDI1YjFmZjE2OWFm
-        N2E4MWQxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjIwLjAx
-        NDkyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MjAuMDgx
-        MTY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhYmIwMWE5ZGY3OTg0YTJkYmVkMzAzYmE1
+        N2IzYTk2NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjUyLjMw
+        MTQ5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NTIuNDAz
+        ODgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWRiNTg0OGItNTI3Yi00M2M1
-        LTk0ZWUtOWNkMDM1Yjc2Y2Q2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWI3MDU2NDYtMjA1Mi00MWU5
+        LWI2ZDEtYzg2NmQxZjhiZGUyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/72f6cb9d-528a-43ae-b501-3785281673a9/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/dcfa39ba-7b13-428c-842b-10a16f429c67/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c62d232c41674ac1a7c2e7224569f967
+      - 74a1165792184b24b742f8b6918ffd67
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzJmNmNiOWQtNTI4
-        YS00M2FlLWI1MDEtMzc4NTI4MTY3M2E5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjAuMDcxMjI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNmYTM5YmEtN2Ix
+        My00MjhjLTg0MmItMTBhMTZmNDI5YzY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTIuMzk0NDg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlYjk4MDllYzVmNjE0YzcwOGEwZTEwMWRl
-        ZmE2ZDJkMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjIwLjEx
-        ODMwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MjAuMTY3
-        MDI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjYTQ1ZmMwNTNhNjk0M2Y0OTA0OThiOTM3
+        YzU0OGUzOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjUyLjQ1
+        MjA5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NTIuNTE4
+        MDk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2YzN2RjNGRmLTRmNjUtNDUwYi04NTA2
-        LTAwOGZlMDM1MjZiZi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzliMmUyNWQyLTVhYjUtNDIxNy1iODU1
+        LTQxMTUxN2MxYjMyOC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 378f756592e3443e8f6160eab03e7342
+      - '080ca694e4f64caea9daa68e54ba0a7d'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1172fca1bd48465b9389d3bf6897dc00
+      - 18a66815c96f44d5ab1a81835644e00c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 15be8b66c7154296a6532644dd2755af
+      - 54940741d99d4f369fabaaa88a320ec4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b6f844e902748bcb676dff3e280a221
+      - a3b8b8df0a4f43dd802815bc3c076498
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 995c89c303f5442f8af02d8181db559f
+      - 395c0bb79c684cc39cb6317a8b134434
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58a63a19ba844d53bb450ead2386b578
+      - 89b61d7f5d574e35b00501c6d4d1e33b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/"
+      - "/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b8eb47271af4b93b74ed6ba4eb4733f
+      - 485480cdf986469a8c71290886db7a97
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZmJlYmNhM2UtMDQ4Yi00MjM4LTgyZWItNzRlZmQ1YzcyNDE2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjk6MjAuNTI0ODQwWiIsInZl
+        cG0vNzBhZmYwZTItNjBiZS00MWEwLTllNDItMTk5MTFjNzhmYjk3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NTIuOTcwOTgyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZmJlYmNhM2UtMDQ4Yi00MjM4LTgyZWItNzRlZmQ1YzcyNDE2L3ZlcnNp
+        cG0vNzBhZmYwZTItNjBiZS00MWEwLTllNDItMTk5MTFjNzhmYjk3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYmViY2EzZS0w
-        NDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MGFmZjBlMi02
+        MGJlLTQxYTAtOWU0Mi0xOTkxMWM3OGZiOTcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:52 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/47443c84-6f98-4c2f-8bc5-f4f80e05a5cc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/5e0e7353-c360-48c1-a5cc-3f8a085d24f7/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7781a1f7080a4168a3ff3edbca907dc8
+      - 871eddc9087140d5af4dd18db2325f40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZhMjc0ZGQzLThhYjAtNGRl
-        NC1hMjk2LWJiODVjNDQ2NzFjNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzZWUzYjdhLTI5MTQtNGUw
+        MC1hZDJjLThiODkwZDRiZDNmMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6a274dd3-8ab0-4de4-a296-bb85c44671c5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a3ee3b7a-2914-4e00-ad2c-8b890d4bd3f1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 843150d8ebff43f0a956b114b778cede
+      - 60be3cbfc9fe44b6bc5d62f7361c670e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmEyNzRkZDMtOGFi
-        MC00ZGU0LWEyOTYtYmI4NWM0NDY3MWM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjAuNzk3Mjg3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTNlZTNiN2EtMjkx
+        NC00ZTAwLWFkMmMtOGI4OTBkNGJkM2YxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTMuMzQ4MTA4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI3NzgxYTFmNzA4MGE0MTY4YTNmZjNlZGJj
-        YTkwN2RjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjIwLjgy
-        OTQyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MjAuODUy
-        NTc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4NzFlZGRjOTA4NzE0MGQ1YWY0ZGQxOGRi
+        MjMyNWY0MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjUzLjM5
+        OTExNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NTMuNDMw
+        NDcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ3NDQzYzg0LTZmOTgtNGMyZi04YmM1
-        LWY0ZjgwZTA1YTVjYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVlMGU3MzUzLWMzNjAtNDhjMS1hNWNj
+        LTNmOGEwODVkMjRmNy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ3NDQz
-        Yzg0LTZmOTgtNGMyZi04YmM1LWY0ZjgwZTA1YTVjYy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVlMGU3
+        MzUzLWMzNjAtNDhjMS1hNWNjLTNmOGEwODVkMjRmNy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:20 GMT
+      - Fri, 29 Jul 2022 11:34:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dea2056224cf4664863916da1da6ecae
+      - 3dcad29f8e814e1fa486193b7c9e9db9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2Njc1NjY3LWQwMTAtNGU3
-        OC1iYzMwLTZmZjVjYWMzZTAyZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2NDkxZDkwLTQ5NDEtNDJi
+        My1iNmE2LWRhZWJmMDc0ZjFmOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/36675667-d010-4e78-bc30-6ff5cac3e02e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c6491d90-4941-42b3-b6a6-daebf074f1f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:21 GMT
+      - Fri, 29 Jul 2022 11:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1865'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c37db69792244306aa8b444db07bb1f5
+      - 56b771f2cf644bf1ac49c42d0feb5986
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '653'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzY2NzU2NjctZDAx
-        MC00ZTc4LWJjMzAtNmZmNWNhYzNlMDJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjAuOTcxOTQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzY0OTFkOTAtNDk0
+        MS00MmIzLWI2YTYtZGFlYmYwNzRmMWY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTMuNTQyNDA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkZWEyMDU2MjI0Y2Y0NjY0ODYz
-        OTE2ZGExZGE2ZWNhZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjIxLjAwMzA3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjEuNzc2ODcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzZGNhZDI5ZjhlODE0ZTFmYTQ4
+        NjE5M2I3YzllOWRiOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjUzLjU4ODU1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTQuNzY3NzM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1714,38 +1839,38 @@ http_interactions:
         bmcubW9kdWxlbWRfZGVmYXVsdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
         cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQ29tcHMiLCJjb2Rl
-        Ijoic3luYy5wYXJzaW5nLmNvbXBzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
-        YXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2aXNv
-        cmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzllMDY0NWVhLTE3YzEtNGMyYi04YjNjLTEyNzQx
-        NzgzMTViYS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85ZTA2
-        NDVlYS0xN2MxLTRjMmItOGIzYy0xMjc0MTc4MzE1YmEvIiwic2hhcmVkOi9w
-        dWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNDc0NDNjODQtNmY5OC00YzJm
-        LThiYzUtZjRmODBlMDVhNWNjLyJdfQ==
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyMCwiZG9uZSI6MjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIENvbXBzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5jb21wcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3Jp
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS8wMGNiZWNlYS01Yzg3LTQ4ZDUtYTg1ZS00MmIxNWFl
+        MDk0NWMvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDBjYmVj
+        ZWEtNWM4Ny00OGQ1LWE4NWUtNDJiMTVhZTA5NDVjLyIsInNoYXJlZDovcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVlMGU3MzUzLWMzNjAtNDhjMS1h
+        NWNjLTNmOGEwODVkMjRmNy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:55 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOWUwNjQ1ZWEtMTdjMS00YzJiLThiM2MtMTI3NDE3ODMx
-        NWJhL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMDBjYmVjZWEtNWM4Ny00OGQ1LWE4NWUtNDJiMTVhZTA5
+        NDVjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1758,7 +1883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:22 GMT
+      - Fri, 29 Jul 2022 11:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1776,21 +1901,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '09db375034ba4930935025ee392bc4f0'
+      - 6f01871663664316a81df8ece3c978bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmYjg1ZjE1LTkzZWUtNGZh
-        MS04ODgwLWY4MTc5NDZkMjZlMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwZmU5OTBhLTJhNjQtNDBl
+        YS05OTM1LTRiZGMzNzBhMjk1ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/afb85f15-93ee-4fa1-8880-f817946d26e3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/50fe990a-2a64-40ea-9935-4bdc370a295d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,56 +1936,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:22 GMT
+      - Fri, 29 Jul 2022 11:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 903950a90c2549daa29fd1831a728a5b
+      - 985f4bdd77f746e8848d30fa959fe96b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '478'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWZiODVmMTUtOTNl
-        ZS00ZmExLTg4ODAtZjgxNzk0NmQyNmUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjIuMDgzNzE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTBmZTk5MGEtMmE2
+        NC00MGVhLTk5MzUtNGJkYzM3MGEyOTVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTUuMTgwMTk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjA5ZGIzNzUwMzRiYTQ5MzA5MzUwMjVlZTM5
-        MmJjNGYwIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MjIuMTE3
-        NzQ3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOToyMi40ODQ1
-        MDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjZmMDE4NzE2NjM2NjQzMTZhODFkZjhlY2Uz
+        Yzk3OGJiIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NTUuMjM5
+        NDMyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDo1NS42NzQz
+        OTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZjFlYWUy
-        MWUtYmM5MC00OTAxLTg0ODUtYzUxNjk1OWZhMTc3LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vN2U1MmU2
+        ZWMtMWUxOC00NDMwLWFjOTctZjNkNWNkNGUxOThlLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOWUwNjQ1ZWEtMTdjMS00YzJiLThiM2MtMTI3NDE3
-        ODMxNWJhLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMDBjYmVjZWEtNWM4Ny00OGQ1LWE4NWUtNDJiMTVh
+        ZTA5NDVjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1868,7 +1993,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1881,35 +2006,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:22 GMT
+      - Fri, 29 Jul 2022 11:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e2aab6be3d674fc0a9d9febad42ed9b3
+      - e8b71344add641ca990a9c9b407f8dbf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1938'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:55 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/7e52e6ec-1e18-4430-ac97-f3d5cd4e198e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f5598eeaac244101bfeeba358776517a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vN2U1MmU2ZWMtMWUxOC00NDMwLWFjOTctZjNkNWNkNGUxOThlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzQ6NTUuMjY1NTI2WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8wMGNiZWNlYS01Yzg3LTQ4ZDUtYTg1ZS00MmIxNWFlMDk0NWMv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzAwY2JlY2VhLTVjODctNDhkNS1hODVlLTQyYjE1
+        YWUwOTQ1Yy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:55 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS83ZTUyZTZlYy0xZTE4LTQ0MzAtYWM5Ny1mM2Q1Y2Q0ZTE5OGUv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - faccae11dae44dc5b14629582e8fd1fb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzYTQ4NGEzLTNiNDgtNDYw
+        NC05ZjdkLTRhMWVhMzIwMWU0My8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/13a484a3-3b48-4604-9f7d-4a1ea3201e43/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4ca66b5674e84acaa71421b727f438ae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTNhNDg0YTMtM2I0
+        OC00NjA0LTlmN2QtNGExZWEzMjAxZTQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTUuOTk2NTA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmYWNjYWUxMWRhZTQ0ZGM1YjE0NjI5NTgy
+        ZThmZDFmYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjU2LjA0
+        ODI2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6NTYuMjgw
+        MDY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDlm
+        YmQyMGYtMDdiNC00MmY1LWI0NzYtZGU2YjMxNTc1Y2JkLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/09fbd20f-07b4-42f5-b476-de6b31575cbd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0d91b77bdba64486a93be57c27d599fd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzA5ZmJkMjBmLTA3YjQtNDJmNS1iNDc2LWRlNmIzMTU3NWNiZC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjM0OjU2LjI2MTExMloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vN2U1MmU2ZWMtMWUxOC00NDMwLWFjOTct
+        ZjNkNWNkNGUxOThlLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:34:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:34:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '7296'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 48d98c0fc5584fec8df9b7921d0d3e51
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyIsIm5hbWUiOiJ3YWxydXMiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiNS4y
         MSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzQ1
         MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVj
@@ -1917,16 +2342,16 @@ http_interactions:
         b2Ygd2FscnVzIiwibG9jYXRpb25faHJlZiI6IndhbHJ1cy01LjIxLTEubm9h
         cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83YTNjNTc5Ni01ZmI4LTQwMjkt
-        YWIzOS04MGQwMjE5YmQ0ODgvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NzIyMmI4NC1jYWVkLTQzYzUt
+        OTM2Zi05YWEwMzU2MzlmMDUvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
         cmNoIiwicGtnSWQiOiI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzli
         OTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwic3VtbWFyeSI6
         IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoi
         d2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Indh
         bHJ1cy0wLjcxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUw
-        YzgyZTlkLWFmODktNDMxMy1iZmVkLWQ0YzRhNmM4MGY5ZS8iLCJuYW1lIjoi
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY1
+        ZmJiOTc0LTE1MmMtNDk2ZS05NDRkLTQ3YzY1YTI1OGFjNy8iLCJuYW1lIjoi
         d2FscnVzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2Ui
         OiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI2ZThkNmRjMDU3ZTNl
         MmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFh
@@ -1934,147 +2359,147 @@ http_interactions:
         LCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
         InJwbV9zb3VyY2VycG0iOiJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwiaXNf
         bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzBhNzVjYjY1LTg3MzEtNGFjMy1iNGQ3LTZl
-        NjdlNTkzZWQzMy8iLCJuYW1lIjoic3F1aXJyZWwiLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCJzdW1tYXJ5IjoiQSBk
-        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNx
-        dWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyIsIm5h
-        bWUiOiJwZW5ndWluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMyIsInJl
-        bGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZmNiMmM5
-        MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZk
-        NmU0ODYzNWJlNjk0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InBlbmd1aW4tMC4zLTAuOC5zcmMu
-        cnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzA1NjFiYzMyLWUwZjUtNGQ3
-        Yi1iY2MzLTQ2MzNhMmM3OTkwZi8iLCJuYW1lIjoibW9ua2V5IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoi
-        bm9hcmNoIiwicGtnSWQiOiIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwic3VtbWFy
-        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCJsb2NhdGlvbl9ocmVm
-        IjoibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8iLCJu
-        YW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxl
-        YXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTI0MDBkYzk1
-        YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2
-        MmVmYTNlNGFlNCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbGlv
-        biIsImxvY2F0aW9uX2hyZWYiOiJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJsaW9uLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
+        bnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkw
+        MzM2ZGQzMGM0Yy8iLCJuYW1lIjoidHJvdXQiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4xMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiYWVhOTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUx
+        YTFiYTI3MzA5MzlkNTdmYzg0MjYwMmUxNCIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgdHJvdXQiLCJsb2NhdGlvbl9ocmVmIjoidHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoidHJvdXQtMC4xMi0x
+        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOWVjYTM4YTItNzhk
+        ZS00ZTZlLTk0MjctYmU3MDk2NTk0MjBlLyIsIm5hbWUiOiJzcXVpcnJlbCIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoiMC44Iiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjUxNzY4YmRkMTVmMTNkNzg0ODdj
+        Mjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBt
+        X3NvdXJjZXJwbSI6InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsImlzX21v
         ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFj
-        OTY2MjVkZmYvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
-        Z0lkIjoiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsInN1bW1hcnkiOiJob3AgbGlr
-        ZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsImxvY2F0aW9uX2hyZWYiOiJr
-        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imth
-        bmdhcm9vLTAuMy0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        ZjRjMDQzZC03NDg3LTRhNzYtODUzMi03ZDdjZDlkZTg5OGYvIiwibmFtZSI6
-        Imthbmdhcm9vIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBi
-        YTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEw
-        M2NlNGNjOCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwi
-        aXNfbW9kdWxhciI6dHJ1ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvMjllNmEyMWQtMmY2OS00Y2QyLWI3MTEt
-        NjFjYzg5Y2Y3MGNlLyIsIm5hbWUiOiJnaXJhZmZlIiwiZXBvY2giOiIwIiwi
-        dmVyc2lvbiI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNo
-        IiwicGtnSWQiOiJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkx
-        YWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0Iiwic3VtbWFyeSI6IkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwibG9jYXRpb25faHJlZiI6Imdp
-        cmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imdp
-        cmFmZmUtMC4zLTAuOC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
+        ZW50L3JwbS9wYWNrYWdlcy9kMWM3OTlhNi1mNzY2LTQ1ODYtYTE5Yi0yNGMy
+        ZmJlMzcxZmMvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFk
+        MmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vp
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vp
+        bi0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzVi
+        YmEwMGItNmYxNi00M2MxLTgxYTUtN2VlOTYyMWRjZTIyLyIsIm5hbWUiOiJt
+        b25rZXkiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6
+        IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIs
+        ImxvY2F0aW9uX2hyZWYiOiJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6Im1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCJpc19t
+        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNjllODNhZDYtMjQyNC00YjkwLTgxZTktM2E1
+        YjFhZDg0YTI0LyIsIm5hbWUiOiJsaW9uIiwiZXBvY2giOiIwIiwidmVyc2lv
+        biI6IjAuMyIsInJlbGVhc2UiOiIwLjgiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
+        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBsaW9uIiwibG9jYXRpb25faHJlZiI6Imxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC4zLTAuOC5z
+        cmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzYyYTQ5ZTM0LTBmMTQt
+        NGU0Ni04ZmMzLTFiZmY3OTlmYjYxZi8iLCJuYW1lIjoia2FuZ2Fyb28iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcy
+        ODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwic3Vt
+        bWFyeSI6ImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwibG9j
+        YXRpb25faHJlZiI6Imthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsImlzX21vZHVs
+        YXIiOnRydWV9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzVhMzI4NDI2LTJiYWYtNDE4OS05Y2M1LTZkOGRjMzVj
+        MTBkNC8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIw
+        YzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBrYW5nYXJvbyIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJvby0w
+        LjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imthbmdhcm9vLTAu
+        Mi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ODA2MDhjMS1i
+        NmFhLTQwOTAtOWFmZi03M2E0NDZjYjZiMDQvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
+        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1
+        bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvN2NmMDVmMmUtYjJjMS00OGIwLTgxMzMtMWJmNzVm
+        ZGQyM2UxLyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIwLjMiLCJyZWxlYXNlIjoiMC44IiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5
+        NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9j
+        MjQ3NDI1NC0xNWEyLTQ0NjQtOWQxMi0yNDFlZjZkNDUzYjAvIiwibmFtZSI6
+        ImVsZXBoYW50IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMzMzNTFmZDZjMmEz
+        OGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0Mzlk
+        ZGQxMjViOSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50
+        LiIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBt
+        IiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTAuMi0xLnNyYy5ycG0iLCJp
+        c19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzItMTBmYy00MDFjLWFmZTUt
+        NTg1YjI5OTM3YzU2LyIsIm5hbWUiOiJkdWNrIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBr
+        Z0lkIjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInN1bW1hcnkiOiJRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4iLCJsb2NhdGlvbl9ocmVmIjoiZHVj
+        ay0wLjctMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1Y2stMC43
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8iLCJuYW1lIjoiZHVjayIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIwLjYiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6Ijk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNl
+        MWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2siLCJsb2NhdGlvbl9ocmVm
+        IjoiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImR1
+        Y2stMC42LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOnRydWV9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2ZkYjk1
+        N2IxLWM5MTItNDFkMS1hOGRmLWZkODQzYTdlZDVhOC8iLCJuYW1lIjoiY2hl
+        ZXRhaCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjMiLCJyZWxlYXNlIjoi
+        MC44IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNDIyZDBiYWEwY2Q5ZDc3
+        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
+        OGRhZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImxvY2F0aW9uX2hyZWYiOiJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9iOTEyYzkwNS02MWY1LTQ3MmItOGU5MS0z
+        NmVjOGZjMzUwNDgvIiwibmFtZSI6ImFybWFkaWxsbyIsImVwb2NoIjoiMCIs
+        InZlcnNpb24iOiIyLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4YThkZjJhMjQx
+        MWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCJzdW1tYXJ5IjoiRmFr
+        ZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRpb25faHJlZiI6ImFy
+        bWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImFy
+        bWFkaWxsby0yLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzk2NTIyODgwLThjNWEtNDgwMS1iNTY3LTFmMmIxZGI3M2RlYy8iLCJuYW1l
-        IjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVs
-        ZWFzZSI6IjAuOCIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjNlMWM3MGNk
-        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
-        MzcyYTBhNzAxZjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwibG9jYXRpb25faHJlZiI6ImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJlbGVwaGFudC0wLjMtMC44LnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzdjMzgwYTAtYWFmZi00
-        M2YyLTlhNmQtN2EyNTJiMDlhYTk2LyIsIm5hbWUiOiJlbGVwaGFudCIsImVw
-        b2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
-        OiJub2FyY2giLCJwa2dJZCI6IjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEy
-        ZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCJzdW1t
-        YXJ5IjoiRmFrZSBwcm92aWRlIGZvciBlbGVwaGFudC4iLCJsb2NhdGlvbl9o
-        cmVmIjoiZWxlcGhhbnQtMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
-        cG0iOiJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8i
-        LCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4
-        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
-        ZTNmNjZjMjQ3MTIiLCJzdW1tYXJ5IjoiUXVhY2sgbGlrZSBhIGR1Y2sgYXQg
-        dGhlIHBhcmsuIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC43LTEubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNy0xLnNyYy5ycG0iLCJp
-        c19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1m
-        NzljNTUwNDMxZTMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
-        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3Iiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjp0cnVlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2ExLTRkNmYt
-        YjYzZC1jZTcxZWZlNTZjNWEvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6
-        IjAiLCJ2ZXJzaW9uIjoiMC4zIiwicmVsZWFzZSI6IjAuOCIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIz
-        ZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVm
-        IjoiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxz
-        ZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzYwOGNlMzctMWM3MS00YWQwLTkwYWMtZWVkNzQ2MGM1NjFiLyIs
-        Im5hbWUiOiJhcm1hZGlsbG8iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4x
-        IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhYmY2
-        OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4
-        OWU2ZjNkOGQxZmYzOTlmIiwic3VtbWFyeSI6IkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsImxvY2F0aW9uX2hyZWYiOiJhcm1hZGlsbG8tMi4xLTEu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJhcm1hZGlsbG8tMi4xLTEu
-        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMDc3OTJjMy1hNDJk
-        LTQ3MGMtYTI2MC1iZWJhNjIwMDM0OWYvIiwibmFtZSI6ImFybWFkaWxsbyIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1
-        MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCJz
-        dW1tYXJ5IjoiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwibG9jYXRp
-        b25faHJlZiI6ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6ImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxh
-        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2ExOWU0N2NiLWQ2ZDYtNDJlYS05NzMyLTMyODUyMTY0
-        MjQyZS8iLCJuYW1lIjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lv
-        biI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lk
-        IjoiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3
-        YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsInN1bW1hcnkiOiJGYWtlIHByb3Zp
-        ZGUgZm9yIGFybWFkaWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxv
-        LTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4
-        NmUtZmE0NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIm5hbWUiOiJ0cm91
-        dCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEyIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsImxvY2F0
-        aW9uX2hyZWYiOiJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
-        Y2VycG0iOiJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
+        LzA1ZTM2OGQ3LTI5MWEtNDMzNi1hZGJkLWQ4OWI3YjAxZDg0Ni8iLCJuYW1l
+        IjoiYXJtYWRpbGxvIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOGQzMTk5MDVl
+        ZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2
+        ZjUxYWIzYjY1YSIsInN1bW1hcnkiOiJGYWtlIHByb3ZpZGUgZm9yIGFybWFk
+        aWxsby4iLCJsb2NhdGlvbl9ocmVmIjoiYXJtYWRpbGxvLTAuMi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTA4MDQ4MjctNjRjOC00NTky
+        LTgzODQtYjI3NmZmYTdlODI2LyIsIm5hbWUiOiJhcm1hZGlsbG8iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJhZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0
+        NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4YTYxZGRjMjdiNTg5Iiwic3VtbWFy
+        eSI6IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsImxvY2F0aW9uX2hy
+        ZWYiOiJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2Vy
+        cG0iOiJhcm1hZGlsbG8tMC4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2507,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2095,36 +2520,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:22 GMT
+      - Fri, 29 Jul 2022 11:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '5579'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 118192b3b0aa4a6589d5deefbeef58e4
+      - f83883d6b28043fcbfeadefd631bb1ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2331'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjk3NjU0
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuNDE5MTE2
         WiIsIm1kNSI6bnVsbCwic2hhMSI6Ijc3OWQ2OGMzYTU5NjJiYTljMTFlYjhi
         YmI3M2U3NjM2NmZkZTg3MGUiLCJzaGEyMjQiOiJkOWJhNDE2YjEzZDIwNGUz
         NjY2NWQ5Yjc4YWZmODYxNDE4OGRlZWFiNjZiNWMzYzcwYTZlYWE2YiIsInNo
@@ -2135,17 +2560,17 @@ http_interactions:
         LCJzaGE1MTIiOiI2OGZhYjdkODVkYjNkYTZkMmMxYzkyNjhkYTIxZjI3YmE4
         ZTJiMWE1NDlhNmQ1YjhjY2VkMTM1MDZlODcxNDUyOGVkOGQ3MjE2YmRiZmE0
         MjZhODVjOWE0MTI1YjA2YTFjMDFjNjJmYjg2YTA0Zjc1YjkzMzY3ZTI3Njg2
-        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wYzEy
-        NzA5NS00ZTQ5LTRhOTItYmI3OS0yNGQ0ZjlhN2E4MDUvIiwibmFtZSI6Indh
+        OWZjMCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kMThh
+        ZmMxNS0xN2VlLTRkNTgtYjhmYi1mNDczMDBkNmNiYTIvIiwibmFtZSI6Indh
         bHJ1cyIsInN0cmVhbSI6IjUuMjEiLCJ2ZXJzaW9uIjoiMjAxODA3MDQxNDQy
         MDMiLCJzdGF0aWNfY29udGV4dCI6ZmFsc2UsImNvbnRleHQiOiJkZWFkYmVl
         ZiIsImFyY2giOiJ4ODZfNjQiLCJhcnRpZmFjdHMiOlsid2FscnVzLTA6NS4y
         MS0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2JmNDAzZTItZTRj
-        ZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyJdfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYzlhNjVmYWMtYzVj
-        Ni00NjJhLWFiMjAtMDYyYWJjYjRhY2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjY6NTguMjkwODE4WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNDYwMTkyZmMtN2Vm
+        Zi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVhLyJdfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvYmNmNzllMjgtY2Q0
+        MC00ODE1LTg4ZGEtODQxZGE3YWMwMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjhUMTU6MDQ6MzQuNDA2NTM5WiIsIm1kNSI6bnVsbCwic2hhMSI6
         ImIzNTE0OTU0ZTBiNzZhNzFlMDcwMjIyZGVjOGIxZWU1MGMxNjQ1YzkiLCJz
         aGEyMjQiOiIxMTg4YWVlYTk4YmM0NWRjZjljMDQ2YTA0NTBhZjc1MzFhNzgy
         NGQ2MDMzYzljNGFiODIwZmYxNSIsInNoYTI1NiI6IjhlNzEwYjcxYjMwZDQ2
@@ -2156,17 +2581,17 @@ http_interactions:
         ZmZhODM5Mzc1Yjc0NDQ2OWY0NDdhNjYzNDE4NDJhYTA5ZWE2Yjk3OWE4OWZl
         N2M2OGY2OGU4NmUzZWY5MDViMWJmYTM5NTdmNTM5ODJlMDJlN2Q2NWE0NmQ0
         MTYzNTA1ZTlhODE4NTNmNGJiOTQ1NjE1MDViOCIsImFydGlmYWN0IjoiL3B1
-        bHAvYXBpL3YzL2FydGlmYWN0cy82MWIwNGUzOC0yMTYyLTRkZTEtYWNhNi0y
-        ZjhmMmFiNDM1YmEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
+        bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdhNGI1ZC00N2U2LTQ5ZDAtOWE2ZC0w
+        Y2YzYjhmNDIwNGEvIiwibmFtZSI6IndhbHJ1cyIsInN0cmVhbSI6IjAuNzEi
         LCJ2ZXJzaW9uIjoiMjAxODA3MDcxNDQyMDMiLCJzdGF0aWNfY29udGV4dCI6
         ZmFsc2UsImNvbnRleHQiOiJjMGZmZWU0MiIsImFyY2giOiJ4ODZfNjQiLCJh
         cnRpZmFjdHMiOlsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCJkZXBlbmRl
         bmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2EzYzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJk
-        NDg4LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9tb2R1bGVtZHMvNTY4YzdhMzAtNjk3MC00OGRhLThiODUtZjkzYmRjMTFm
-        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTguMjgw
-        NDUxWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
+        cG0vcGFja2FnZXMvOTcyMjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5
+        ZjA1LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9tb2R1bGVtZHMvM2IwNmQyNDYtMmE5Mi00MGU1LWFlMDUtZWIxNGVmN2Ex
+        MTkxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQuMzc1
+        MjcwWiIsIm1kNSI6bnVsbCwic2hhMSI6ImNmMzIxNDU1MWEwZTA5MmU4Yjcx
         OTUxMTNhNmM4ZDljNTg3Yjc2MzIiLCJzaGEyMjQiOiI5NDVjNTY1MTIyMDAw
         ZTA5MmUwY2Q0NTk1MjdlNDZiNWRhOWQ5M2FiYTg2YTU3NjU5ZmFlMzZjNyIs
         InNoYTI1NiI6ImRmNDk4NGEwZjMwYzM3ODg3N2E5YmQ1NjRlZjUwMjgxZWE4
@@ -2176,17 +2601,17 @@ http_interactions:
         YjQiLCJzaGE1MTIiOiI4Nzk5ZTY2NDhiZWNkNTYzYjQyOTRhNzI4OTIwMDc1
         ZThlODU5NzE3NDg1MzNiYWYyY2VjNzc1MjQ1Yzk5ZTMyOGNjMjkyZWU1OWUz
         MzY2ZDJhYWFkOWFlZTk4MjE3YWFiZWFhOTE1YWViMWIwNjBjNTY1Njk4ODcw
-        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
-        OGJmMzg3Zi00ZWVjLTRhNTQtYWI0NC1jMDQzNTVmMzQ1YmEvIiwibmFtZSI6
+        YjM3NjNjNyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        YzA5ZDQ2YS01ZjYzLTRhYjItYTg3MC04YWQxNzBhOTYwODEvIiwibmFtZSI6
         Imthbmdhcm9vIiwic3RyZWFtIjoiMCIsInZlcnNpb24iOiIyMDE4MDczMDIy
         MzQwNyIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwiY29udGV4dCI6ImRlYWRi
         ZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0cyI6WyJrYW5nYXJvby0w
         OjAuMy0xLm5vYXJjaCJdLCJkZXBlbmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6
-        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGIyNTE3Mzgt
-        NmE0OC00M2NiLWI3OWEtZjBhYzk2NjI1ZGZmLyJdfSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvOGFhYjgyYTMt
-        ZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyIsInB1bHBfY3JlYXRlZCI6
-        IjIwMjItMDUtMjNUMjM6MjY6NTguMjc5MjMwWiIsIm1kNSI6bnVsbCwic2hh
+        WyIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJhNDllMzQt
+        MGYxNC00ZTQ2LThmYzMtMWJmZjc5OWZiNjFmLyJdfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvM2I5YjliNTkt
+        MjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjItMDctMjhUMTU6MDQ6MzQuMzcyMDc1WiIsIm1kNSI6bnVsbCwic2hh
         MSI6ImU1NWZlNjVhN2MyNTlmZWMxZjNjNzM0NzY1N2Q1ODI3MzQxZjhkYjAi
         LCJzaGEyMjQiOiI5NDA5MWJkMmU2YzUzNjRiMzFjNDdlNzcyZTdkMDI2YzI2
         YjdlNGVjNzFhNzZiNTYwNjc1NzA0YyIsInNoYTI1NiI6IjM4ODRkZGQ4MWJh
@@ -2197,17 +2622,17 @@ http_interactions:
         NDBhYmIzZGE2NjcyNTM2YTUyZGRmODAzMzg3ODA3ODYyMzg0OGJhZTlhNDI2
         ZWExYjhlMDA4ZGM0MWQxMzEwOGJlYjMzNmRjYmUyNzQyMWU5MzBjMWZhOGE3
         NzI1ZjFlMzljZGQ4M2FhNTUwZjMzODM3ZTg1MjQwNiIsImFydGlmYWN0Ijoi
-        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85N2Y5YmNjYi05YjdiLTQxNTEtYjJl
-        YS1hNjBlY2Q1ZjhlNjcvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy80M2VlNmI0Yy01NTZjLTRlMmQtYjE4
+        Zi1iODY2MWU3MmZlMzAvIiwibmFtZSI6Imthbmdhcm9vIiwic3RyZWFtIjoi
         MCIsInZlcnNpb24iOiIyMDE4MDcwNDExMTcxOSIsInN0YXRpY19jb250ZXh0
         IjpmYWxzZSwiY29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIs
         ImFydGlmYWN0cyI6WyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCJkZXBl
         bmRlbmNpZXMiOltdLCJwYWNrYWdlcyI6WyIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvOGY0YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5
-        ZGU4OThmLyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZHMvNDg4Mjg4MjAtNGRkNC00YWUzLWIwYjktNjI4Mzc5
-        NGQ0YWFjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6NTgu
-        MjY2MDcyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
+        dC9ycG0vcGFja2FnZXMvNWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMz
+        NWMxMGQ0LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9tb2R1bGVtZHMvMTVlYTc4MDAtOWNkZS00ZTk5LWJhZTMtNzBkNGM2
+        ZTkwNzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6MzQu
+        MzQ2MzI0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjU2OTM0YTcxODllZmY4OWE2
         Njc5ZTZkMzMwNDE5YjZiYTZmZDk0MTgiLCJzaGEyMjQiOiIxOWZhMDhhZjUz
         ZTA4YTkxNjYzMGUxMzgxMmVhOTk1ZGQ1Mzk1YzE3MTBiZjIyZDJlMzk1ZTkz
         ZCIsInNoYTI1NiI6IjIyZTA0YzRiYTA5ZGQxNjVkYzNiMzlhZTZhY2VhOGJi
@@ -2218,16 +2643,16 @@ http_interactions:
         OWQwOGI0NjBkYTkyZjUwMjA2NDdkZTA0NDliNjExMmRhZTlhM2RkZDM1MzE3
         N2RiZDQwMTc2NGU1NjBhZjY2YmNlODI4OWMxZGY2NmQ3NTVkNWM4NGMxMDM4
         NjU0NTkyZjFmOCIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
-        cy8xMzk0OTUyNS1lNDI4LTQxOWYtOTM0OS1iZDgzOTcxMGNjMmUvIiwibmFt
+        cy84ODE0NTJhZi02YTIyLTQ0M2QtOGNhYy01ZjdlNWE2YzAzYWMvIiwibmFt
         ZSI6ImR1Y2siLCJzdHJlYW0iOiIwIiwidmVyc2lvbiI6IjIwMTgwNzMwMjMz
         MTAyIiwic3RhdGljX2NvbnRleHQiOmZhbHNlLCJjb250ZXh0IjoiZGVhZGJl
         ZWYiLCJhcmNoIjoibm9hcmNoIiwiYXJ0aWZhY3RzIjpbImR1Y2stMDowLjct
         MS5ub2FyY2giXSwiZGVwZW5kZW5jaWVzIjpbXSwicGFja2FnZXMiOlsiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTIt
-        NDQ1ZC1hODc3LTkzOTlmOGU2NWMwZC8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMt
-        NDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
-        LTA1LTIzVDIzOjI2OjU4LjI2NDc1NFoiLCJtZDUiOm51bGwsInNoYTEiOiJj
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMt
+        NDAxYy1hZmU1LTU4NWIyOTkzN2M1Ni8iXX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1ZTg1LTA1NTUt
+        NGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIy
+        LTA3LTI4VDE1OjA0OjM0LjM0MjM0N1oiLCJtZDUiOm51bGwsInNoYTEiOiJj
         NzFiMjA3NzVjOWMzNWMyMjE1YTI5M2M4OGM2OGE2NDdmY2QzNzc2Iiwic2hh
         MjI0IjoiYmE4ODgwZGEyMzgzZGJmODVjYTVlN2IyNzA4OWI4ZGE2YTc5YWEx
         MjdmMmZiMmE0Nzg3MTA1MDQiLCJzaGEyNTYiOiIzNzk5MWRhNGYzOGM0MjFh
@@ -2238,18 +2663,18 @@ http_interactions:
         NWNlMWZiMjc3ODk3M2Y3YWJmNjM3NDc2OWVmMzM5ZjcyZjg3OTJkMjEzMDRi
         MDgzODc4YzEzNjMwNmEwZThjOGJmMjUwMTY4ZDVkOWNlODE2ODNjN2FmNDUy
         YzJiZDkzOTgzOTY5YmUyOThlZjE4YWZhM2MiLCJhcnRpZmFjdCI6Ii9wdWxw
-        L2FwaS92My9hcnRpZmFjdHMvY2ZlOGM4NTMtYzgyMi00ZmJkLWE1NDYtYjY0
-        ZjQ2MzI0Y2YxLyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
+        L2FwaS92My9hcnRpZmFjdHMvMzZiOTBkZjgtZDMxZS00OTZiLWIzYjEtODU0
+        YWExOTEzMzM1LyIsIm5hbWUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInZlcnNp
         b24iOiIyMDE4MDcwNDI0NDIwNSIsInN0YXRpY19jb250ZXh0IjpmYWxzZSwi
         Y29udGV4dCI6ImRlYWRiZWVmIiwiYXJjaCI6Im5vYXJjaCIsImFydGlmYWN0
         cyI6WyJkdWNrLTA6MC42LTEubm9hcmNoIl0sImRlcGVuZGVuY2llcyI6W10s
         InBhY2thZ2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wM2Y4ZWU0Zi01YjcxLTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIl19XX0=
+        cy81MmQxODVhMi1kMTEzLTRhY2MtOWUxOS04NGI5YzQ5NTRlZWQvIl19XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +2682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,37 +2695,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '8824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f49916bc9cac4305beb245dea555ce2d
+      - 8d1fd9ce9863459fb46e7e7bf5655dc8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '2058'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -2373,9 +2798,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvN2FhZDAzMDgtMTgyYy00YzRhLThlMWQt
-        ZDcxNTNhZDc4NDIyLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjY3ODM1WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMjM5ZjdmOWMtZTQwZi00NjU4LWE4ZmIt
+        YzE1ZTNjYmQ3NjRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzQ5NjgwWiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
         LCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiQXJtYWRpbGxv
         IiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJvbXN0
         ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -2391,8 +2816,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIyLjEi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0ZS05ZWY3LWQwOGUxMzg2ODRlMS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI1OTA4Nloi
+        c29yaWVzLzM5YjRlNGY3LWQ3N2MtNDA2Ni05MmQwLTk1MGZmMGUyYmU2OS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjMzMDkwOFoi
         LCJpZCI6IlJIRUEtMjAyMTo5OTk5IiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         MS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU291cmNlIFJQTSBFcnJh
         dHVtIiwiaXNzdWVkX2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZnJv
@@ -2410,9 +2835,9 @@ http_interactions:
         LjAtMS5zcmMucnBtIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9u
         IjoiMS4wIn1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVk
         IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8zODUzMGFlNi00YmM2LTQxNmYtYmJlZS05NjEwNmE0
-        Y2Y5NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4y
-        NDkyMjNaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
+        cG0vYWR2aXNvcmllcy83MTFmODM5OS01NDYzLTQ1YWMtYWU2My1mNzkzMDA1
+        ZmRmOTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4y
+        OTMxMDBaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMDowMTExIiwidXBkYXRl
         ZF9kYXRlIjpudWxsLCJkZXNjcmlwdGlvbiI6IkR1cGxpY2F0ZSBPbmUgcGFj
         a2FnZSBlcnJhdGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTItMDEtMDEgMDE6MDE6
         MDEiLCJmcm9tc3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6
@@ -2434,9 +2859,9 @@ http_interactions:
         b3JhcHJvamVjdC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNp
         b24iOiIwLjMifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0
         ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9hZHZpc29yaWVzLzI5NmU1MDU0LTgyMjUtNDMzYy1hM2NkLTY0MWMx
-        MDA5NTExMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4
-        LjI0ODA1OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
+        L3JwbS9hZHZpc29yaWVzLzlhMWNkYjY4LWU3ZGQtNDkwYS04Njg5LTUxNGUz
+        Y2QwYWY0ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0
+        LjI5MTE4OVoiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCJ1cGRh
         dGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiT25lIHBhY2thZ2UgZXJy
         YXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAxIiwiZnJv
         bXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUi
@@ -2452,9 +2877,9 @@ http_interactions:
         dy5mZWRvcmFwcm9qZWN0Lm9yZyIsInN1bSI6IiIsInN1bV90eXBlIjoiIiwi
         dmVyc2lvbiI6IjAuMyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvZjE3ODkzMDgtZDIzZC00NDgwLThmMjEt
-        MmM5MjAxMDcxM2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjQwOTk2WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYt
+        YjBlMDc4OTYzOGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMjc3MjA3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIs
         InVwZGF0ZWRfZGF0ZSI6bnVsbCwiZGVzY3JpcHRpb24iOiJFbXB0eSBlcnJh
         dGEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTAtMDEtMDEgMDE6MDE6MDEiLCJmcm9t
         c3RyIjoibHphcCtwdWJAcmVkaGF0LmNvbSIsInN0YXR1cyI6InN0YWJsZSIs
@@ -2463,9 +2888,9 @@ http_interactions:
         biI6IiIsInJlbGVhc2UiOiIxIiwicmlnaHRzIjoiIiwicHVzaGNvdW50Ijoi
         IiwicGtnbGlzdCI6W10sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2Vz
         dGVkIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vYWR2aXNvcmllcy82M2ZiZjAyYS00MjU5LTQzYWUtOWE3Ni0xMmJm
-        Yjg3ODk1NmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yMzgyMzdaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
+        dC9ycG0vYWR2aXNvcmllcy9lYTVmMDQ2Mi02MmFiLTRjMWYtYTY0ZC1iOTFk
+        MDZjNDViNmYvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4yNzIxODRaIiwiaWQiOiJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwidXBk
         YXRlZF9kYXRlIjoiMjAxOC0wNy0yMCAwNjowMDowMSIsImRlc2NyaXB0aW9u
         IjoiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCJpc3N1ZWRf
         ZGF0ZSI6IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJyYXRh
@@ -2494,10 +2919,10 @@ http_interactions:
         In1dfV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxz
         ZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2505,7 +2930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2518,37 +2943,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2320'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96d2ce5fd65e49708ceed0f7448ebb86
+      - 6260f383f3f94ba39c0403ce032fd390
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '572'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3
-        MjI3MVoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1
+        NzM1NFoiLCJpZCI6Im1hbW1hbCIsImRlZmF1bHQiOnRydWUsInVzZXJfdmlz
         aWJsZSI6dHJ1ZSwiZGlzcGxheV9vcmRlciI6MTAyNCwibmFtZSI6Im1hbW1h
         bCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJiZWFy
         IiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6bnVs
@@ -2585,9 +3010,9 @@ http_interactions:
         bmciOnt9LCJuYW1lX2J5X2xhbmciOnt9LCJkaWdlc3QiOiJmNDU5OTdkOTM4
         MDMzMTQxMzIxOGU1NTVkMjdkM2JhZDAwNTU2ZDYxOTJlMzZjODJiZjU5MTVl
         Y2RiMWQyZTJlIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1m
-        ZDJlNzFhNmRhYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoy
-        Njo1OC4yNDU2NTdaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
+        dC9ycG0vcGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0x
+        NGJmMjFjYmRiZTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTow
+        NDozNC4yODY1NTVaIiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNl
         cl92aXNpYmxlIjp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoi
         YmlyZCIsImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJk
         dWNrIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNob25seSI6
@@ -2597,10 +3022,10 @@ http_interactions:
         OiI2YjQ4MDA0ZDYzNzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNi
         NDg1NGU4ODkxMTg3N2FhZTQ2M2M2In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2608,7 +3033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2621,35 +3046,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '379'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c10657bd38cb419d9eb34cfdcdee68a5
+      - d7ee045477854c8c8c58cbc5f60e26fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '284'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         IiwibmFtZSI6InRlc3Qtc3JwbTAxIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNTRj
         YzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2OTJmNTNiMGM2YWVm
@@ -2657,10 +3082,10 @@ http_interactions:
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         MS0xLjAtMS5zcmMucnBtIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2668,7 +3093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2681,36 +3106,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed22834d8b544bfba916ddf4a213bd4b
+      - 4afb2af595c745e1a037adece983c4c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -2732,10 +3157,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2743,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2756,35 +3181,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fac3cb925eab48298920c100d6c21d95
+      - 02c9d8e2837d43a4a1780a9c409ebb65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -2795,10 +3220,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2806,7 +3231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2819,35 +3244,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 379a96b5d94f425c923a93e3f4a2faf6
+      - 72cd1d7831464b298458cfbf427d1eda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2886,10 +3311,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/0fca103c-2ec6-447b-ac71-6b2c86ad8dbb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/5e1d0db4-d10d-41c2-a400-39ee193f920a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2897,7 +3322,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2910,35 +3335,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1761'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08aea7cbb26149b0b551a64c74422596'
+      - b141982310d74188990092de26fd2de9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '435'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZhZDhkYmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNzIyNzFa
+        ZWdyb3Vwcy81ZTFkMGRiNC1kMTBkLTQxYzItYTQwMC0zOWVlMTkzZjkyMGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4zNTczNTRa
         IiwiaWQiOiJtYW1tYWwiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zpc2libGUi
         OnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJtYW1tYWwiLCJk
         ZXNjcmlwdGlvbiI6IiIsInBhY2thZ2VzIjpbeyJuYW1lIjoiYmVhciIsInR5
@@ -2977,10 +3402,10 @@ http_interactions:
         MTMyMThlNTU1ZDI3ZDNiYWQwMDU1NmQ2MTkyZTM2YzgyYmY1OTE1ZWNkYjFk
         MmUyZSJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,35 +3426,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd53c496702244b7bc732eeaabb2630b
+      - c4e0d0cb2c84423e90d21d2f7840bd53
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3040,10 +3465,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/ef1e7c4d-03d7-490d-ab96-fd2e71a6daa3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/458c1d84-75f1-4fad-b55f-14bf21cbdbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3051,7 +3476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3064,35 +3489,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '506'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a37cac1d244e4c2a84b2a3fbdf63516c
+      - 801dd5adc7214c67ab7ed455079d32f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '323'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy9lZjFlN2M0ZC0wM2Q3LTQ5MGQtYWI5Ni1mZDJlNzFhNmRhYTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1OC4yNDU2NTda
+        ZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFjYmRiZTkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDozNC4yODY1NTVa
         IiwiaWQiOiJiaXJkIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxlIjp0
         cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoiYmlyZCIsImRlc2Ny
         aXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJkdWNrIiwidHlwZSI6
@@ -3103,10 +3528,10 @@ http_interactions:
         NzBkNTk0ZTk3ZGJkMmQ1N2UyZmQ0ZTUzMGZlOTQyMGNiNDg1NGU4ODkxMTg3
         N2FhZTQ2M2M2In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3114,7 +3539,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3127,37 +3552,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '954'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ed4811ed6b34b9eb9421e23f4b6c503
+      - 7e176b614e66441e96a96ae92a6329c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '534'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9y
-        ZXBvX21ldGFkYXRhX2ZpbGVzL2Y0N2EzZmU2LTJjNDYtNDNlZC1iZWY0LWQz
-        MTI0NDExYmQyNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI4NjE2MVoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
+        ZXBvX21ldGFkYXRhX2ZpbGVzLzRhYmY1MzdmLWI5YzAtNDIzMS04N2QyLWUx
+        MzAzYmZkZmE1Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjM5MzgxMFoiLCJtZDUiOm51bGwsInNoYTEiOiI1MjJlOTYxMjZjY2I4
         YWNhNGIzZGFlZmE0ZTE2MzdiOGM2NzZkMWUyIiwic2hhMjI0IjoiYTIzMDU3
         M2UwYjRhYTQ3NmIxZDViZTVkY2Q0Mzg4YjFlM2VjMGQ3ODJkYTA2OGRiMDg2
         YTQ2YzAiLCJzaGEyNTYiOiJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2ZTI3NzVh
@@ -3168,7 +3593,7 @@ http_interactions:
         NmRjNTIyMDUxMDQ5MjJkN2M5MDFlNGFiNGJkZWE0Y2M5M2I2ZjVhNGU2M2Q2
         ZjVjNzBkNmEyNmNmNmYxZTY2NGU1YmQxOWZlZDM1NDc5YWU2OTQ3YzQyNDQy
         NzZmMjQxMjU2NWE4YzYiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
-        ZmFjdHMvY2ExMzFlNzMtYzlkOS00NjU5LTlhNTktYzZjNTY0YTRiM2Y5LyIs
+        ZmFjdHMvYmQ4MGU1OTktOWZlMy00MjhmLWEzOTAtNTczNDVkYmIxZGI2LyIs
         InJlbGF0aXZlX3BhdGgiOiJyZXBvZGF0YS9iYTgyZDRjN2E3YzBiMGE2YTU3
         NTA2ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMy
         LXByb2R1Y3RpZC5neiIsImRhdGFfdHlwZSI6InByb2R1Y3RpZCIsImNoZWNr
@@ -3176,10 +3601,10 @@ http_interactions:
         YTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhlODc1OTli
         OTUyMzIifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3187,7 +3612,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3200,36 +3625,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d8d1cfe27bc4557821a330c7ceecd04
+      - 5cc7279456324fca8d153aaf0a245fa3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -3251,10 +3676,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3262,7 +3687,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3275,37 +3700,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dc604da78ba64a79b797056bb71bf044
+      - f4ccb111376149bebbab303aafed1b2f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1122'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFm
-        Yjc3NjQ4NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNjo1
-        OC4yNTY3MzZaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
+        b2R1bGVtZF9kZWZhdWx0cy80MmJhZGY4Zi0xMDBlLTRhOGQtYTAyZC1mMjAz
+        Y2EzMGNmOTQvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNTowNDoz
+        NC4zMjQ5ODVaIiwibWQ1IjpudWxsLCJzaGExIjoiODFiNDVhNTJlYjAzMDE3
         OGExZTA1NmJlZmQzMDdlMzJhN2JlYTNlYyIsInNoYTIyNCI6Ijg1ODc5Y2Vl
         ZTllNGFmZGIyMzIzNjVlOWZkMDEwZDJhNTNmMTU4YmZlODAyYTIyNTI5NDdk
         NjhmIiwic2hhMjU2IjoiYzBjMzg2YWEzNTE1MzBiYTQ1OTI2MjViYWNkMzRl
@@ -3316,12 +3741,12 @@ http_interactions:
         NGU2Mjc5ZDk4MmNkZmNjOGI5ZTljNjM1YzM5NjYyYzI1ZDZmOWUxMmQzOTE0
         OGU3NmNjYjlkNTc1NmY2MDc4YzBmZmJhNGRkOWI2YWU2NzlmMTRkOTU2Yjll
         ZDJkZjlkNjE5M2JlIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzL2ZjYzc3OTkxLWZhOTAtNDJkZS1hMWJiLThkNzVjZTBjMzlhNC8iLCJt
+        Y3RzLzgxMzNiNmFkLTUwOWQtNDNhMS1hZjE0LTk2MWQ5NjUwYTEyZi8iLCJt
         b2R1bGUiOiJkdWNrIiwic3RyZWFtIjoiMCIsInByb2ZpbGVzIjpbImRlZmF1
         bHQiXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTctMzUz
-        YThjZTUxNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjY6
-        NTguMjQ2ODk0WiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
+        bW9kdWxlbWRfZGVmYXVsdHMvYjE4ZGU1YjQtNGUzZi00NjBmLTk0ZWYtMDY5
+        ZjQ5YjgyMzIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6MDQ6
+        MzQuMjg5NzAxWiIsIm1kNSI6bnVsbCwic2hhMSI6IjNhMzhmMjFhNzJhOTBk
         ZDllMjBhNWUzYmZjYmZlZjZiODA0YmNlM2YiLCJzaGEyMjQiOiJiOTU1OTAw
         OGQ1ZGEzOGIxYzVmNzdlMTVkNDA0ZDg3MDE3MDE1NDRkMGM1OWU4NzliNDVl
         ZmUzZiIsInNoYTI1NiI6Ijc0MzdmMzU5M2E5MmJjNTMyM2E5MGUzMTdmODA1
@@ -3332,12 +3757,12 @@ http_interactions:
         YzFhOTFiOGNjNGI0ZmI4NjFiZWYyZTE3NzFhYjBhYTdhYjM5NmQxMTE4YjNi
         YmY4N2Y4Yjk3NGY1ODZjYjRiOGQ1MDhiZGJmYWY3MTU2ZDRkOThkOGUyNDc0
         MWM5MTRjZjlmNjMzYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
-        YWN0cy9hYTViZjc3OS0yOWExLTQyODYtOWE5Yi1iMDdmMDcyMGQ5ZjcvIiwi
+        YWN0cy85MTk2MjViOS1lN2NiLTQ5YzAtYTVmYi05OWZiNmIzMmMwMDUvIiwi
         bW9kdWxlIjoia2FuZ2Fyb28iLCJzdHJlYW0iOiIwIiwicHJvZmlsZXMiOlsi
         ZGVmYXVsdCJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mMGE3NzVlZi03MTRiLTQyZTktYWRj
-        My1hNGE4MGY3OWVkNzMvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1Qy
-        MzoyNjo1OC4yNDQ0MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
+        L3JwbS9tb2R1bGVtZF9kZWZhdWx0cy9mOWQwNGQyZC0zYWRkLTRmZDgtYmU2
+        MC02NDE5Yjg2M2U1NzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQx
+        NTowNDozNC4yODM5MDdaIiwibWQ1IjpudWxsLCJzaGExIjoiZmU3YjM5MjEx
         YjdjYTY3NDU0NDM4MTdmYTA5MGNjODAyYmMxY2I2NCIsInNoYTIyNCI6IjA5
         N2UyNmQ0MDRmZWJkZGY4ZjJkNjRiOTBlZDc4NzNhZTBlZTI4YWIzNmQ3OWRm
         YzIxZTFiMDRkIiwic2hhMjU2IjoiNjQ0ODY5MDhmNTExNTU4MWI4MGVlY2Ey
@@ -3348,14 +3773,14 @@ http_interactions:
         MmNmMWUzMjJjYmY3YzgxOGE5ZjQxZTJjYTU0NjA0YjZhZTUyNmVhMzMwNGFj
         NTk4ZmVkMjc3NDRiZDVlNmNkNjFhYzA5Y2Q5NjFlYzI0NDU4NDYyYjIyNTE3
         ZjZiNjY0Yzk5NWUxZDk1MTE0IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzE1ZDA4NTcwLTg2NzUtNDNkZi05ODEwLTgyZGVmNDllZmFk
-        My8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
+        YXJ0aWZhY3RzLzc5MTRmZTVmLTZkNWEtNDU3Yy05ZjUyLTEzYzdiY2RmZjhl
+        OC8iLCJtb2R1bGUiOiJ3YWxydXMiLCJzdHJlYW0iOiIwLjcxIiwicHJvZmls
         ZXMiOlsiZmxpcHBlciJdfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9e0645ea-17c1-4c2b-8b3c-1274178315ba/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/00cbecea-5c87-48d5-a85e-42b15ae0945c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3363,7 +3788,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3376,47 +3801,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '439'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9262c5ac19cc4b94952181c4698a0af8
+      - 46740eb693544f3fb9986c1ab9b6a47d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '312'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZW52aXJvbm1lbnRzL2U1ODBkZWZkLTNhMDgtNGY2MC1hNDZmLWM5
-        NTMxYzI0OWFkYy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2
-        OjU4LjI1NzkwMloiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
+        YWNrYWdlZW52aXJvbm1lbnRzLzEyMTY3ODU5LWRlYmUtNGVhZi1hNGE4LTZl
+        NzE5NTdjYjE3Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0
+        OjM0LjMyNzkwM1oiLCJpZCI6Im1pbmltYWwiLCJuYW1lIjoiTWluaW1hbCIs
         ImRlc2NyaXB0aW9uIjoiIiwiZGlzcGxheV9vcmRlciI6bnVsbCwiZ3JvdXBf
         aWRzIjpbeyJuYW1lIjoiYmlyZCIsImRlZmF1bHQiOmZhbHNlfV0sIm9wdGlv
         bl9pZHMiOltdLCJkZXNjX2J5X2xhbmciOnt9LCJuYW1lX2J5X2xhbmciOnt9
         LCJkaWdlc3QiOiJjNDk2MzliYWQ4ZjcwMWI2YjMzNmQ2MGZhZjA1NDc0OWQ4
         NmFmY2ZhYTJhNTljYWZkOGNmMWJmNTEwY2QwN2VmIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3426,7 +3851,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3439,7 +3864,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:23 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3457,32 +3882,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bcc13087239643478c69a0784accc733
+      - 7924670fa8ef4089be13eb08cbc35f20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjODk5MWQ1LTg5ZGUtNDI3
-        MC04OGMyLWExNzdkNjRmOTY3NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxYWUyNDkwLTJmZjQtNDE0
+        ZC05ZGEwLTliZWNkZGYyOTk4Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy9lNTgwZGVmZC0zYTA4LTRmNjAtYTQ2
-        Zi1jOTUzMWMyNDlhZGMvIl19
+        cG0vcGFja2FnZWVudmlyb25tZW50cy8xMjE2Nzg1OS1kZWJlLTRlYWYtYTRh
+        OC02ZTcxOTU3Y2IxNzcvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3495,7 +3920,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3513,36 +3938,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9a216d52af64d339c09d3703a9f5af4
+      - d903ab4b79814b4aa2699dc6ee250bbb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlY2ViMjg4LTdjZTQtNDNk
-        Yi04YmU1LWRkNzkyNDMxYjAxZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzOGFiNDc4LTAzYTYtNGNj
+        Yi05YzE0LWEzNGUyYmM4ZTVlZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/modify/
     body:
       encoding: UTF-8
       base64_string: |
         eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRfZGVmYXVsdHMvMjE3ZmE5ZWQtYmViNi00MTI3LWEyOTct
-        MzUzYThjZTUxNjg1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZF9kZWZhdWx0cy84ZGU2ZmU3OS1hMTgxLTRhMjEtYTdlNS0wZjFmYjc3
-        NjQ4NmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
-        ZmF1bHRzL2YwYTc3NWVmLTcxNGItNDJlOS1hZGMzLWE0YTgwZjc5ZWQ3My8i
+        cG0vbW9kdWxlbWRfZGVmYXVsdHMvNDJiYWRmOGYtMTAwZS00YThkLWEwMmQt
+        ZjIwM2NhMzBjZjk0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
+        bGVtZF9kZWZhdWx0cy9iMThkZTViNC00ZTNmLTQ2MGYtOTRlZi0wNjlmNDli
+        ODIzMjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2Rl
+        ZmF1bHRzL2Y5ZDA0ZDJkLTNhZGQtNGZkOC1iZTYwLTY0MTliODYzZTU3MS8i
         XX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3555,7 +3980,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3573,72 +3998,72 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4431afa161ce4f36bd1e29bba1991593
+      - 59e0a5ae69614f3498475789f52a1997
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1YzU2OTUyLTNkNGEtNDZl
-        NS04YjRlLWM3MDcxZGNkNjY5MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiN2E3YjU2LWY0MjMtNGE4
+        Ny1hZjA2LTc5M2JkM2RkOTEyNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWUwNjQ1ZWEtMTdjMS00YzJiLThi
-        M2MtMTI3NDE3ODMxNWJhL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ZiZWJjYTNlLTA0OGIt
-        NDIzOC04MmViLTc0ZWZkNWM3MjQxNi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzAxMmUwMDU5LTNkYTQtNGM0
-        ZS05ZWY3LWQwOGUxMzg2ODRlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy8yMWE0OTc3MS04MmYzLTQxZDgtOTdhOC1kNDk0Mzkx
-        ODE3MDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        NjNmYmYwMmEtNDI1OS00M2FlLTlhNzYtMTJiZmI4Nzg5NTZmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2Qt
-        NDQ4MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzU4OTc5MDk5LTU2Y2UtNDE1ZC1i
-        ODczLTIxNGE3MzU2ZDEwMC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRzLzQ4ODI4ODIwLTRkZDQtNGFlMy1iMGI5LTYyODM3OTRkNGFh
-        Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzRlNTYx
-        MGU3LTkzNDctNGIzOC04MjVmLTIyNGY4YTZmMzg3Yy8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04
-        Yjg1LWY5M2JkYzExZjc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        bW9kdWxlbWRzLzhhYWI4MmEzLWRkMjAtNGQxNy05NjA1LTc0OTY2ZTNlYzY5
-        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2M5YTY1
-        ZmFjLWM1YzYtNDYyYS1hYjIwLTA2MmFiY2I0YWNlZC8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05
-        M2RjLTE3NjMxY2M0ZjRjYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZWdyb3Vwcy8wZmNhMTAzYy0yZWM2LTQ0N2ItYWM3MS02YjJjODZh
-        ZDhkYmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvZWYxZTdjNGQtMDNkNy00OTBkLWFiOTYtZmQyZTcxYTZkYWEzLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wM2Y4ZWU0Zi01Yjcx
-        LTQxNTUtYTQ3My1mNzljNTUwNDMxZTMvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzE0YjllMWQxLWZhZTItNDQ1ZC1hODc3LTkzOTlm
-        OGU2NWMwZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        M2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2VmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1
-        ZDItODU2MC1jNzBhZjkxMzdjY2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzY2NDY1ZmZhLTk1MWUtNGVkNS1iM2MzLWE4MDZlZWRm
-        Yzg1ZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2Ez
-        YzU3OTYtNWZiOC00MDI5LWFiMzktODBkMDIxOWJkNDg4LyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84YjI1MTczOC02YTQ4LTQzY2It
-        Yjc5YS1mMGFjOTY2MjVkZmYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzhmNGMwNDNkLTc0ODctNGE3Ni04NTMyLTdkN2NkOWRlODk4
-        Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9m
-        aWxlcy9mNDdhM2ZlNi0yYzQ2LTQzZWQtYmVmNC1kMzEyNDQxMWJkMjQvIl19
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDBjYmVjZWEtNWM4Ny00OGQ1LWE4
+        NWUtNDJiMTVhZTA5NDVjL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcwYWZmMGUyLTYwYmUt
+        NDFhMC05ZTQyLTE5OTExYzc4ZmI5Ny8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhk
+        ZS1hYmQ1LWFlMThjN2Q5OGIzOC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy8zOWI0ZTRmNy1kNzdjLTQwNjYtOTJkMC05NTBmZjBl
+        MmJlNjkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        YWZhMzVhNjAtOTE0Yy00ZDc0LTkyNjYtYjBlMDc4OTYzOGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2VhNWYwNDYyLTYyYWIt
+        NGMxZi1hNjRkLWI5MWQwNmM0NWI2Zi8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLzRmMjUyZWNlLTMxOTUtNDdhYi1h
+        NTY3LWU5Y2RkZGQ1MGEyMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzBjODQxODBkLTk4ZTYtNDgzOS05ZTdmLTJjYjI3NTQyOTI5
+        My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzE1ZWE3
+        ODAwLTljZGUtNGU5OS1iYWUzLTcwZDRjNmU5MDc3NS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1h
+        ZTA1LWViMTRlZjdhMTE5MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzNiOWI5YjU5LTI2ZWYtNGY3OC1hZGMwLWVlODY3OGFkMTkx
+        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzYyNTE1
+        ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vbW9kdWxlbWRzL2JjZjc5ZTI4LWNkNDAtNDgxNS04
+        OGRhLTg0MWRhN2FjMDM4NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZWdyb3Vwcy80NThjMWQ4NC03NWYxLTRmYWQtYjU1Zi0xNGJmMjFj
+        YmRiZTkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
+        cHMvNWUxZDBkYjQtZDEwZC00MWMyLWE0MDAtMzllZTE5M2Y5MjBhLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80NjAxOTJmYy03ZWZm
+        LTRlZGItYTA4YS1iYmFhNDgzNWFjNWEvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQxMTMtNGFjYy05ZTE5LTg0Yjlj
+        NDk1NGVlZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NWEzMjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82MmE0OWUzNC0wZjE0LTRl
+        NDYtOGZjMy0xYmZmNzk5ZmI2MWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzY2ZDAyNGMyLTEwZmMtNDAxYy1hZmU1LTU4NWIyOTkz
+        N2M1Ni8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTcy
+        MjJiODQtY2FlZC00M2M1LTkzNmYtOWFhMDM1NjM5ZjA1LyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzIt
+        YTk5YS0yMmZhMjI5YzliMGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2QxYzc5OWE2LWY3NjYtNDU4Ni1hMTliLTI0YzJmYmUzNzFm
+        Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9m
+        aWxlcy80YWJmNTM3Zi1iOWMwLTQyMzEtODdkMi1lMTMwM2JmZGZhNWYvIl19
         XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3651,7 +4076,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3669,21 +4094,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2636563dfe0e4d31b2eb2e36909d4669
+      - ccb2f043c80f4309a675196d5b6ec19a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4MGM4YmE3LWQzZmYtNDc5
-        MS1iMGI4LTJhMDI4MjU2YjBlNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhZjdlZTY5LTdjYWUtNDI1
+        YS1iYTczLTZkMjdhYTA0MDk4MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dc8991d5-89de-4270-88c2-a177d64f9675/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/01ae2490-2ff4-414d-9da0-9becddf2998c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3704,51 +4129,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c3c3da248ed14ee4a005ad9de9c056e3
+      - f27d09234fe542b0b1b91d2ff7044ab0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGM4OTkxZDUtODlk
-        ZS00MjcwLTg4YzItYTE3N2Q2NGY5Njc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjMuOTUzNTM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDFhZTI0OTAtMmZm
+        NC00MTRkLTlkYTAtOWJlY2RkZjI5OThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguMzMwNTU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiY2MxMzA4NzIzOTY0MzQ3OGM2
-        OWEwNzg0YWNjYzczMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjIzLjk5MjA1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuMjI1Nzk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3OTI0NjcwZmE4ZWY0MDg5YmUx
+        M2ViMDhjYmMzNWYyMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjQwMTYwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTguNjI4MDUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4
-        Yi00MjM4LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBi
+        ZS00MWEwLTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dc8991d5-89de-4270-88c2-a177d64f9675/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/01ae2490-2ff4-414d-9da0-9becddf2998c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3769,51 +4194,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8fb28410ec564d64834c8331ef9de82f
+      - f6233afb382747018d894675a8a38870
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGM4OTkxZDUtODlk
-        ZS00MjcwLTg4YzItYTE3N2Q2NGY5Njc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjMuOTUzNTM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDFhZTI0OTAtMmZm
+        NC00MTRkLTlkYTAtOWJlY2RkZjI5OThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguMzMwNTU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiY2MxMzA4NzIzOTY0MzQ3OGM2
-        OWEwNzg0YWNjYzczMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjIzLjk5MjA1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuMjI1Nzk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3OTI0NjcwZmE4ZWY0MDg5YmUx
+        M2ViMDhjYmMzNWYyMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjQwMTYwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTguNjI4MDUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4
-        Yi00MjM4LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBi
+        ZS00MWEwLTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/deceb288-7ce4-43db-8be5-dd792431b01d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b38ab478-03a6-4ccb-9c14-a34e2bc8e5ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3834,53 +4259,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 79ee2d2263934666a63652524ca3ed87
+      - fc5ea458af2a404ab724d34cd4703b2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGVjZWIyODgtN2Nl
-        NC00M2RiLThiZTUtZGQ3OTI0MzFiMDFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjQuMDA0NjAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjM4YWI0NzgtMDNh
+        Ni00Y2NiLTljMTQtYTM0ZTJiYzhlNWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguNDEyMzg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWEyMTZkNTJhZjY0ZDMzOWMw
-        OWQzNzAzYTlmNWFmNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjI0LjI1OTI4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuNDg4MjU1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkOTAzYWI0Yjc5ODE0YjRhYTI2
+        OTlkYzZlZTI1MGJiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjY2NzM4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTguODgwMjY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYvdmVyc2lv
+        bS83MGFmZjBlMi02MGJlLTQxYTAtOWU0Mi0xOTkxMWM3OGZiOTcvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4Yi00MjM4
-        LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBiZS00MWEw
+        LTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dc8991d5-89de-4270-88c2-a177d64f9675/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/01ae2490-2ff4-414d-9da0-9becddf2998c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3901,51 +4326,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08073bdfb2424029986fe5b9701466d7'
+      - e9d983f4d58c4a678cf0f58e8b332bf6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGM4OTkxZDUtODlk
-        ZS00MjcwLTg4YzItYTE3N2Q2NGY5Njc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjMuOTUzNTM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDFhZTI0OTAtMmZm
+        NC00MTRkLTlkYTAtOWJlY2RkZjI5OThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguMzMwNTU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiY2MxMzA4NzIzOTY0MzQ3OGM2
-        OWEwNzg0YWNjYzczMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjIzLjk5MjA1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuMjI1Nzk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3OTI0NjcwZmE4ZWY0MDg5YmUx
+        M2ViMDhjYmMzNWYyMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjQwMTYwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTguNjI4MDUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4
-        Yi00MjM4LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBi
+        ZS00MWEwLTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/deceb288-7ce4-43db-8be5-dd792431b01d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b38ab478-03a6-4ccb-9c14-a34e2bc8e5ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3966,53 +4391,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86383202ad0a44debae9f8e054fb732d
+      - 8be50bc942b947cc9af46fffb69958ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGVjZWIyODgtN2Nl
-        NC00M2RiLThiZTUtZGQ3OTI0MzFiMDFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjQuMDA0NjAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjM4YWI0NzgtMDNh
+        Ni00Y2NiLTljMTQtYTM0ZTJiYzhlNWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguNDEyMzg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWEyMTZkNTJhZjY0ZDMzOWMw
-        OWQzNzAzYTlmNWFmNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjI0LjI1OTI4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuNDg4MjU1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkOTAzYWI0Yjc5ODE0YjRhYTI2
+        OTlkYzZlZTI1MGJiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjY2NzM4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTguODgwMjY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYvdmVyc2lv
+        bS83MGFmZjBlMi02MGJlLTQxYTAtOWU0Mi0xOTkxMWM3OGZiOTcvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4Yi00MjM4
-        LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBiZS00MWEw
+        LTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e5c56952-3d4a-46e5-8b4e-c7071dcd6690/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6b7a7b56-f423-4a87-af06-793bd3dd9127/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4033,53 +4458,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:24 GMT
+      - Fri, 29 Jul 2022 11:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b865e11bbd434cb28d7aa1908d080513
+      - 10eec5ebe6ca4d049bf87f3c70db6be6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVjNTY5NTItM2Q0
-        YS00NmU1LThiNGUtYzcwNzFkY2Q2NjkwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjQuMDU0NjM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmI3YTdiNTYtZjQy
+        My00YTg3LWFmMDYtNzkzYmQzZGQ5MTI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguNDg2MTYxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0NDMxYWZhMTYxY2U0ZjM2YmQx
-        ZTI5YmJhMTk5MTU5MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjI0LjUyNDA5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuNzU4NTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1OWUwYTVhZTY5NjE0ZjM0OTg0
+        NzU3ODlmNTJhMTk5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjkxNzk4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTkuMTQ5MTY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYvdmVyc2lv
+        bS83MGFmZjBlMi02MGJlLTQxYTAtOWU0Mi0xOTkxMWM3OGZiOTcvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4Yi00MjM4
-        LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBiZS00MWEw
+        LTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dc8991d5-89de-4270-88c2-a177d64f9675/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/01ae2490-2ff4-414d-9da0-9becddf2998c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4100,51 +4525,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 47977e99616b442c97c09d3dc4c44ae8
+      - 82b7c4c86d914b2d8f545d4d130d925f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGM4OTkxZDUtODlk
-        ZS00MjcwLTg4YzItYTE3N2Q2NGY5Njc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjMuOTUzNTM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDFhZTI0OTAtMmZm
+        NC00MTRkLTlkYTAtOWJlY2RkZjI5OThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguMzMwNTU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiY2MxMzA4NzIzOTY0MzQ3OGM2
-        OWEwNzg0YWNjYzczMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjIzLjk5MjA1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuMjI1Nzk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3OTI0NjcwZmE4ZWY0MDg5YmUx
+        M2ViMDhjYmMzNWYyMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjQwMTYwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTguNjI4MDUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4
-        Yi00MjM4LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBi
+        ZS00MWEwLTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/deceb288-7ce4-43db-8be5-dd792431b01d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b38ab478-03a6-4ccb-9c14-a34e2bc8e5ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4165,53 +4590,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 84b98b92c1d94cb191c2dbbe2a034b02
+      - 26dc9349a32f4e9bb1564cc50b039759
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGVjZWIyODgtN2Nl
-        NC00M2RiLThiZTUtZGQ3OTI0MzFiMDFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjQuMDA0NjAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjM4YWI0NzgtMDNh
+        Ni00Y2NiLTljMTQtYTM0ZTJiYzhlNWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguNDEyMzg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWEyMTZkNTJhZjY0ZDMzOWMw
-        OWQzNzAzYTlmNWFmNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjI0LjI1OTI4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuNDg4MjU1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkOTAzYWI0Yjc5ODE0YjRhYTI2
+        OTlkYzZlZTI1MGJiYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjY2NzM4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTguODgwMjY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYvdmVyc2lv
+        bS83MGFmZjBlMi02MGJlLTQxYTAtOWU0Mi0xOTkxMWM3OGZiOTcvdmVyc2lv
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4Yi00MjM4
-        LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBiZS00MWEw
+        LTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e5c56952-3d4a-46e5-8b4e-c7071dcd6690/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6b7a7b56-f423-4a87-af06-793bd3dd9127/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4232,53 +4657,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fe78fd28813d427eba59c8ac0fc1c5da
+      - 65bec6e78d994a23b3c849f6afcedb89
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVjNTY5NTItM2Q0
-        YS00NmU1LThiNGUtYzcwNzFkY2Q2NjkwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjQuMDU0NjM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmI3YTdiNTYtZjQy
+        My00YTg3LWFmMDYtNzkzYmQzZGQ5MTI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguNDg2MTYxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0NDMxYWZhMTYxY2U0ZjM2YmQx
-        ZTI5YmJhMTk5MTU5MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjI0LjUyNDA5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuNzU4NTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1OWUwYTVhZTY5NjE0ZjM0OTg0
+        NzU3ODlmNTJhMTk5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0
+        OjU4LjkxNzk4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzQ6
+        NTkuMTQ5MTY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYvdmVyc2lv
+        bS83MGFmZjBlMi02MGJlLTQxYTAtOWU0Mi0xOTkxMWM3OGZiOTcvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4Yi00MjM4
-        LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYwZTItNjBiZS00MWEw
+        LTllNDItMTk5MTFjNzhmYjk3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:34:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dc8991d5-89de-4270-88c2-a177d64f9675/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/faf7ee69-7cae-425a-ba73-6d27aa040980/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4299,254 +4724,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '0168a9253d2d42eda186d432ff346d67'
+      - 6263a314d4154753843279b0ebb10eaf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGM4OTkxZDUtODlk
-        ZS00MjcwLTg4YzItYTE3N2Q2NGY5Njc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjMuOTUzNTM4WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiY2MxMzA4NzIzOTY0MzQ3OGM2
-        OWEwNzg0YWNjYzczMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjIzLjk5MjA1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuMjI1Nzk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4
-        Yi00MjM4LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/deceb288-7ce4-43db-8be5-dd792431b01d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:29:25 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - c61edfaae1be429fbd8fc86fb93fcc52
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '388'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGVjZWIyODgtN2Nl
-        NC00M2RiLThiZTUtZGQ3OTI0MzFiMDFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjQuMDA0NjAwWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWEyMTZkNTJhZjY0ZDMzOWMw
-        OWQzNzAzYTlmNWFmNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjI0LjI1OTI4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuNDg4MjU1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYvdmVyc2lv
-        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4Yi00MjM4
-        LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e5c56952-3d4a-46e5-8b4e-c7071dcd6690/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:29:25 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - b255ad5bfedb4e1dae0673ef236cf38f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '390'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVjNTY5NTItM2Q0
-        YS00NmU1LThiNGUtYzcwNzFkY2Q2NjkwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjQuMDU0NjM0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0NDMxYWZhMTYxY2U0ZjM2YmQx
-        ZTI5YmJhMTk5MTU5MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5
-        OjI0LjUyNDA5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6
-        MjQuNzU4NTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9mYmViY2EzZS0wNDhiLTQyMzgtODJlYi03NGVmZDVjNzI0MTYvdmVyc2lv
-        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNhM2UtMDQ4Yi00MjM4
-        LTgyZWItNzRlZmQ1YzcyNDE2LyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/180c8ba7-d3ff-4791-b0b8-2a028256b0e7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:29:25 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 59878d56be9a485db87e651384259818
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTgwYzhiYTctZDNm
-        Zi00NzkxLWIwYjgtMmEwMjgyNTZiMGU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MjQuMTE3MTk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmFmN2VlNjktN2Nh
+        ZS00MjVhLWJhNzMtNmQyN2FhMDQwOTgwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzQ6NTguNTY0OTU1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiMjYzNjU2M2RmZTBlNGQzMWIyZWIyZTM2OTA5
-        ZDQ2NjkiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOToyNC43OTI1
-        ODdaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjI1LjI0Mzky
-        MloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvM2ZhNmQwODItOTY4My00ZWZmLWFhNmQtMWVkMzQ1MTA3MmU1LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiY2NiMmYwNDNjODBmNDMwOWE2NzUxOTZkNWI2
+        ZWMxOWEiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozNDo1OS4xOTQw
+        ODRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjM0OjU5Ljg3NTE3
+        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJlYmNh
-        M2UtMDQ4Yi00MjM4LTgyZWItNzRlZmQ1YzcyNDE2L3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzBhZmYw
+        ZTItNjBiZS00MWEwLTllNDItMTk5MTFjNzhmYjk3L3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2ZiZWJjYTNlLTA0OGItNDIzOC04MmViLTc0
-        ZWZkNWM3MjQxNi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzllMDY0NWVhLTE3YzEtNGMyYi04YjNjLTEyNzQxNzgzMTVi
-        YS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzcwYWZmMGUyLTYwYmUtNDFhMC05ZTQyLTE5
+        OTExYzc4ZmI5Ny8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzAwY2JlY2VhLTVjODctNDhkNS1hODVlLTQyYjE1YWUwOTQ1
+        Yy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4554,7 +4780,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4567,62 +4793,62 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1108'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d3b895fc63224adebcdd828945bdd63e
+      - 5fb357071c3e4de383fe608fbff7bea5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '407'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvM2JmNDAzZTItZTRjZS00MmMwLTg4ZjMtMTUyODkwZWZhN2Vm
+        cGFja2FnZXMvNDYwMTkyZmMtN2VmZi00ZWRiLWEwOGEtYmJhYTQ4MzVhYzVh
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzdhM2M1Nzk2LTVmYjgtNDAyOS1hYjM5LTgwZDAyMTliZDQ4OC8i
+        Y2thZ2VzLzk3MjIyYjg0LWNhZWQtNDNjNS05MzZmLTlhYTAzNTYzOWYwNS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8wYTc1Y2I2NS04NzMxLTRhYzMtYjRkNy02ZTY3ZTU5M2VkMzMvIn0s
+        YWdlcy85ZWNhMzhhMi03OGRlLTRlNmUtOTQyNy1iZTcwOTY1OTQyMGUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNjY0NjVmZmEtOTUxZS00ZWQ1LWIzYzMtYTgwNmVlZGZjODVkLyJ9LHsi
+        ZXMvZDFjNzk5YTYtZjc2Ni00NTg2LWExOWItMjRjMmZiZTM3MWZjLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2NiYjM4NDg3LTk2NzctNGE0My04M2UzLTQzOTBiM2QyMDViNC8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84
-        YjI1MTczOC02YTQ4LTQzY2ItYjc5YS1mMGFjOTY2MjVkZmYvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGY0
-        YzA0M2QtNzQ4Ny00YTc2LTg1MzItN2Q3Y2Q5ZGU4OThmLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzI5ZTZh
-        MjFkLTJmNjktNGNkMi1iNzExLTYxY2M4OWNmNzBjZS8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85NjUyMjg4
-        MC04YzVhLTQ4MDEtYjU2Ny0xZjJiMWRiNzNkZWMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTRiOWUxZDEt
-        ZmFlMi00NDVkLWE4NzctOTM5OWY4ZTY1YzBkLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzAzZjhlZTRmLTVi
-        NzEtNDE1NS1hNDczLWY3OWM1NTA0MzFlMy8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYzJhZTgyZS1iN2Ex
-        LTRkNmYtYjYzZC1jZTcxZWZlNTZjNWEvIn1dfQ==
+        LzY5ZTgzYWQ2LTI0MjQtNGI5MC04MWU5LTNhNWIxYWQ4NGEyNC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82
+        MmE0OWUzNC0wZjE0LTRlNDYtOGZjMy0xYmZmNzk5ZmI2MWYvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNWEz
+        Mjg0MjYtMmJhZi00MTg5LTljYzUtNmQ4ZGMzNWMxMGQ0LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ4MDYw
+        OGMxLWI2YWEtNDA5MC05YWZmLTczYTQ0NmNiNmIwNC8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83Y2YwNWYy
+        ZS1iMmMxLTQ4YjAtODEzMy0xYmY3NWZkZDIzZTEvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjZkMDI0YzIt
+        MTBmYy00MDFjLWFmZTUtNTg1YjI5OTM3YzU2LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzUyZDE4NWEyLWQx
+        MTMtNGFjYy05ZTE5LTg0YjljNDk1NGVlZC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mZGI5NTdiMS1jOTEy
+        LTQxZDEtYThkZi1mZDg0M2E3ZWQ1YTgvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4630,7 +4856,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4643,50 +4869,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '585'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da0c4c378f384317ba36160ff2acc277
+      - c499a0bae4e8446a97182c282c6f08a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '266'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9t
-        b2R1bGVtZHMvNGU1NjEwZTctOTM0Ny00YjM4LTgyNWYtMjI0ZjhhNmYzODdj
+        b2R1bGVtZHMvMGM4NDE4MGQtOThlNi00ODM5LTllN2YtMmNiMjc1NDI5Mjkz
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kcy9jOWE2NWZhYy1jNWM2LTQ2MmEtYWIyMC0wNjJhYmNiNGFjZWQv
+        ZHVsZW1kcy9iY2Y3OWUyOC1jZDQwLTQ4MTUtODhkYS04NDFkYTdhYzAzODUv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9k
-        dWxlbWRzLzU2OGM3YTMwLTY5NzAtNDhkYS04Yjg1LWY5M2JkYzExZjc2Mi8i
+        dWxlbWRzLzNiMDZkMjQ2LTJhOTItNDBlNS1hZTA1LWViMTRlZjdhMTE5MS8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1
-        bGVtZHMvOGFhYjgyYTMtZGQyMC00ZDE3LTk2MDUtNzQ5NjZlM2VjNjliLyJ9
+        bGVtZHMvM2I5YjliNTktMjZlZi00Zjc4LWFkYzAtZWU4Njc4YWQxOTE5LyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy80ODgyODgyMC00ZGQ0LTRhZTMtYjBiOS02MjgzNzk0ZDRhYWMvIn0s
+        ZW1kcy8xNWVhNzgwMC05Y2RlLTRlOTktYmFlMy03MGQ0YzZlOTA3NzUvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRzL2Q0ZmI4NzgxLTM5MDMtNDU3MC05M2RjLTE3NjMxY2M0ZjRjYi8ifV19
+        bWRzLzYyNTE1ZTg1LTA1NTUtNGI1OS04NDNjLTA1ZTgwNTU2NWQ3NC8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4694,7 +4920,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4707,37 +4933,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '6131'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96b165b4919243099e6c60e6c318b11d
+      - 3520ca00a1e644e88a13885ffeb72cf7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '1830'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzIxYTQ5NzcxLTgyZjMtNDFkOC05N2E4LWQ0OTQzOTE4MTcw
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI2OjU4LjI3MzUx
-        MFoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
+        ZHZpc29yaWVzLzFkMDlmMGNlLTNmMzktNDhkZS1hYmQ1LWFlMThjN2Q5OGIz
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE1OjA0OjM0LjM1OTQ2
+        OVoiLCJpZCI6IktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCJ1cGRhdGVkX2Rh
         dGUiOiIyMDEwLTExLTEwIDAwOjAwOjAwIiwiZGVzY3JpcHRpb24iOiJiemlw
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
@@ -4810,9 +5036,9 @@ http_interactions:
         cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCJpZCI6
         bnVsbCwidGl0bGUiOm51bGwsInR5cGUiOiJvdGhlciJ9XSwicmVib290X3N1
         Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMDEyZTAwNTktM2RhNC00YzRlLTllZjct
-        ZDA4ZTEzODY4NGUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6
-        MjY6NTguMjU5MDg2WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
+        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvMzliNGU0ZjctZDc3Yy00MDY2LTkyZDAt
+        OTUwZmYwZTJiZTY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhUMTU6
+        MDQ6MzQuMzMwOTA4WiIsImlkIjoiUkhFQS0yMDIxOjk5OTkiLCJ1cGRhdGVk
         X2RhdGUiOiIyMDE2LTAxLTI3IDE2OjA4OjA2IiwiZGVzY3JpcHRpb24iOiJT
         b3VyY2UgUlBNIEVycmF0dW0iLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcg
         MTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0
@@ -4829,9 +5055,9 @@ http_interactions:
         L3Rlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0iLCJzdW0iOiIiLCJzdW1fdHlw
         ZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6W10sInJl
         Ym9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2YxNzg5MzA4LWQyM2QtNDQ4
-        MC04ZjIxLTJjOTIwMTA3MTNmNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1
-        LTIzVDIzOjI2OjU4LjI0MDk5NloiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmYTM1YTYwLTkxNGMtNGQ3
+        NC05MjY2LWIwZTA3ODk2MzhkNC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3
+        LTI4VDE1OjA0OjM0LjI3NzIwN1oiLCJpZCI6IktBVEVMTE8tUkhFQS0yMDEw
         OjAwMDEiLCJ1cGRhdGVkX2RhdGUiOm51bGwsImRlc2NyaXB0aW9uIjoiRW1w
         dHkgZXJyYXRhIiwiaXNzdWVkX2RhdGUiOiIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwiZnJvbXN0ciI6Imx6YXArcHViQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJz
@@ -4840,9 +5066,9 @@ http_interactions:
         c29sdXRpb24iOiIiLCJyZWxlYXNlIjoiMSIsInJpZ2h0cyI6IiIsInB1c2hj
         b3VudCI6IiIsInBrZ2xpc3QiOltdLCJyZWZlcmVuY2VzIjpbXSwicmVib290
         X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvNjNmYmYwMmEtNDI1OS00M2FlLTlh
-        NzYtMTJiZmI4Nzg5NTZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNU
-        MjM6MjY6NTguMjM4MjM3WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
+        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvZWE1ZjA0NjItNjJhYi00YzFmLWE2
+        NGQtYjkxZDA2YzQ1YjZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjhU
+        MTU6MDQ6MzQuMjcyMTg0WiIsImlkIjoiS0FURUxMTy1SSEVBLTIwMTI6MDA1
         OSIsInVwZGF0ZWRfZGF0ZSI6IjIwMTgtMDctMjAgMDY6MDA6MDEiLCJkZXNj
         cmlwdGlvbiI6IkR1Y2tfS2FuZ2Fyb19FcnJhdHVtIGRlc2NyaXB0aW9uIiwi
         aXNzdWVkX2RhdGUiOiIyMDE4LTAxLTI3IDE2OjA4OjA5IiwiZnJvbXN0ciI6
@@ -4871,10 +5097,10 @@ http_interactions:
         biI6IjAuNyJ9XX1dLCJyZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3Rl
         ZCI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4882,7 +5108,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4895,43 +5121,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 452fd299d73d43c291e815092402e768
+      - bffad6d52c254239af58d83852c1e8dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4939,7 +5165,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4952,41 +5178,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8f8f159f26444a1cbacc165581aaad07
+      - b2ce0b653f6b4427b29c7649e9f145c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '136'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80OTQzZDE5ZC1jNTUyLTQ1ZDItODU2MC1jNzBhZjkxMzdjY2Mv
+        YWNrYWdlcy9hNzI0MGQyNi05MGY4LTRhYzItYTk5YS0yMmZhMjI5YzliMGUv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4994,7 +5220,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5007,36 +5233,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:25 GMT
+      - Fri, 29 Jul 2022 11:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1066'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef4f868d84fb415e8917879e3c9213e7
+      - 26caaddba7ea4516a2a42d748cd3dced
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9k
-        aXN0cmlidXRpb25fdHJlZXMvNTg5NzkwOTktNTZjZS00MTVkLWI4NzMtMjE0
-        YTczNTZkMTAwLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
+        aXN0cmlidXRpb25fdHJlZXMvNGYyNTJlY2UtMzE5NS00N2FiLWE1NjctZTlj
+        ZGRkZDUwYTIzLyIsImhlYWRlcl92ZXJzaW9uIjoiMS4yIiwicmVsZWFzZV9u
         YW1lIjoiVGVzdCBGYW1pbHkiLCJyZWxlYXNlX3Nob3J0IjoiIiwicmVsZWFz
         ZV92ZXJzaW9uIjoiMTYiLCJyZWxlYXNlX2lzX2xheWVyZWQiOmZhbHNlLCJi
         YXNlX3Byb2R1Y3RfbmFtZSI6bnVsbCwiYmFzZV9wcm9kdWN0X3Nob3J0Ijpu
@@ -5058,10 +5284,10 @@ http_interactions:
         b3J5IjpudWxsLCJkZWJ1Z19wYWNrYWdlcyI6bnVsbCwiZGVidWdfcmVwb3Np
         dG9yeSI6bnVsbCwiaWRlbnRpdHkiOm51bGx9XX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fbebca3e-048b-4238-82eb-74efd5c72416/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/70aff0e2-60be-41a0-9e42-19911c78fb97/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5069,7 +5295,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -5082,38 +5308,38 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:26 GMT
+      - Fri, 29 Jul 2022 11:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '237'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a5f643e4c3334d4ab6284160a158c521
+      - e88e71aa0de5470abea93e9773d2904f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '170'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzBmY2ExMDNjLTJlYzYtNDQ3Yi1hYzcxLTZiMmM4NmFk
-        OGRiYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlZ3JvdXBzL2VmMWU3YzRkLTAzZDctNDkwZC1hYjk2LWZkMmU3
-        MWE2ZGFhMy8ifV19
+        YWNrYWdlZ3JvdXBzLzVlMWQwZGI0LWQxMGQtNDFjMi1hNDAwLTM5ZWUxOTNm
+        OTIwYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlZ3JvdXBzLzQ1OGMxZDg0LTc1ZjEtNGZhZC1iNTVmLTE0YmYy
+        MWNiZGJlOS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:35:00 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_all_no_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_all_no_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2542f452104840e7aaeafe716e02c929
+      - 5a19b1c434d94a619bfac627df1d13e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yZTZmNzViOS1iMzg1LTRhZjQtODYwNy1mNGQyZDRhOTQ3YzMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNToyMC4xNDMxMTRa
+        cnBtL3JwbS9iOTA5M2I1Mi02MjhjLTRhMmEtYjllMS1kODdhNWE1ZjNkNzQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyOToyNy4wMzU1OTVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yZTZmNzViOS1iMzg1LTRhZjQtODYwNy1mNGQyZDRhOTQ3YzMv
+        cnBtL3JwbS9iOTA5M2I1Mi02MjhjLTRhMmEtYjllMS1kODdhNWE1ZjNkNzQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJlNmY3
-        NWI5LWIzODUtNGFmNC04NjA3LWY0ZDJkNGE5NDdjMy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I5MDkz
+        YjUyLTYyOGMtNGEyYS1iOWUxLWQ4N2E1YTVmM2Q3NC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:41 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a7b0504beeba4b56b98cd7b8ec79b332
+      - 8d126adca6244e8d82f103c142711794
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1YThmNmI2LTIwNzEtNDJk
-        MC04Yzk0LTRiMzMxNjJhNTllYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwNmM5NTljLThlNjUtNDVi
+        ZC05NWM2LTBkZDhmNWFmZWJiZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 287bf8dc13e14a5c88baf2e7a6034d91
+      - 5444d1f6d3b645f4ba381296fe6d0f26
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/15a8f6b6-2071-42d0-8c94-4b33162a59ec/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/406c959c-8e65-45bd-95c6-0dd8f5afebbd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1817f119933b410aad60646522ec77c9
+      - 94f187f16f544ea592b24f51ab2131e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTVhOGY2YjYtMjA3
-        MS00MmQwLThjOTQtNGIzMzE2MmE1OWVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjguMzIyMDI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDA2Yzk1OWMtOGU2
+        NS00NWJkLTk1YzYtMGRkOGY1YWZlYmJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NDEuMDg2NjYwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhN2IwNTA0YmVlYmE0YjU2Yjk4Y2Q3Yjhl
-        Yzc5YjMzMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjI4LjM1
-        Mzg4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MjguNDcx
-        NjU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4ZDEyNmFkY2E2MjQ0ZThkODJmMTAzYzE0
+        MjcxMTc5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjQxLjE0
+        NDI0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NDEuNTYy
+        NTg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmU2Zjc1YjktYjM4NS00YWY0
-        LTg2MDctZjRkMmQ0YTk0N2MzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjkwOTNiNTItNjI4Yy00YTJh
+        LWI5ZTEtZDg3YTVhNWYzZDc0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 970cf4b6503c4b44944686807352ffca
+      - 4eae82f1a6774dda95ac638b7caba5d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5c823dee90404f6586557027d033848e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZTJjYmJkYWYtZGQ2Ni00YTgzLWE4YWQtM2E2YzY5ZDk0YzU0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MzQuOTQyNzUx
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:41 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/e2cbbdaf-dd66-4a83-a8ad-3a6c69d94c54/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 464bc30f8c2b42e2b68001513943c6e5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5ODkzYjA5LWMzYzQtNDI5
+        Ni04MTFjLWNlYjQzOWM3MThiYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/19893b09-c3c4-4296-811c-ceb439c718bc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - aa8f8f711cac453c9dc6a2d8f34b5150
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTk4OTNiMDktYzNj
+        NC00Mjk2LTgxMWMtY2ViNDM5YzcxOGJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NDEuODMwMjgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0NjRiYzMwZjhjMmI0MmUyYjY4MDAxNTEz
+        OTQzYzZlNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjQxLjg4
+        NzA2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NDEuOTQx
+        MTU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 64fb252f61494758b7aa1dacc5985741
+      - e25509a30b274b8597b7b47c7ee64007
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 954cb958726a487d9c5519584a2ea44a
+      - ccd161955d334bb09bad577581aff682
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 585974d52e634602817327644732ad35
+      - 07606571250e4c9c950f58aa260f1471
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c88db144dd24155917426747369095c
+      - 9d9904fcd0504de295d50bcaf5284bee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:28 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 8feb99f05fab44c9810cfd425c9ee31f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:28 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/77e791a6-ba88-4b57-bba6-0ae143b79070/"
+      - "/pulp/api/v3/remotes/rpm/rpm/c5acd5e3-2228-4fd1-8bd2-e9743ce1766b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc76c13ee1c9495f8955d57064068a73
+      - bc0e6c81bb4a413d9122658a9056dd86
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc3
-        ZTc5MWE2LWJhODgtNGI1Ny1iYmE2LTBhZTE0M2I3OTA3MC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjI4LjkwOTg4OFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M1
+        YWNkNWUzLTIyMjgtNGZkMS04YmQyLWU5NzQzY2UxNzY2Yi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjQyLjMzODIxOFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjI4LjkwOTkwNloiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjQyLjMzODI0MVoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1668abca3a924ba589a5e66e809ef512
+      - ac2348638a88441ab436702c67b674d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjIxYmJkNDItZWZlZi00ZGU5LTg2NWMtMjgyYzg3MTdkNTAyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MjkuMDY5MzkzWiIsInZl
+        cG0vMDY0MjQwOWItN2I1Ny00MjliLWE1MTEtMjQzYzk0YWIzYzQwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6NDIuNTIwNjgyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjIxYmJkNDItZWZlZi00ZGU5LTg2NWMtMjgyYzg3MTdkNTAyL3ZlcnNp
+        cG0vMDY0MjQwOWItN2I1Ny00MjliLWE1MTEtMjQzYzk0YWIzYzQwL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yMjFiYmQ0Mi1l
-        ZmVmLTRkZTktODY1Yy0yODJjODcxN2Q1MDIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wNjQyNDA5Yi03
+        YjU3LTQyOWItYTUxMS0yNDNjOTRhYjNjNDAvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - effc4d2f30544060b8e1245143caa13a
+      - c50c56d65ec247f88dbfe89fd52f052a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83OGJjZjJlZS0yZmRiLTQ0MmItOTcyNy0zNjVhYTg2ZWRiMDcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNToyMC45NDIyODda
+        cnBtL3JwbS85ZWI3ZjAyNS03MmRiLTQ1MDYtYTg3Yi05NmM0YjdiYmY1ZjYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyOToyOC4xNzgxNDZa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83OGJjZjJlZS0yZmRiLTQ0MmItOTcyNy0zNjVhYTg2ZWRiMDcv
+        cnBtL3JwbS85ZWI3ZjAyNS03MmRiLTQ1MDYtYTg3Yi05NmM0YjdiYmY1ZjYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzc4YmNm
-        MmVlLTJmZGItNDQyYi05NzI3LTM2NWFhODZlZGIwNy92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzllYjdm
+        MDI1LTcyZGItNDUwNi1hODdiLTk2YzRiN2JiZjVmNi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2fd2c6d2e0dc48ef8e894833001fb2b7
+      - a28c4f148ae94584bb3c1815f19e16cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0N2VhMzVkLTM3YTEtNDk5
-        MC1hNzRlLTViNjcyY2ZlM2M1OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlODRiNTViLTA5NzMtNGJk
+        Ni1iMjQ2LTc2Yjc1NzhiNjAwYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae4ddf3388564b27a307d048b7ff9018
+      - 1ca8da07cd464acfa18eaa0a3a00ba8b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '380'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYmY4ZWRmMTEtYjQzZi00NWQ3LTgxZmUtMDdlODkwODI4NmM3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MTkuOTUzNjY1WiIsIm5h
+        cG0vYjlmODY4ZmItMDIwOS00ZDhjLWJjZGUtYTI1NTg3Zjg4MzhiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MjYuODQ4MjcyWiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNToyMS40NTQxNjZaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMToyOToyOC43MTgzOTRaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/bf8edf11-b43f-45d7-81fe-07e8908286c7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b9f868fb-0209-4d8c-bcde-a25587f8838b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 70456e6c055e42c9af3d12810ffdbfa8
+      - 3e93b25bfb7d41ceb380733e8c571edf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxMGZiOTUwLTdkYjQtNDky
-        Zi1hNTA4LWE1OTUxZjVhMDVmMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhMDU0OGE1LWZiMGItNGQy
+        ZC1iMmNhLTQwNmJhY2FmMTUxYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f47ea35d-37a1-4990-a74e-5b672cfe3c58/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4e84b55b-0973-4bd6-b246-76b7578b600c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f397402236ae46d3946c19f0a44b3d6e
+      - f43343e5807748acacadbc0003d3f987
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjQ3ZWEzNWQtMzdh
-        MS00OTkwLWE3NGUtNWI2NzJjZmUzYzU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjkuMjI1MDk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGU4NGI1NWItMDk3
+        My00YmQ2LWIyNDYtNzZiNzU3OGI2MDBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NDIuODI1MjE1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyZmQyYzZkMmUwZGM0OGVmOGU4OTQ4MzMw
-        MDFmYjJiNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjI5LjI1
-        NzYzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MjkuMzIy
-        MzE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhMjhjNGYxNDhhZTk0NTg0YmIzYzE4MTVm
+        MTllMTZjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjQyLjg4
+        MzM0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NDMuMDI5
+        MjU1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzhiY2YyZWUtMmZkYi00NDJi
-        LTk3MjctMzY1YWE4NmVkYjA3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWViN2YwMjUtNzJkYi00NTA2
+        LWE4N2ItOTZjNGI3YmJmNWY2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c10fb950-7db4-492f-a508-a5951f5a05f0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fa0548a5-fb0b-4d2d-b2ca-406bacaf151c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6325eedf37634930b4385b83e4c7593f
+      - 20b896c763a84b3b9efcaf0a348873cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzEwZmI5NTAtN2Ri
-        NC00OTJmLWE1MDgtYTU5NTFmNWEwNWYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjkuMzI1MzE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmEwNTQ4YTUtZmIw
+        Yi00ZDJkLWIyY2EtNDA2YmFjYWYxNTFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NDIuOTcwNjY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MDQ1NmU2YzA1NWU0MmM5YWYzZDEyODEw
-        ZmZkYmZhOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjI5LjM1
-        OTkzOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MjkuNDAz
-        MDY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzZTkzYjI1YmZiN2Q0MWNlYjM4MDczM2U4
+        YzU3MWVkZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjQzLjA2
+        MDUyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NDMuMTUz
+        NDMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JmOGVkZjExLWI0M2YtNDVkNy04MWZl
-        LTA3ZTg5MDgyODZjNy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I5Zjg2OGZiLTAyMDktNGQ4Yy1iY2Rl
+        LWEyNTU4N2Y4ODM4Yi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7b4d66e9727e49aa89620135ca43121c
+      - b84938269ab1499697c928a30d625d9c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58b202e6f5ef4abe9daf9406ce3bd900
+      - 06d8d1c557f5465e9a96ae29db550212
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 302ca9c6a5ee49acbcf0a80a5da3ea5e
+      - c3caee295530448cbe35fd8bd812c463
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db1245b82887490f86374940e636f568
+      - c0b349d18c5040cf8e7d3dd5085a64e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 827196e1f9be41d980a3d463f2de5f04
+      - 8989d70112e7425b98a30bda211c1feb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8fdd71f1b8874a6f8b8b24c42711f168
+      - 35f174383b43419cacdd18b6ed3c9282
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:29 GMT
+      - Fri, 29 Jul 2022 11:29:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/"
+      - "/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2bc7dbba931f4af092786d109b400564
+      - 6a70ea6e45664086baff2914b30c358d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2Q3NTQyYzItN2M3YS00NjUwLTk4ZGQtNWQ3ODMyYjFlMTFkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MjkuNzgwMDU5WiIsInZl
+        cG0vNTg0YjY2NzUtMmMwMC00ZGFmLTg3ZWMtN2M5ZGFlNzQ4MDZlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6NDMuNzE2Nzk3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2Q3NTQyYzItN2M3YS00NjUwLTk4ZGQtNWQ3ODMyYjFlMTFkL3ZlcnNp
+        cG0vNTg0YjY2NzUtMmMwMC00ZGFmLTg3ZWMtN2M5ZGFlNzQ4MDZlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83ZDc1NDJjMi03
-        YzdhLTQ2NTAtOThkZC01ZDc4MzJiMWUxMWQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ODRiNjY3NS0y
+        YzAwLTRkYWYtODdlYy03YzlkYWU3NDgwNmUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:43 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/77e791a6-ba88-4b57-bba6-0ae143b79070/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c5acd5e3-2228-4fd1-8bd2-e9743ce1766b/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:30 GMT
+      - Fri, 29 Jul 2022 11:29:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f386af13aa334889bebcd27aae0be6f8
+      - 79d6134483144223b2745035d73cb801
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5YzJkYjM0LWYyYzctNGMw
-        ZS05Y2ZhLTgwNzE0Zjg2NzNkYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2YmQ1ZmQxLWMwOGQtNGFm
+        Yy05NzRhLWJiYTZmNThmMmM3Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c9c2db34-f2c7-4c0e-9cfa-80714f8673dc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f6bd5fd1-c08d-4afc-974a-bba6f58f2c7b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:30 GMT
+      - Fri, 29 Jul 2022 11:29:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 99d4302eba434640905f29ee748ea246
+      - 70471b365134441294c51ba2f14fc32e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzljMmRiMzQtZjJj
-        Ny00YzBlLTljZmEtODA3MTRmODY3M2RjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzAuMDgzOTc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjZiZDVmZDEtYzA4
+        ZC00YWZjLTk3NGEtYmJhNmY1OGYyYzdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NDQuMTY4ODk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmMzg2YWYxM2FhMzM0ODg5YmViY2QyN2Fh
-        ZTBiZTZmOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjMwLjEx
-        NTY5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MzAuMTM3
-        MjgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3OWQ2MTM0NDgzMTQ0MjIzYjI3NDUwMzVk
+        NzNjYjgwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjQ0LjI0
+        MzE0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NDQuMjcw
+        NjIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc3ZTc5MWE2LWJhODgtNGI1Ny1iYmE2
-        LTBhZTE0M2I3OTA3MC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M1YWNkNWUzLTIyMjgtNGZkMS04YmQy
+        LWU5NzQzY2UxNzY2Yi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:44 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc3ZTc5
-        MWE2LWJhODgtNGI1Ny1iYmE2LTBhZTE0M2I3OTA3MC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M1YWNk
+        NWUzLTIyMjgtNGZkMS04YmQyLWU5NzQzY2UxNzY2Yi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:30 GMT
+      - Fri, 29 Jul 2022 11:29:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f22f2b764b094584b049d4aadf012bf2
+      - 133d78dd710141b7a3bdf03572523604
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VhNWQ4ZjNiLTY5ZGQtNDk3
-        NS05NjRjLTJhMmM4ZmU0MTY1My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2NWM1MzBjLTliYzQtNDk2
+        YS05NGUxLTg2MjAxMzU4ZmM3YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ea5d8f3b-69dd-4975-964c-2a2c8fe41653/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/365c530c-9bc4-496a-94e1-86201358fc7a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:32 GMT
+      - Fri, 29 Jul 2022 11:29:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 862fe441c5d048609f4f69e3625f02bf
+      - 4663b8bd0b1b460c9214f9ac85caa36a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '600'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWE1ZDhmM2ItNjlk
-        ZC00OTc1LTk2NGMtMmEyYzhmZTQxNjUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzAuMjg3Mzg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzY1YzUzMGMtOWJj
+        NC00OTZhLTk0ZTEtODYyMDEzNThmYzdhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NDQuNDczNTE1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmMjJmMmI3NjRiMDk0NTg0YjA0
-        OWQ0YWFkZjAxMmJmMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjMwLjMxNzA3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MzEuOTAyMjQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxMzNkNzhkZDcxMDE0MWI3YTNi
+        ZGYwMzU3MjUyMzYwNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjQ0LjUzMzIyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        NDguNjczMDgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMjIxYmJkNDItZWZlZi00ZGU5LTg2NWMt
-        MjgyYzg3MTdkNTAyL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzIyMWJiZDQyLWVmZWYtNGRlOS04NjVjLTI4MmM4NzE3ZDUwMi8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS83N2U3OTFhNi1iYTg4
-        LTRiNTctYmJhNi0wYWUxNDNiNzkwNzAvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzA2NDI0MDliLTdiNTctNDI5Yi1hNTExLTI0
+        M2M5NGFiM2M0MC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
+        NjQyNDA5Yi03YjU3LTQyOWItYTUxMS0yNDNjOTRhYjNjNDAvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYzVhY2Q1ZTMtMjIyOC00
+        ZmQxLThiZDItZTk3NDNjZTE3NjZiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:48 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMjIxYmJkNDItZWZlZi00ZGU5LTg2NWMtMjgyYzg3MTdk
-        NTAyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vMDY0MjQwOWItN2I1Ny00MjliLWE1MTEtMjQzYzk0YWIz
+        YzQwL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:32 GMT
+      - Fri, 29 Jul 2022 11:29:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 98004df4fef44f5c986bf35ab9455775
+      - 41743081f4634c03abdf5d903182884b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyNDFhMzFkLTg2MWQtNDVh
-        Yi1hOWQ3LTJjOTlkNjU4ODNjZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q0MGNhZTMxLTgyYTMtNDdl
+        Mi04OWYxLTczOTFiYzczNmM5Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d241a31d-861d-45ab-a9d7-2c99d65883cd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d40cae31-82a3-47e2-89f1-7391bc736c9b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:32 GMT
+      - Fri, 29 Jul 2022 11:29:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f4fdb24cdbf4b4fb7f7983d79aceddd
+      - 1b2e6cdc099649d495307b7024a3b6ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDI0MWEzMWQtODYx
-        ZC00NWFiLWE5ZDctMmM5OWQ2NTg4M2NkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzIuMTIyMTQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDQwY2FlMzEtODJh
+        My00N2UyLTg5ZjEtNzM5MWJjNzM2YzliLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NDguOTgzNzE5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6Ijk4MDA0ZGY0ZmVmNDRmNWM5ODZiZjM1YWI5
-        NDU1Nzc1Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MzIuMTUz
-        OTkxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNTozMi4zMzI0
+        c2giLCJsb2dnaW5nX2NpZCI6IjQxNzQzMDgxZjQ2MzRjMDNhYmRmNWQ5MDMx
+        ODI4ODRiIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NDkuMDQw
+        MjU2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOTo0OS41NDAy
         NjBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTAyNTdh
-        OTItMDY1ZC00NGE5LWI3Y2YtZjIyNDQxNzFiM2Y1LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDZmMGU4
+        NWQtODJkMC00OGJmLWIzMmYtYzhiZjI5MjYzODMxLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMjIxYmJkNDItZWZlZi00ZGU5LTg2NWMtMjgyYzg3
-        MTdkNTAyLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vMDY0MjQwOWItN2I1Ny00MjliLWE1MTEtMjQzYzk0
+        YWIzYzQwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:32 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f8c3f03c7dbe4a2cb9f435f35878e6de
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:32 GMT
+      - Fri, 29 Jul 2022 11:29:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7076fbbcbb148548f24ca0cfd1d0ef1
+      - a3817f77a0f34539b5c8a3e6ed410017
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/06f0e85d-82d0-48bf-b32f-c8bf29263831/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:32 GMT
+      - Fri, 29 Jul 2022 11:29:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3fac85cf6a7949b18d1b697e4f867810
+      - eba1638c7b674cd580363ef8b1e9ceb3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMDZmMGU4NWQtODJkMC00OGJmLWIzMmYtYzhiZjI5MjYzODMxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6NDkuMDcxNzg4WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8wNjQyNDA5Yi03YjU3LTQyOWItYTUxMS0yNDNjOTRhYjNjNDAv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzA2NDI0MDliLTdiNTctNDI5Yi1hNTExLTI0M2M5
+        NGFiM2M0MC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:49 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8wNmYwZTg1ZC04MmQwLTQ4YmYtYjMyZi1jOGJmMjkyNjM4MzEv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7f67da90dc8b40c5808fa071eb7a3bd8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3YTU2Zjk0LTFlMGYtNGI5
+        Zi04NzkzLWViYTgxMGNlYWE5ZC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a7a56f94-1e0f-4b9f-8793-eba810ceaa9d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 47c31a7104b440ecbba75940a9688829
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTdhNTZmOTQtMWUw
+        Zi00YjlmLTg3OTMtZWJhODEwY2VhYTlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NDkuODc5NTE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3ZjY3ZGE5MGRjOGI0MGM1ODA4ZmEwNzFl
+        YjdhM2JkOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjQ5Ljk1
+        NDE2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NTAuNTYz
+        MDQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMjBk
+        MjdhODctYjgxOC00NzAyLWEzMDgtMWEzMDg0NTA4OTAwLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/20d27a87-b818-4702-a308-1a3084508900/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7a6ae21b9fe24c759816db0a25c6d91d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzIwZDI3YTg3LWI4MTgtNDcwMi1hMzA4LTFhMzA4NDUwODkwMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjUwLjUzMzU0NFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMDZmMGU4NWQtODJkMC00OGJmLWIzMmYt
+        YzhiZjI5MjYzODMxLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2f71f43ad6374d8fa6c7e2cdccb41a57
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - '0294b51d8eee49ceb28aae0a5f189147'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6193de9a637f4010b64e8a9081e23dd0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:32 GMT
+      - Fri, 29 Jul 2022 11:29:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71e773ff7fb348e086725202c27d60f7
+      - e329576dc134479d8d2ef1af8eb0a97b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:32 GMT
+      - Fri, 29 Jul 2022 11:29:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 62c7d111da7d4c5182eaafa7e43d43f9
+      - a8bc5af75a5b4c23a5742f374ac0a799
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:32 GMT
+      - Fri, 29 Jul 2022 11:29:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94c15195bcef4995b2f7632936149fce
+      - 7c33a4ffe67348caafed7e963d9cfd03
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d9a6e202fdb041e298b8a30842b8873a
+      - 01d7f051b79a4d58a75624118f9ad162
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 01f9762cb39841f999d30a533db47186
+      - 2557c65115274a56bdd6cff9a61a2615
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 77119f42ac58400d8a37588a0308d66f
+      - 711ecdb471d54f3eb7df1d786456ac0d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,94 +3153,94 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa774a71c57d41b0a37441f6e8399087
+      - f25e8c0e29114cb285257c3d531c2903
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:52 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjIxYmJkNDItZWZlZi00ZGU5LTg2
-        NWMtMjgyYzg3MTdkNTAyL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdkNzU0MmMyLTdjN2Et
-        NDY1MC05OGRkLTVkNzgzMmIxZTExZC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJl
-        ZC1hNTg0LTgxYTFkOGU0ZGFlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdk
-        ZWExNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzkwYTZjNmExLTM4NjUt
-        NDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMGI0NmU0OTAtYjM1Ny00YjRmLWIxYWQtOTg3MDNi
-        NWU3ZDEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8x
-        OWIzOTcyMy0wYjc1LTRkZmUtYWMzZi03NmZhZWJlODFmYjUvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFhNTc2NWVlLTcwNzgtNDMz
-        OC1hMDM2LWZkOTI3MzA0NTE5NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMWYyNDQ2MjEtMGNiYi00YmU4LTk2MjMtM2JkZGMzYjEw
-        ZWIxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJkNjJjZjg0LTRjNTUtNDg5NC05
-        NDRmLTg2MjczNzk3NTZkMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYx
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0MTJmLTRjMzQtNGE0Mi1hYWY2
-        LTYyOTc1NDliMDM4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzAxYmEwMzctNWY4Zi00N2JkLWE5MGEtNDU4MTFmZTNmZDgwLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83MGJkMTJiMS00
-        MDcxLTRjNTktODMxYS03YTdhMjg1YjBkM2IvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVkNzYtNDRhZC05OWFmLWIz
-        MjAzNTA0NmViZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvN2VlMTJmOWMtMTc1Zi00NDY3LWJkMjItMzU5YjA2MWI1OGE2LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84M2FlMzc4Ni02ZmZl
-        LTQ2OWUtYjM4Zi1hNTQ4ZWFlZjVmYTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2EzZTAzY2QxLTNjMzQtNGNiYi05Zjg2LWY5Mjdm
-        NmFjMWY5Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2MjE0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQz
-        NmItYmQwNy1iODQwN2EzZWY4NzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2FhZTgzMzVkLTg1ZjItNGVlMS04ODljLThiNGQyODBm
-        NWVkMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2
-        ZjcwZGEtNTlkOC00M2I3LThkYTItYzJiMTEwYTFmMWJlLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOGQ0ZTdhMS0wMzg3LTQ4YjEt
-        YTBkNi1jZjdhOThhZmRjNTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2I4ZTY0ZDRkLTIwZTAtNDdjMi05NTk2LTMzYTQzZjE0YmJi
-        NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRj
-        MWEtMGUwNy00MTZlLTg0YTctZWU0NTcyMzJiMDVkLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMWQ2OTMwYi0yNjFjLTRkZjQtOTY5
-        Yi1lMTU2MDVhZjNmMTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0OTk5ZDIxOWM0NC8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2RlNzUwNTQt
-        NDJkOS00MGVlLThlZTUtMDk1MWRmMzE3NWZhLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9jZTZmMTY5ZS1kOWZkLTRjMjQtODZjYi1j
-        MjUzYTZmZTU1MDkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2QwNmI3OTk2LTQyNWEtNGE4NS04MWJiLWEyNDZjODAwZTliOC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0
-        NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNiNy0yYTM4
-        MjZkMDFkNmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4ZjUwMmMzNDAxMi8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTVjYWUzZjMtYjJkMC00
-        MjJjLTllOTEtOGVkZDlkOWQxMTYyLyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2MtYjJjYS1kZWQzZTI3
-        ZmU2ZGEvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDY0MjQwOWItN2I1Ny00MjliLWE1
+        MTEtMjQzYzk0YWIzYzQwL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU4NGI2Njc1LTJjMDAt
+        NGRhZi04N2VjLTdjOWRhZTc0ODA2ZS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzIyNTBmMTdhLWJjMTgtNGNl
+        MS04YzZhLTA3YzRmMDY4MjU0Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy82NmYzNGYxYS0zNzA0LTQ4M2MtOGM1Ny0yM2IzOWVk
+        YTU1ZGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2E3YWZjYTk1LWIzYjYt
+        NGVjZC05YzQ2LTc3MWE0NGNkZGViOS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvMDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1
+        MjE1OGJiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
+        ZDRmNzdiMy0xNDgxLTRmNTItOWM3NS0xYmJhNzcwYjY3ZGUvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBk
+        Mi1hZjQzLTM4MDMxMzZkMTIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMGY3NTdkMjQtNjc4Mi00NTEwLTliZDctMWY0ZDg5ZjE5
+        OGNiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xMjMy
+        YzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2ZGE2OGEvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1i
+        ZjczLTc1MTgxOGZjNmYxNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgzNGQtNTdlYzRlZDlkNzlh
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zMzE5Y2Zh
+        MC1kZGZjLTQzYzAtOGE2ZS1kMWQ5OWQ0MWI2ZDgvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1
+        LTEzYTkzYjM5MmEwZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvNjkzYTRlYjItZDczOS00MDkyLTg5NmYtODM2MzBmZjNjNGZiLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4My0w
+        NjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFkZC1iNDU1LTgz
+        NGMyZjhkNTg4Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvNmViNWRlODEtZDYwNS00OTMxLThlNjQtNDZlMDFmMTUzMDAzLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3
+        LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhj
+        M2VlNzNiOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NzYyOWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84YWVmODliMC1kM2IzLTRk
+        NDItYmJlMS1mYTBkODkwMTMzNTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzhiODNhODk3LTU4NGMtNDZhMi04MjdmLThiMDdkYWU5
+        N2JhZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTJi
+        NjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgyLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5Zjkt
+        YTM2Yi04NTE4MDMzZjAzNjAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3
+        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFj
+        OWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0
+        MS1jN2JlODFmNzkyNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzL2FlMzViYWYwLTU2ZjgtNGY5YS04NGYzLTFiMzEyNTRjZWRkNy8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzkt
+        ZTA1Ni00NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1l
+        MGYzMzdmNTE3Y2QvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2QwMWMxYmUwLWJmMmEtNDIwOS1iMTgxLThkNTk5ZmQwNzkzMy8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDUwOTg5MWEtZjIy
+        Mi00OTI5LWFmMmQtYzkxMDBhNDhhNmNjLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5LTRjNTAtOWNjNy0yYzgy
+        YWU3ODc4OGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2U0OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRhODIyZDYtNGVmNC00
+        NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5
+        ODI2ZGYvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2828,7 +3253,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2846,21 +3271,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 895c4d4b2cb34cbbae013b3c18d4dd93
+      - 76556449165e413d87bd73883dd7d2b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwYmJiOWMzLTIxMmEtNDU2
-        OC1iZTUyLTdjNDY3ZWZmYjQ0ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3MDA4Yzk1LWQ3OWItNGI1
+        Ni04NmY3LTUwMDFkNDJjMTQ2Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/90bbb9c3-212a-4568-be52-7c467effb44e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b7008c95-d79b-4b56-86f7-5001d42c1466/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2881,55 +3306,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 705575eb2b104c3f8872d8a7b0b840d3
+      - 3604931532d048e79f73dbaf8512a361
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '415'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTBiYmI5YzMtMjEy
-        YS00NTY4LWJlNTItN2M0NjdlZmZiNDRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzMuMjU0NTgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjcwMDhjOTUtZDc5
+        Yi00YjU2LTg2ZjctNTAwMWQ0MmMxNDY2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NTIuMTg0OTk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiODk1YzRkNGIyY2IzNGNiYmFlMDEzYjNjMThk
-        NGRkOTMiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNTozMy4yOTQz
-        NTNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjMzLjQ3ODc1
-        NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiNzY1NTY0NDkxNjVlNDEzZDg3YmQ3Mzg4M2Rk
+        N2QyYjQiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOTo1Mi4yNDkw
+        NTRaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjUyLjg1Njcy
+        MFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2Q3NTQy
-        YzItN2M3YS00NjUwLTk4ZGQtNWQ3ODMyYjFlMTFkL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTg0YjY2
+        NzUtMmMwMC00ZGFmLTg3ZWMtN2M5ZGFlNzQ4MDZlL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzdkNzU0MmMyLTdjN2EtNDY1MC05OGRkLTVk
-        NzgzMmIxZTExZC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzIyMWJiZDQyLWVmZWYtNGRlOS04NjVjLTI4MmM4NzE3ZDUw
-        Mi8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzU4NGI2Njc1LTJjMDAtNGRhZi04N2VjLTdj
+        OWRhZTc0ODA2ZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzA2NDI0MDliLTdiNTctNDI5Yi1hNTExLTI0M2M5NGFiM2M0
+        MC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2937,7 +3362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2950,101 +3375,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f417444fb84488786f3d42350200013
+      - 6a1af96f720c488bb2394dcc47b87f00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3052,7 +3477,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3065,7 +3490,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3083,21 +3508,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90347e45d2984a3186185d986e9efece
+      - ea6304a17e934064aa22b3039e1652b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3105,7 +3530,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3118,37 +3543,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - be922f27d0814805afbcdd6c17d7a792
+      - 7e54536b277d43f4b6952d2752b71e48
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3164,8 +3589,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3193,8 +3618,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3222,8 +3647,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3241,10 +3666,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3252,7 +3677,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3265,7 +3690,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3283,21 +3708,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 29cf51b82767434c899aeeefe19c95fc
+      - 4d9b7c2be11c4e2295f24da497ff53ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3305,7 +3730,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3318,7 +3743,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3336,21 +3761,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 035d26ee908e497383b2e2e58636b5fd
+      - a6f9016b947f45d28db027a14260907a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3358,7 +3783,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3371,7 +3796,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:33 GMT
+      - Fri, 29 Jul 2022 11:29:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3389,21 +3814,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71cb657010fa483f9bf4762530832c09
+      - 514a7d04bf2a478ab63881d2345ae4f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3411,7 +3836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3424,101 +3849,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:34 GMT
+      - Fri, 29 Jul 2022 11:29:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5a765f4caace494abc6e38483956ee64
+      - bde61a81b6264f7893c9e9a368a87da0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3526,7 +3951,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3539,7 +3964,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:34 GMT
+      - Fri, 29 Jul 2022 11:29:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3557,21 +3982,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7b0db3d0b65d4a49b6de366bdb7ff29b
+      - '0802f5e2d89647ceb8eb708bc4c0bb1b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3579,7 +4004,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3592,37 +4017,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:34 GMT
+      - Fri, 29 Jul 2022 11:29:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8110f45d4a3049448c9736bd93495075
+      - '09bda62a4447496ca3117bf25d3399a9'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3638,8 +4063,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3667,8 +4092,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3696,8 +4121,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3715,10 +4140,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3726,7 +4151,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3739,7 +4164,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:34 GMT
+      - Fri, 29 Jul 2022 11:29:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3757,21 +4182,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6625c0cc8e8348af8c565959c6228685
+      - f17285c29ff84c7c8b1465f7988d584d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3779,7 +4204,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3792,7 +4217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:34 GMT
+      - Fri, 29 Jul 2022 11:29:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3810,21 +4235,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8271f81f08394199af4955970ec8e514
+      - e0905f22958b400d81ca74118a69fda8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3832,7 +4257,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3845,7 +4270,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:34 GMT
+      - Fri, 29 Jul 2022 11:29:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3863,16 +4288,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 24184126e2a443b38561bb60313120e9
+      - a3aab038ceda4afb93521066aedda28b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:54 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_all_no_filter_rules_with_dependency_solving.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_all_no_filter_rules_with_dependency_solving.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:14 GMT
+      - Fri, 29 Jul 2022 11:31:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ada5723247724467a0451b3acac5a8f3
+      - a4e54768d64e40e5b9ad4d53e655d7dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84OTdlYzk0Mi05YzQ4LTRiZDctYWE1YS1kZjcyMWQzMTcxMmMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDowOS45ODU4OTZa
+        cnBtL3JwbS9lMGIxNmVkOC03Yjk1LTQwZjYtYmQ2Mi1hNzQ5YTgzNmZlMWUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTo0MC4xOTY3NzVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84OTdlYzk0Mi05YzQ4LTRiZDctYWE1YS1kZjcyMWQzMTcxMmMv
+        cnBtL3JwbS9lMGIxNmVkOC03Yjk1LTQwZjYtYmQ2Mi1hNzQ5YTgzNmZlMWUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzg5N2Vj
-        OTQyLTljNDgtNGJkNy1hYTVhLWRmNzIxZDMxNzEyYy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UwYjE2
+        ZWQ4LTdiOTUtNDBmNi1iZDYyLWE3NDlhODM2ZmUxZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:55 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/897ec942-9c48-4bd7-aa5a-df721d31712c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:14 GMT
+      - Fri, 29 Jul 2022 11:31:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - df7c5ae2fe314eacb2d9f63894fdc9af
+      - 4a3e89f5ab9048e8a5ae7a52c04da57a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFkYzQ1NTQzLWZlM2MtNDcw
-        OS1hZDIzLTJmODlmODQ3NGVmNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4NWU4MDRlLTM4OTEtNGY1
+        MS05MjYwLTQyYjQ2ZjhhMmJmMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,73 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 4493937b09894c37a0f5627550bd21ed
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '384'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNzUyMzQyMjgtMTcxYi00YjhlLWE5ZDktZTQyYzA2ODE4YTAxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MDkuODcxMDgwWiIsIm5h
-        bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHBzOi8vamxzaGVycmlsbC5m
-        ZWRvcmFwZW9wbGUub3JnL2Zha2UtcmVwb3MvbmVlZGVkLWVycmF0YS8iLCJj
-        YV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRp
-        b24iOnRydWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MTAuMzU1MjQ0
-        WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6
-        bnVsbCwicG9saWN5IjoiaW1tZWRpYXRlIiwidG90YWxfdGltZW91dCI6MzYw
-        MC4wLCJjb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfY29ubmVjdF90aW1l
-        b3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGltZW91dCI6MzYwMC4wLCJoZWFkZXJz
-        IjpudWxsLCJyYXRlX2xpbWl0IjowLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
-        XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/75234228-171b-4b8e-a9d9-e42c06818a01/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:14 GMT
+      - Fri, 29 Jul 2022 11:31:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -217,31 +151,31 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '67'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d64e4a5bea8417bbf0818e126d81984
+      - 2adae3edc28344d9960dc1d87ffef3fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhN2EyYzcxLTkwNGUtNDE0
-        ZS1hYzkxLWQxY2M1MDQyZjZkZC8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1dc45543-fe3c-4709-ad23-2f89f8474ef4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/185e804e-3891-4f51-9260-42b46f8a2bf1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -262,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:14 GMT
+      - Fri, 29 Jul 2022 11:31:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a50b9fb2f7b4492b286600704daa7d9
+      - 0b6e51ce490a47dc8360764010aafdfb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWRjNDU1NDMtZmUz
-        Yy00NzA5LWFkMjMtMmY4OWY4NDc0ZWY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTQuMzM5MzA3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTg1ZTgwNGUtMzg5
+        MS00ZjUxLTkyNjAtNDJiNDZmOGEyYmYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTUuMTM0NjYwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZjdjNWFlMmZlMzE0ZWFjYjJkOWY2Mzg5
-        NGZkYzlhZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjE0LjM3
-        MDMyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MTQuNTEz
-        MTA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0YTNlODlmNWFiOTA0OGU4YTVhZTdhNTJj
+        MDRkYTU3YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjU1LjE5
+        MTE5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NTUuNDc4
+        NTEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODk3ZWM5NDItOWM0OC00YmQ3
-        LWFhNWEtZGY3MjFkMzE3MTJjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBiMTZlZDgtN2I5NS00MGY2
+        LWJkNjItYTc0OWE4MzZmZTFlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9a7a2c71-904e-414e-ac91-d1cc5042f6dd/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -314,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -327,113 +261,39 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:14 GMT
+      - Fri, 29 Jul 2022 11:31:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - b8de683cf4934b398d5be284372a687f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWE3YTJjNzEtOTA0
-        ZS00MTRlLWFjOTEtZDFjYzUwNDJmNmRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTQuNDQxNTc0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4ZDY0ZTRhNWJlYTg0MTdiYmYwODE4ZTEy
-        NmQ4MTk4NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjE0LjQ3
-        NDEyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MTQuNTIw
-        NjMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc1MjM0MjI4LTE3MWItNGI4ZS1hOWQ5
-        LWU0MmMwNjgxOGEwMS8iXX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 79bc293045cc4dc9822a04e5f7dc149e
+      - b26eb596e73e487d8fbb033f92f1d77f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '306'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMzdhNjA0OTYtMjVmMi00ZDg4LWFhMTgtNDAzMzkzNzZjZWU3
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MTIuODk0NTYx
-        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
-        OC1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
-        bnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0
-        ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6
-        e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1
-        YmxpY2F0aW9uIjpudWxsfV19
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:55 GMT
 - request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/37a60496-25f2-4d88-aa18-40339376cee7/
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -441,7 +301,68 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9d450d47d5634f1d8a7920417ee409a1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNzVlMWFkYzUtNGY5OC00ZjNiLThlNzYtZjUzOTkyMzJkZDQ2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6NDguNjg0MTU2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:55 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/75e1adc5-4f98-4f3b-8e76-f5399232dd46/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -454,7 +375,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:14 GMT
+      - Fri, 29 Jul 2022 11:31:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -472,136 +393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 35669288babb40c9bf250cd6567c9b2a
+      - 0dff1e78edf14c4083ad53915d1e1fe8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RhNGZlNThiLWJiZjEtNGMw
-        MS1hNTg3LWUzYjQwYzdkNTE5Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3YTJkMzgyLTAyY2MtNDBi
+        MS1hNjkxLTEwNTE1Mjc1N2Y1Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d85c5bb4d5b2486d8a93629ad77d51bd
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '306'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMzdhNjA0OTYtMjVmMi00ZDg4LWFhMTgtNDAzMzkzNzZjZWU3
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MTIuODk0NTYx
-        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
-        OC1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
-        bnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0
-        ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6
-        e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1
-        YmxpY2F0aW9uIjpudWxsfV19
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/37a60496-25f2-4d88-aa18-40339376cee7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '23'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - cea7d36cb16c4895b7a21f1ef9218bba
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
-
-'
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/da4fe58b-bbf1-4c01-a587-e3b40c7d519b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/07a2d382-02cc-40b1-a691-105152757f56/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -622,50 +428,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:14 GMT
+      - Fri, 29 Jul 2022 11:31:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dd2bc40b0655438ab337507ebf592836
+      - 35e25a72e4b446bf9f33854232eedc35
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '344'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGE0ZmU1OGItYmJm
-        MS00YzAxLWE1ODctZTNiNDBjN2Q1MTliLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTQuODAxOTU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDdhMmQzODItMDJj
+        Yy00MGIxLWE2OTEtMTA1MTUyNzU3ZjU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTUuNjU5OTA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNTY2OTI4OGJhYmI0MGM5YmYyNTBjZDY1
-        NjdjOWIyYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjE0Ljgz
-        MzQ4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MTQuODYw
-        NjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZGZmMWU3OGVkZjE0YzQwODNhZDUzOTE1
+        ZDFlMWZlOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjU1Ljcx
+        NDQ0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NTUuODky
+        MDI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
         L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -673,7 +479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -686,7 +492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:14 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -704,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 992fa5e315804f7085b34220f9995d20
+      - '09f18be9937d495793747abc38a5c87a'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -726,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -739,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -757,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ae660c5753749caa9a48156d8707b7f
+      - 10e159bbee2542a2923c03a26ad061df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -779,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -792,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -810,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4efebf340bc34efeb52eafd6820b8c90
+      - d9de50f41e474d8b9772bd657b414642
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -832,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -845,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -863,21 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f8b2184111b6494c9e62340cb7bafb8a
+      - 8bd284244e414fb4a8429c59f4253eaa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -894,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -907,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/c2e823fd-4812-4169-814e-61d01ecbeccb/"
+      - "/pulp/api/v3/remotes/rpm/rpm/c9f9978f-9b5e-43f5-8715-46c1175647fb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -927,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d3469ceecef4cdab20ebe04106fcb10
+      - 4c450c76d6a44114b583bc66cac0793c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2My
-        ZTgyM2ZkLTQ4MTItNDE2OS04MTRlLTYxZDAxZWNiZWNjYi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjE1LjE1OTE1OFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M5
+        Zjk5NzhmLTliNWUtNDNmNS04NzE1LTQ2YzExNzU2NDdmYi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjU2LjI5NDQ5OVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjE1LjE1OTE3N1oiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjU2LjI5NDUyNVoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -962,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -975,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -995,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 245ee0048ac04683bcc7db0ee8339c47
+      - 1b9203be3ea34b45b4ad0f249b3349ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZjZiYzAyODUtZDdlYi00MWFjLWFjZmMtNGYyNmQyZGE3NzNjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MTUuMzQxNTcwWiIsInZl
+        cG0vZTU5ZGUzMWItOTY0NC00NDQwLWI1MDktMzk0MzY1ODUzYWMzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6NTYuNDc3NTI1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZjZiYzAyODUtZDdlYi00MWFjLWFjZmMtNGYyNmQyZGE3NzNjL3ZlcnNp
+        cG0vZTU5ZGUzMWItOTY0NC00NDQwLWI1MDktMzk0MzY1ODUzYWMzL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mNmJjMDI4NS1k
-        N2ViLTQxYWMtYWNmYy00ZjI2ZDJkYTc3M2MvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lNTlkZTMxYi05
+        NjQ0LTQ0NDAtYjUwOS0zOTQzNjU4NTNhYzMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -1019,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1030,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1043,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d3772bf217b646beaf2046faa8b9d506
+      - 4e82b4833ca94beabab955b176bad537
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '307'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jZWNhNWViZS01MzQwLTQ3MTYtOTc5Ni1lZGU5MDkyZmFhZjMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMzo1OS4wNTE3NjNa
+        cnBtL3JwbS80OWU1YmZjYS05YWMyLTQwNjItODcyNy03YjQ2NDA4MTk3MzYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTo0MS42Mzk2NjVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jZWNhNWViZS01MzQwLTQ3MTYtOTc5Ni1lZGU5MDkyZmFhZjMv
+        cnBtL3JwbS80OWU1YmZjYS05YWMyLTQwNjItODcyNy03YjQ2NDA4MTk3MzYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2NlY2E1
-        ZWJlLTUzNDAtNDcxNi05Nzk2LWVkZTkwOTJmYWFmMy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQ5ZTVi
+        ZmNhLTlhYzItNDA2Mi04NzI3LTdiNDY0MDgxOTczNi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -1085,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ceca5ebe-5340-4716-9796-ede9092faaf3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1096,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1109,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1127,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f839558b9994608a7ae2ec46b0b1acd
+      - ae251318637643c184b6f36b6e7ac5b5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2MmNiZDAzLWZkNmEtNDBi
-        MS05Yzk1LTQwMDczNTc2NDExNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3MjNlMDJmLTE2NWQtNGQ4
+        ZS04ZDBiLThhNzRjMmZhZTdjMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1149,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1162,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41aaab100e0c4ad9a29d250a6bd17f69
+      - 86d465a11e3447e99cae61d8c162fc40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNDJmNjJjY2YtMzRlNy00ZjE4LTg0YTgtMWQxZDM0YTYyN2VlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjM6NTguMDQzMTM1WiIsIm5h
-        bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
-        cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
-        ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
-        dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoyMzo1OS40NTE3MDVaIiwiZG93bmxvYWRfY29uY3VycmVu
-        Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
-        dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
-        NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
-        aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
-        InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+        cG0vYWU0YjkwZjQtZjdlOC00MmRmLTgyY2YtYTI4ZGM3NTg3MmExLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6NDAuMDAyODQwWiIsIm5h
+        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
+        ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
+        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
+        cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTo0Mi4zNTg4NjZaIiwiZG93bmxv
+        YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
+        Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
+        Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
+        InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
+        dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/42f62ccf-34e7-4f18-84a8-1d1d34a627ee/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/ae4b90f4-f7e8-42df-82cf-a28dc75872a1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1214,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1227,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1245,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1c4862c8368e4e90a5c41db6cd1ecab1
+      - dee9136414924bf797e8ad175ba1fa47
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxYzk5YTZiLTczMzItNDA4
-        ZS05OWI5LTFmOTM3ZDY3M2E0ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2ZGY2NzJmLTE4ODQtNDI3
+        MS1iNDdjLTkzZDJiNTRhNTEzYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c62cbd03-fd6a-40b1-9c95-400735764116/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4723e02f-165d-4d8e-8d0b-8a74c2fae7c2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1280,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8ec520a9e08b43dd83bba0a55df6b265
+      - 41806a37d9aa40f8bb1cf26280bccec9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzYyY2JkMDMtZmQ2
-        YS00MGIxLTljOTUtNDAwNzM1NzY0MTE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTUuNDk5Njc3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDcyM2UwMmYtMTY1
+        ZC00ZDhlLThkMGItOGE3NGMyZmFlN2MyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTYuNzU5MTg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzZjgzOTU1OGI5OTk0NjA4YTdhZTJlYzQ2
-        YjBiMWFjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjE1LjU0
-        ODQyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MTUuNjA4
-        MDc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZTI1MTMxODYzNzY0M2MxODRiNmYzNmI2
+        ZTdhYzViNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjU2Ljgx
+        MDEyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NTcuMTAy
+        Mzg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2VjYTVlYmUtNTM0MC00NzE2
-        LTk3OTYtZWRlOTA5MmZhYWYzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDllNWJmY2EtOWFjMi00MDYy
+        LTg3MjctN2I0NjQwODE5NzM2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/61c99a6b-7332-408e-99b9-1f937d673a4d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/86df672f-1884-4271-b47c-93d2b54a513c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1345,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b784f006aa14ebdb17e21730573ce8c
+      - 1f2fb26765d44b9a894bb367c9d7c172
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjFjOTlhNmItNzMz
-        Mi00MDhlLTk5YjktMWY5MzdkNjczYTRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTUuNjA1MTk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODZkZjY3MmYtMTg4
+        NC00MjcxLWI0N2MtOTNkMmI1NGE1MTNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTYuOTE1MTU4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxYzQ4NjJjODM2OGU0ZTkwYTVjNDFkYjZj
-        ZDFlY2FiMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjE1LjYz
-        OTYzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MTUuNjgx
-        NzM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZWU5MTM2NDE0OTI0YmY3OTdlOGFkMTc1
+        YmExZmE0NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjU3LjAx
+        NzA1NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NTcuMTEw
+        NzQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQyZjYyY2NmLTM0ZTctNGYxOC04NGE4
-        LTFkMWQzNGE2MjdlZS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2FlNGI5MGY0LWY3ZTgtNDJkZi04MmNm
+        LWEyOGRjNzU4NzJhMS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1397,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1410,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1428,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7c186ce7c6e4261904ad167df729961
+      - 756c229a41d944a3b24f0106b011777f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1450,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1463,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1481,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53d601e8c3624851baaad4cca66e99ae
+      - 20657e945fa44b28bf4a49956f4f0798
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1503,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1516,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1534,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11809ffed6f645f89cb4206fba4d0cae
+      - 8a792a7b4cb34c869449b5de86264ae9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1556,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1569,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1587,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d55b0445e96406297cb57a7e9526a00
+      - e8893b1418f742cba3a7a04b380bfd8c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1609,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1622,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1640,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 267c463e31c94a0ebb50836fc5b74017
+      - a9d0395970a0464ca3d864fd487b4923
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1675,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:15 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1693,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0446b59c77414a928aff235468fcf956
+      - c9d5a4bd38dc4eb281cdc7f394e5e08b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1717,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1730,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:16 GMT
+      - Fri, 29 Jul 2022 11:31:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/"
+      - "/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1750,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ef8611a688c4453b214c0f2f1a4aaef
+      - 5a8337a1333647db80e65fd4890982c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDMxZmVhMmUtOWQxOC00NzlhLWE1N2MtMGNlYTRkNzIwMDk5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MTYuMTIzMTUxWiIsInZl
+        cG0vMjEzYzBlNTQtMmJmMi00NzA2LTg0YTgtZWYwZmVjNjhiYThhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6NTcuODA5NzEzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDMxZmVhMmUtOWQxOC00NzlhLWE1N2MtMGNlYTRkNzIwMDk5L3ZlcnNp
+        cG0vMjEzYzBlNTQtMmJmMi00NzA2LTg0YTgtZWYwZmVjNjhiYThhL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80MzFmZWEyZS05
-        ZDE4LTQ3OWEtYTU3Yy0wY2VhNGQ3MjAwOTkvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yMTNjMGU1NC0y
+        YmYyLTQ3MDYtODRhOC1lZjBmZWM2OGJhOGEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1773,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:57 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/c2e823fd-4812-4169-814e-61d01ecbeccb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c9f9978f-9b5e-43f5-8715-46c1175647fb/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1793,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1806,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:16 GMT
+      - Fri, 29 Jul 2022 11:31:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1824,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3fea4f6125cf4b998f5a14d1c768247d
+      - 677564490ee342159fd6e06faeb3e0e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4Y2MwNmM1LWI2MjQtNGQ2
-        NS05YjU1LWJhZTk4NGQxNmUyMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyOGIxYmEzLTZkODUtNDBj
+        Ni05ZTJkLTRhMjNiMDc4NDI0MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d8cc06c5-b624-4d65-9b55-bae984d16e23/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c28b1ba3-6d85-40c6-9e2d-4a23b0784240/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1859,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:16 GMT
+      - Fri, 29 Jul 2022 11:31:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4476eb0a085446e7bbc517de0fb23379
+      - 9cf2d1980f6f4ce6aa704d26e46cacb9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDhjYzA2YzUtYjYy
-        NC00ZDY1LTliNTUtYmFlOTg0ZDE2ZTIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTYuMzkzMTAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzI4YjFiYTMtNmQ4
+        NS00MGM2LTllMmQtNGEyM2IwNzg0MjQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTguMjc3MDMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIzZmVhNGY2MTI1Y2Y0Yjk5OGY1YTE0ZDFj
-        NzY4MjQ3ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjE2LjQy
-        NzM1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MTYuNDUz
-        ODM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2Nzc1NjQ0OTBlZTM0MjE1OWZkNmUwNmZh
+        ZWIzZTBlNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjU4LjMz
+        MjAyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NTguMzY0
+        NzE4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MyZTgyM2ZkLTQ4MTItNDE2OS04MTRl
-        LTYxZDAxZWNiZWNjYi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M5Zjk5NzhmLTliNWUtNDNmNS04NzE1
+        LTQ2YzExNzU2NDdmYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MyZTgy
-        M2ZkLTQ4MTItNDE2OS04MTRlLTYxZDAxZWNiZWNjYi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M5Zjk5
+        NzhmLTliNWUtNDNmNS04NzE1LTQ2YzExNzU2NDdmYi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1928,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:16 GMT
+      - Fri, 29 Jul 2022 11:31:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1946,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 284211a1a3a241af8d3c2d8d12d7876c
+      - faf2e0ebc64e4d62ac88510d861f4e9c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFkZDRmNDVmLTEyN2UtNDE3
-        OC05ODU0LWY2MGQxOWNhM2IxNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjNmQ2NmU0LTQ2YTAtNDBj
+        Ni1hODc4LWYxNDUwOThmYTQ3ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1dd4f45f-127e-4178-9854-f60d19ca3b14/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6c6d66e4-46a0-40c6-a878-f145098fa47e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1981,82 +1787,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:18 GMT
+      - Fri, 29 Jul 2022 11:32:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5abf836be43a4b38b75b37f06e7e9429
+      - e596072357164b8e84930c933c701997
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '598'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWRkNGY0NWYtMTI3
-        ZS00MTc4LTk4NTQtZjYwZDE5Y2EzYjE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTYuNTk0NjU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmM2ZDY2ZTQtNDZh
+        MC00MGM2LWE4NzgtZjE0NTA5OGZhNDdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTguNTcxMjIzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyODQyMTFhMWEzYTI0MWFmOGQz
-        YzJkOGQxMmQ3ODc2YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjE2LjYyNDI4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        MTguMTU4NDg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmYWYyZTBlYmM2NGU0ZDYyYWM4
+        ODUxMGQ4NjFmNGU5YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjU4LjYzNTA1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MDIuNjc0NjcxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
         IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZjZiYzAyODUtZDdlYi00MWFjLWFjZmMt
-        NGYyNmQyZGE3NzNjL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2Y2YmMwMjg1LWQ3ZWItNDFhYy1hY2ZjLTRmMjZkMmRhNzczYy8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9jMmU4MjNmZC00ODEy
-        LTQxNjktODE0ZS02MWQwMWVjYmVjY2IvIl19
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBh
+        Y2thZ2VzIiwiY29kZSI6InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJz
+        eW5jLnBhcnNpbmcuYWR2aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        VW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
+        b25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5n
+        IENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2U1OWRlMzFiLTk2NDQtNDQ0MC1iNTA5LTM5
+        NDM2NTg1M2FjMy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9l
+        NTlkZTMxYi05NjQ0LTQ0NDAtYjUwOS0zOTQzNjU4NTNhYzMvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYzlmOTk3OGYtOWI1ZS00
+        M2Y1LTg3MTUtNDZjMTE3NTY0N2ZiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:02 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZjZiYzAyODUtZDdlYi00MWFjLWFjZmMtNGYyNmQyZGE3
-        NzNjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZTU5ZGUzMWItOTY0NC00NDQwLWI1MDktMzk0MzY1ODUz
+        YWMzL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2069,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:18 GMT
+      - Fri, 29 Jul 2022 11:32:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2087,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e7c7b94ccda34d008da5ff33bbbf407c
+      - a999166014084f24bd571dd4bcf3abe0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlMjgxZDdlLWYzYWUtNGEw
-        Mi04OGExLWVhYjk5MjExODgwMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczM2E2OGRiLTJmZjEtNDky
+        NC04ZGU2LTU4MmY3NjQzMDJmMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3e281d7e-f3ae-4a02-88a1-eab992118802/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/733a68db-2ff1-4924-8de6-582f764302f2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2122,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:18 GMT
+      - Fri, 29 Jul 2022 11:32:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22b30c15b54d4784b1ed3430cef4a943
+      - c79dac41d23c4f6a8de72417e42b7b42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2UyODFkN2UtZjNh
-        ZS00YTAyLTg4YTEtZWFiOTkyMTE4ODAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTguMzYxNjU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzMzYTY4ZGItMmZm
+        MS00OTI0LThkZTYtNTgyZjc2NDMwMmYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MDMuMDk0NzEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImU3YzdiOTRjY2RhMzRkMDA4ZGE1ZmYzM2Ji
-        YmY0MDdjIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MTguMzkz
-        MTIwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDoxOC41OTcz
-        ODdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImE5OTkxNjYwMTQwODRmMjRiZDU3MWRkNGJj
+        ZjNhYmUwIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MDMuMTQ1
+        Njk2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMjowMy42MjQx
+        ODVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZDE1NWE3
-        YzQtMjM3ZS00Mjk1LWFiNjMtZWQyZWE3ZDEwMzc3LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZjBlOTZj
+        OTEtZWI0OC00MDM3LWFmODgtODJmZTM0ODI3NzUwLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZjZiYzAyODUtZDdlYi00MWFjLWFjZmMtNGYyNmQy
-        ZGE3NzNjLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZTU5ZGUzMWItOTY0NC00NDQwLWI1MDktMzk0MzY1
+        ODUzYWMzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2179,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2192,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e7c43526c0d2406d9720319713deebcd
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:18 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:18 GMT
+      - Fri, 29 Jul 2022 11:32:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2529,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d9f8d797a2994984af0bed3b0f379323
+      - 33134ad70330402dbe5d93ee68b6f1ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/f0e96c91-eb48-4037-af88-82fe34827750/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2551,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2564,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:18 GMT
+      - Fri, 29 Jul 2022 11:32:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0677eaaa24ad47be87ccdb5768eaeb15
+      - 6d74958c60f34897a7413538d2f67003
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vZjBlOTZjOTEtZWI0OC00MDM3LWFmODgtODJmZTM0ODI3NzUwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MDMuMzA4MjE1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lNTlkZTMxYi05NjQ0LTQ0NDAtYjUwOS0zOTQzNjU4NTNhYzMv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2U1OWRlMzFiLTk2NDQtNDQ0MC1iNTA5LTM5NDM2
+        NTg1M2FjMy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:03 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9mMGU5NmM5MS1lYjQ4LTQwMzctYWY4OC04MmZlMzQ4Mjc3NTAv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 772b10b3447f479ca4b0aafa65d7ff9c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzN2RmM2E4LWY4NzItNGE3
+        Ni1iNzE5LTNkNDM3ODI3ODgzNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a37df3a8-f872-4a76-b719-3d4378278835/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 97a1913868ab4271b36499381cc89e54
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTM3ZGYzYTgtZjg3
+        Mi00YTc2LWI3MTktM2Q0Mzc4Mjc4ODM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MDMuOTYwMDYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3NzJiMTBiMzQ0N2Y0NzljYTRiMGFhZmE2
+        NWQ3ZmY5YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjA0LjAx
+        NTQ4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MDQuNDk2
+        NzM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMmJi
+        NzIxNzItYzg1Yi00YTlhLWI5MzQtYWIzMWNkZjYwNjliLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/2bb72172-c85b-4a9a-b934-ab31cdf6069b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 632f5ee3c86949a68f6ea290804f3a33
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzJiYjcyMTcyLWM4NWItNGE5YS1iOTM0LWFiMzFjZGY2MDY5Yi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjA0LjQ2OTg0OFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vZjBlOTZjOTEtZWI0OC00MDM3LWFmODgt
+        ODJmZTM0ODI3NzUwLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8cf45acde1e54c0eb2473b6b729cb710
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - cc7e2a87c45042cf9a7bc2778ca4a42b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fbdc5818ac7b443aac3544222be8bf60
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2610,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2639,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2668,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2687,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2698,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2711,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2729,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1aaae24ad7aa4a799e22d7110cd96b88
+      - da2b385f0a0b4bafa7b0857caf0b0ac6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2751,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2764,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2782,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d00b8899b9745cdb96de3079586a056
+      - 74f6aa2bc44949da879003da6ffaca6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2804,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2817,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2835,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 16aa89431a3d46b3b6695126048d1755
+      - 5471111ecb3f48dd9229d1c865b8d8da
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2857,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2870,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2888,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 47641d99aca74834835e9610b74cbaf3
+      - 71cad351219b43389f9769ca7e052031
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2910,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2923,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2941,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd22375793b54ddb86783fda40c8adcb
+      - 3aa0e4bafada4e26b72d1171b30eb518
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2963,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2976,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2994,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ca080db4e7c74f369c89f7895eecf212
+      - 7469500f3d0d4836a488a87c151de073
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3016,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3029,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3047,37 +3153,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - daf8cb254e4d4d1c89f7b44a11f2e1e9
+      - c24095dc44954d5c9d1690173d3efbb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjZiYzAyODUtZDdlYi00MWFjLWFj
-        ZmMtNGYyNmQyZGE3NzNjL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQzMWZlYTJlLTlkMTgt
-        NDc5YS1hNTdjLTBjZWE0ZDcyMDA5OS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYt
-        YWVhZC1mZjg1MGI5MjZlNWMvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjp0
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTU5ZGUzMWItOTY0NC00NDQwLWI1
+        MDktMzk0MzY1ODUzYWMzL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzIxM2MwZTU0LTJiZjIt
+        NDcwNi04NGE4LWVmMGZlYzY4YmE4YS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAt
+        YmQyYi05MDMzNmRkMzBjNGMvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjp0
         cnVlfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3090,7 +3196,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3108,21 +3214,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f4daeae180747b080c6c866832ef3e8
+      - 461feb3575404f5dbf88948fffd4b12c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxYmMyNzk1LTkyMjYtNDYx
-        OC1iYTA2LTY0YTEyOWNmMmQxMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0OGM4NDg0LTlmMGMtNDk1
+        OS05ZTJmLTMxMDVkYTIzYzAxYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01bc2795-9226-4618-ba06-64a129cf2d11/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a48c8484-9f0c-4959-9e2f-3105da23c01b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3143,55 +3249,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 93fc79c5cffe4c23a5f5731ab44e74a8
+      - 6e6e2fe2ceb742bf88216b68331cf7ab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '415'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDFiYzI3OTUtOTIy
-        Ni00NjE4LWJhMDYtNjRhMTI5Y2YyZDExLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MTkuNTI2OTU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQ4Yzg0ODQtOWYw
+        Yy00OTU5LTllMmYtMzEwNWRhMjNjMDFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MDYuMzU4MTU1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiNWY0ZGFlYWUxODA3NDdiMDgwYzZjODY2ODMy
-        ZWYzZTgiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDoxOS41NjY3
-        NDlaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjE5Ljc3NTYy
-        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvMGRmMThhZmYtNjRiOC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiNDYxZmViMzU3NTQwNGY1ZGJmODg5NDhmZmZk
+        NGIxMmMiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMjowNi40MDgw
+        NjBaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjA2LjgxNDQ4
+        NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDMxZmVh
-        MmUtOWQxOC00NzlhLWE1N2MtMGNlYTRkNzIwMDk5L3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjEzYzBl
+        NTQtMmJmMi00NzA2LTg0YTgtZWYwZmVjNjhiYThhL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzQzMWZlYTJlLTlkMTgtNDc5YS1hNTdjLTBj
-        ZWE0ZDcyMDA5OS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2Y2YmMwMjg1LWQ3ZWItNDFhYy1hY2ZjLTRmMjZkMmRhNzcz
-        Yy8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzIxM2MwZTU0LTJiZjItNDcwNi04NGE4LWVm
+        MGZlYzY4YmE4YS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2U1OWRlMzFiLTk2NDQtNDQ0MC1iNTA5LTM5NDM2NTg1M2Fj
+        My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3199,7 +3305,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3212,70 +3318,70 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1460'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 154b0623e96c44feb0d8b13d6d6e084e
+      - cad38fc2ee2d4a08a30090f64c335b7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '497'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTYsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0s
+        YWdlcy85OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvYzFkNjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsi
+        ZXMvMGQ0Zjc3YjMtMTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzc3MDJiYWQ2LTVkNzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NTkyNDRiNi0xNjdhLTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFm
-        MjRjMWEtMGUwNy00MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRl
-        OTJlLTE2NDEtNGNlYi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1
-        OS05Mzg4LTQ4N2MtYjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEt
-        NTlkOC00M2I3LThkYTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQw
-        NzEtNGM1OS04MzFhLTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUw
-        LTQ3YzItOTU5Ni0zM2E0M2YxNGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00
-        ZTdiLThiMGItYmYxOThkY2I2MjE0LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1
-        Mi1iYTM3LWNlODdhYzc1YWFmMS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVlNjYxOC0wYjBkLTRiOWYt
-        OWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00OGIxLWEw
-        ZDYtY2Y3YTk4YWZkYzU1LyJ9XX0=
+        LzhhZWY4OWIwLWQzYjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9h
+        ZTM1YmFmMC01NmY4LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJk
+        ZmYxM2UtZjg5Mi00Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhj
+        MDc2LWQ1MWQtNDFkZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBi
+        MC1hNzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2Qt
+        MTliYS00NmM3LTgzNGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcy
+        MjEtNDQwOC05MDA1LTEzYTkzYjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNDk3ZTBlZS0zYmE5
+        LTRhM2UtYTdiYS1kYjI1MDU5MWIyMzIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDAxYzFiZTAtYmYyYS00
+        MjA5LWIxODEtOGQ1OTlmZDA3OTMzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBmNzU3ZDI0LTY3ODItNDUx
+        MC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNWM5MTA0Zi0xMjMzLTQ2YzQt
+        YmY3My03NTE4MThmYzZmMTUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJk
+        MmItOTAzMzZkZDMwYzRjLyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3283,7 +3389,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3296,7 +3402,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:19 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3314,21 +3420,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '093ecd643ac94faf87e262704ba05d20'
+      - 0a3230787c2e4b7c96ee9afa8b46601f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3336,7 +3442,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3349,7 +3455,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3367,21 +3473,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9557a1e6de384832884b25c47d0a299d
+      - a78477c6543f4b178e9cc34822677c78
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3389,7 +3495,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3402,7 +3508,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3420,21 +3526,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aeae80368dc44c5c801f1ab3d058dfe5
+      - 88bd2d7074f74fb18dfe21b12f187198
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3442,7 +3548,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3455,7 +3561,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3473,21 +3579,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 654fbabe4b0a4013aeedad65de30c635
+      - '0992af2ae9264445b50034e81768938e'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3495,7 +3601,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3508,7 +3614,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3526,21 +3632,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5736f8195164dceb26bea1a42dc6f57
+      - 12754f7a54a544d1a98b226a99f0c1e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3548,7 +3654,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3561,70 +3667,70 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1460'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 648e97299b84478a831965989bd0eabc
+      - b4586cd3a0eb419e8580d78e0e6cea64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '497'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MTYsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0s
+        YWdlcy85OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvYzFkNjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsi
+        ZXMvMGQ0Zjc3YjMtMTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lzc3MDJiYWQ2LTVkNzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NTkyNDRiNi0xNjdhLTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFm
-        MjRjMWEtMGUwNy00MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRl
-        OTJlLTE2NDEtNGNlYi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1
-        OS05Mzg4LTQ4N2MtYjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEt
-        NTlkOC00M2I3LThkYTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQw
-        NzEtNGM1OS04MzFhLTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUw
-        LTQ3YzItOTU5Ni0zM2E0M2YxNGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00
-        ZTdiLThiMGItYmYxOThkY2I2MjE0LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1
-        Mi1iYTM3LWNlODdhYzc1YWFmMS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVlNjYxOC0wYjBkLTRiOWYt
-        OWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00OGIxLWEw
-        ZDYtY2Y3YTk4YWZkYzU1LyJ9XX0=
+        LzhhZWY4OWIwLWQzYjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9h
+        ZTM1YmFmMC01NmY4LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJk
+        ZmYxM2UtZjg5Mi00Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhj
+        MDc2LWQ1MWQtNDFkZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBi
+        MC1hNzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2Qt
+        MTliYS00NmM3LTgzNGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcy
+        MjEtNDQwOC05MDA1LTEzYTkzYjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNDk3ZTBlZS0zYmE5
+        LTRhM2UtYTdiYS1kYjI1MDU5MWIyMzIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDAxYzFiZTAtYmYyYS00
+        MjA5LWIxODEtOGQ1OTlmZDA3OTMzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBmNzU3ZDI0LTY3ODItNDUx
+        MC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xNWM5MTA0Zi0xMjMzLTQ2YzQt
+        YmY3My03NTE4MThmYzZmMTUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFjOWMtNTAwMC00MjEwLWJk
+        MmItOTAzMzZkZDMwYzRjLyJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3632,7 +3738,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3645,7 +3751,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3663,21 +3769,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d196654643146b785b124f4fc51af8f
+      - e77ecc9f189f43d7ae92dd05f3196ff0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3685,7 +3791,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3698,7 +3804,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3716,21 +3822,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c31506cf30b4dbc9d47794fe8ada961
+      - 140bf38e43604643b4bf4c102116457d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3738,7 +3844,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3751,7 +3857,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3769,21 +3875,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b91cacf9bde14a90bbe2ae00e1e45f95
+      - db658385fa304522b7f734e1bb6a4c59
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3791,7 +3897,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3804,7 +3910,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3822,21 +3928,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 066620c2c310421c93bc0001aa12a4a5
+      - 330b3444219647e8a7b511e1a320fcae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3844,7 +3950,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3857,7 +3963,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:20 GMT
+      - Fri, 29 Jul 2022 11:32:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3875,16 +3981,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3df667612cd445af92749c56ea461b75
+      - ff7504dc1bca48398713d52959447a8e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:08 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_all_no_filter_rules_without_dependency_solving.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_all_no_filter_rules_without_dependency_solving.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 29fc1555cc3843a4a0354d0fb372d032
+      - b9f10360563448b4a0a1e9fce5d6c415
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mNmJjMDI4NS1kN2ViLTQxYWMtYWNmYy00ZjI2ZDJkYTc3M2Mv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDoxNS4zNDE1NzBa
+        cnBtL3JwbS80N2YwZTM3ZS1hYjMzLTRmODctYjkzMi0wNzllMzk1Njg2ZjIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDo0NS44MjQyMzha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9mNmJjMDI4NS1kN2ViLTQxYWMtYWNmYy00ZjI2ZDJkYTc3M2Mv
+        cnBtL3JwbS80N2YwZTM3ZS1hYjMzLTRmODctYjkzMi0wNzllMzk1Njg2ZjIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Y2YmMw
-        Mjg1LWQ3ZWItNDFhYy1hY2ZjLTRmMjZkMmRhNzczYy92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQ3ZjBl
+        MzdlLWFiMzMtNGY4Ny1iOTMyLTA3OWUzOTU2ODZmMi92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:04 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/f6bc0285-d7eb-41ac-acfc-4f26d2da773c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ab75f0e4d08412c8e0ebd82c2665ba1
+      - '06489b3768b543ed922bffe246e252aa'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwM2E3ZjQwLTE4NjMtNDE3
-        OS04YWFkLTE5Njk0ZTA4MDE0OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyYzgzNjJkLTNhYjctNDBm
+        My04YTRmLTY2ZGY5MDY1OGViNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c41a5f1f24fc470194939967d93ca965
+      - d4a9fa2572094732b34f0e35cdc39bfb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a03a7f40-1863-4179-8aad-19694e080148/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b2c8362d-3ab7-40f3-8a4f-66df90658eb7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9ee16007b850471d8db7b9644520a1c9
+      - c93a48549fed453384d39b43ab77ccf4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTAzYTdmNDAtMTg2
-        My00MTc5LThhYWQtMTk2OTRlMDgwMTQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjEuNDIyODA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjJjODM2MmQtM2Fi
+        Ny00MGYzLThhNGYtNjZkZjkwNjU4ZWI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDQuNDcxODk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyYWI3NWYwZTRkMDg0MTJjOGUwZWJkODJj
-        MjY2NWJhMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjIxLjQ1
-        NjQwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MjEuNTg2
-        NDA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNjQ4OWIzNzY4YjU0M2VkOTIyYmZmZTI0
+        NmUyNTJhYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjA0LjU1
+        ODQ2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MDUuMDQy
+        NDU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjZiYzAyODUtZDdlYi00MWFj
-        LWFjZmMtNGYyNmQyZGE3NzNjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDdmMGUzN2UtYWIzMy00Zjg3
+        LWI5MzItMDc5ZTM5NTY4NmYyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 026ffa4dbb1940c7b96fc2ec64a85f78
+      - 4190aa12fa324e81ae4af99987bc9519
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a40f11e80c774e3d81c453cf1c0cebfd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNDI2OWJkYTAtODkwNy00OGNiLTgyZGUtYzQzODgxMjlkM2Rj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6NTQuOTk1Mjg2
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:05 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4269bda0-8907-48cb-82de-c4388129d3dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7c9277a16be64d3b8f8e16e16e905c5a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwNzYzZDRjLTJjYmYtNDc2
+        Yy05ZmEwLTc2ZDY1M2Y3NGM2Yy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d0763d4c-2cbf-476c-9fa0-76d653f74c6c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a270eafb63244c818a92f7cd4f3bc6ab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDA3NjNkNGMtMmNi
+        Zi00NzZjLTlmYTAtNzZkNjUzZjc0YzZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDUuNTI0MzM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3YzkyNzdhMTZiZTY0ZDNiOGY4ZTE2ZTE2
+        ZTkwNWM1YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjA1LjU5
+        NTgxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MDUuODI2
+        NTU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e8a8cdb561a540e8be3e1cee636d2abc
+      - 67cb6549d83040cc9fec7ff7e885c269
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6823c5d8fcdb4d8b8c60d08adcafc0fb
+      - b02c3a53707a43589ea83558e0b99a8f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 335ae337ae7d4b1d87c2dd2bfc3a2958
+      - c01d605b758c4b1db226914e5f555a4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:21 GMT
+      - Fri, 29 Jul 2022 11:31:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 40d76a81c95e46f489694e9fcae69721
+      - 88389f075b7d42fcaf02aa4a1b61406b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 649fc51c373446b9abadb71386a0ef4f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/fd7a3f49-af16-4b07-9dec-b5ae9e363ecc/"
+      - "/pulp/api/v3/remotes/rpm/rpm/900041b3-83bb-4d22-a581-89b3e2099e4a/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e986236fb4a484a94500500cf4e7663
+      - '00422880d9c9446d982dc7e4fe69496c'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Zk
-        N2EzZjQ5LWFmMTYtNGIwNy05ZGVjLWI1YWU5ZTM2M2VjYy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjIyLjAwODM0MloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkw
+        MDA0MWIzLTgzYmItNGQyMi1hNTgxLTg5YjNlMjA5OWU0YS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjA2LjM3MTQ3N1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjIyLjAwODM2MloiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjA2LjM3MTUwOFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/"
+      - "/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0276d471321d43ec831fb976a0c17672
+      - d69a977c87e545b5907da6b15efbd54a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTU2MGFiNDMtM2IxNy00ZGFlLWFmOTUtYTc3MjU1ZGY2NDcxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MjIuMTIzODUxWiIsInZl
+        cG0vYWM0YmMwNjQtODAyZC00NTY4LWE1MzItNjU1NWUxZGQwNTYxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MDYuNjAzMDQyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOTU2MGFiNDMtM2IxNy00ZGFlLWFmOTUtYTc3MjU1ZGY2NDcxL3ZlcnNp
+        cG0vYWM0YmMwNjQtODAyZC00NTY4LWE1MzItNjU1NWUxZGQwNTYxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85NTYwYWI0My0z
-        YjE3LTRkYWUtYWY5NS1hNzcyNTVkZjY0NzEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hYzRiYzA2NC04
+        MDJkLTQ1NjgtYTUzMi02NTU1ZTFkZDA1NjEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '09097e716b4e4efca8eb5b91b7072755'
+      - f869be463ada40c9911cf0c09d9dfbd9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80MzFmZWEyZS05ZDE4LTQ3OWEtYTU3Yy0wY2VhNGQ3MjAwOTkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDoxNi4xMjMxNTFa
+        cnBtL3JwbS9kOTE3Y2FjYi1iN2NmLTQ4Y2YtOTgxNi0yZjQxNDIwMTcwNWIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDo0Ny41ODExMzFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80MzFmZWEyZS05ZDE4LTQ3OWEtYTU3Yy0wY2VhNGQ3MjAwOTkv
+        cnBtL3JwbS9kOTE3Y2FjYi1iN2NmLTQ4Y2YtOTgxNi0yZjQxNDIwMTcwNWIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQzMWZl
-        YTJlLTlkMTgtNDc5YS1hNTdjLTBjZWE0ZDcyMDA5OS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q5MTdj
+        YWNiLWI3Y2YtNDhjZi05ODE2LTJmNDE0MjAxNzA1Yi92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:06 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/431fea2e-9d18-479a-a57c-0cea4d720099/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 354a10fb641a43a1861da6bc360df731
+      - 258f77b3520b41dcb4ca3b43669d9327
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0MjBmZmU3LTMwNWMtNDI0
-        NC1iNTAyLWNjOGJlNGMyMDQwZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlNGMxZmQwLTA5ZjEtNDE4
+        My1hNDY0LTYwNzhmMTRlMzdlMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 16848369c1cc459ba48e5ab4c21a2be7
+      - '0085933e283347ba8a8eb2397487c23c'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYzJlODIzZmQtNDgxMi00MTY5LTgxNGUtNjFkMDFlY2JlY2NiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MTUuMTU5MTU4WiIsIm5h
+        cG0vMjAwNzQxZGEtNDU2Zi00ZWI4LTg5MGEtZDQzMGY0NTIwNTZlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6NDUuNjI1OTAxWiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDoxNi40NDc0MTdaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDo0OC4zMDk0NzdaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:07 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/c2e823fd-4812-4169-814e-61d01ecbeccb/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/200741da-456f-4eb8-890a-d430f452056e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 79464d9e11184839b9eb6997c38d6a3e
+      - affb2be69fd24d29b7c35c388025bea4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYyZjQ3ODFkLTMzM2EtNDJh
-        MS04NWUzLTU3MmMxYzBjZDI3ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiNGE3MGRjLWI4ZjMtNGI0
+        My1hZjZmLTIxNDRjY2JlNzY0MS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0420ffe7-305c-4244-b502-cc8be4c2040d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0e4c1fd0-09f1-4183-a464-6078f14e37e1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d01cfbf391f749b5955a90b493a73963
+      - 7641d23b59a54680b88c3a56e4e12638
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQyMGZmZTctMzA1
-        Yy00MjQ0LWI1MDItY2M4YmU0YzIwNDBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjIuMzI5MjM2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGU0YzFmZDAtMDlm
+        MS00MTgzLWE0NjQtNjA3OGYxNGUzN2UxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDcuMDI0NDU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNTRhMTBmYjY0MWE0M2ExODYxZGE2YmMz
-        NjBkZjczMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjIyLjM2
-        MTk1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MjIuNDIz
-        MDg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyNThmNzdiMzUyMGI0MWRjYjRjYTNiNDM2
+        NjlkOTMyNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjA3LjA5
+        MDIwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MDcuNTIz
+        OTY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDMxZmVhMmUtOWQxOC00Nzlh
-        LWE1N2MtMGNlYTRkNzIwMDk5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2NhY2ItYjdjZi00OGNm
+        LTk4MTYtMmY0MTQyMDE3MDViLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/62f4781d-333a-42a1-85e3-572c1c0cd27d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0b4a70dc-b8f3-4b43-af6f-2144ccbe7641/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53d6ad46cde04a1a87f595127b165c8c
+      - 34c6995547c24395827ad6bb624c1f88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjJmNDc4MWQtMzMz
-        YS00MmExLTg1ZTMtNTcyYzFjMGNkMjdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjIuNDIzNzcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGI0YTcwZGMtYjhm
+        My00YjQzLWFmNmYtMjE0NGNjYmU3NjQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDcuMjU0MjY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3OTQ2NGQ5ZTExMTg0ODM5YjllYjY5OTdj
-        MzhkNmEzZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjIyLjQ1
-        NjUzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MjIuNTAz
-        NTgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZmZiMmJlNjlmZDI0ZDI5YjdjMzVjMzg4
+        MDI1YmVhNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjA3LjM5
+        MzI4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MDcuNzIy
+        MzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MyZTgyM2ZkLTQ4MTItNDE2OS04MTRl
-        LTYxZDAxZWNiZWNjYi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzIwMDc0MWRhLTQ1NmYtNGViOC04OTBh
+        LWQ0MzBmNDUyMDU2ZS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4bb14f5588fd4f37aaa0fd188d14afe9
+      - 3d884ab39cc7425e8e4c84024246d802
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2e02849e8169485bbf67c889db37ba28
+      - e0d6344232874908b81239e59038333d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56f5bab8153047cabcc1a6f25394bb0b
+      - 3cd9b6769ee249489e015de472dae21c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31f4a2a7b22a422dafc8cbd192b0886d
+      - fc92a3b96a174d67ba114a3ebe5fd829
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e3a0337bde074cefa3ac36b5e8dbde1a
+      - 322c4d556a424c39b11393ec6b9d63c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:22 GMT
+      - Fri, 29 Jul 2022 11:31:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 983281a3a7934eb7a97d29f15377c07b
+      - 47674483aa214c5ebb67fedb6bcf81b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:08 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:23 GMT
+      - Fri, 29 Jul 2022 11:31:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff99baa7fac441bd9050330634e80983
+      - 6caaa59fff4b4cf58af573f0705095c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vODk1N2VhOTQtNmEwNy00NmFmLTg2N2QtZDMzNmJiNDY4ZDBhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MjMuMDA0MjkxWiIsInZl
+        cG0vODIxNDJjMTItNjdmNS00YTkzLTg0MjItMmZhZGFkMTdhOGVlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MDguNTU0MzE1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vODk1N2VhOTQtNmEwNy00NmFmLTg2N2QtZDMzNmJiNDY4ZDBhL3ZlcnNp
+        cG0vODIxNDJjMTItNjdmNS00YTkzLTg0MjItMmZhZGFkMTdhOGVlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84OTU3ZWE5NC02
-        YTA3LTQ2YWYtODY3ZC1kMzM2YmI0NjhkMGEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84MjE0MmMxMi02
+        N2Y1LTRhOTMtODQyMi0yZmFkYWQxN2E4ZWUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:08 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/fd7a3f49-af16-4b07-9dec-b5ae9e363ecc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/900041b3-83bb-4d22-a581-89b3e2099e4a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:23 GMT
+      - Fri, 29 Jul 2022 11:31:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a14c69e42d1c404b8d6d4924274dc72b
+      - 5d75d164717342d897138c37e5c3a681
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmYmVlMjI3LTc4NTUtNGNi
-        Zi04MmY0LTkwNzdjZWQxYWJjZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5MTJmNzgzLWY5MjMtNGZj
+        NS1hOTc5LTJmNmFlZjY2OTFmOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/7fbee227-7855-4cbf-82f4-9077ced1abce/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9912f783-f923-4fc5-a979-2f6aef6691f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:23 GMT
+      - Fri, 29 Jul 2022 11:31:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8bd0388fed04422b87ad90f43bb5cec
+      - 3741f6a487e544aa95da6499e9cbfb26
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2ZiZWUyMjctNzg1
-        NS00Y2JmLTgyZjQtOTA3N2NlZDFhYmNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjMuMjk1NDcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTkxMmY3ODMtZjky
+        My00ZmM1LWE5NzktMmY2YWVmNjY5MWY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDkuMTM5NTg0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJhMTRjNjllNDJkMWM0MDRiOGQ2ZDQ5MjQy
-        NzRkYzcyYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjIzLjM0
-        NzEyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MjMuMzcy
-        MjQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1ZDc1ZDE2NDcxNzM0MmQ4OTcxMzhjMzdl
+        NWMzYTY4MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjA5LjE5
+        ODQ0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MDkuMjM2
+        MzE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZkN2EzZjQ5LWFmMTYtNGIwNy05ZGVj
-        LWI1YWU5ZTM2M2VjYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkwMDA0MWIzLTgzYmItNGQyMi1hNTgx
+        LTg5YjNlMjA5OWU0YS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:09 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZkN2Ez
-        ZjQ5LWFmMTYtNGIwNy05ZGVjLWI1YWU5ZTM2M2VjYy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkwMDA0
+        MWIzLTgzYmItNGQyMi1hNTgxLTg5YjNlMjA5OWU0YS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:23 GMT
+      - Fri, 29 Jul 2022 11:31:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 92d3c0976ab54f1fa4de05a0b56b5533
+      - 7bff93c8bf004747b90438d15fc6e937
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyNGRkZjg2LTY0YmEtNGIx
-        YS04Y2FmLTcyMDEzYmJmNzI5MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhNWUwNDMxLTY1MzItNDMx
+        ZC1iMDhjLTZjYTUxZjllZGQ2NC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b24ddf86-64ba-4b1a-8caf-72013bbf7291/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3a5e0431-6532-431d-b08c-6ca51f9edd64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:25 GMT
+      - Fri, 29 Jul 2022 11:31:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a13fa6a17b042a7958956f54518e3df
+      - d0ad2ef43c8b4417854e81cb8f772cd4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '598'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjI0ZGRmODYtNjRi
-        YS00YjFhLThjYWYtNzIwMTNiYmY3MjkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjMuNTAyMDU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2E1ZTA0MzEtNjUz
+        Mi00MzFkLWIwOGMtNmNhNTFmOWVkZDY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDkuNDY3NjM3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI5MmQzYzA5NzZhYjU0ZjFmYTRk
-        ZTA1YTBiNTZiNTUzMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjIzLjUzMjE3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        MjUuMTIzMjI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI3YmZmOTNjOGJmMDA0NzQ3Yjkw
+        NDM4ZDE1ZmM2ZTkzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjA5LjUxODU5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        MTMuNjY3NDg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vOTU2MGFiNDMtM2IxNy00ZGFlLWFmOTUt
-        YTc3MjU1ZGY2NDcxL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        Lzk1NjBhYjQzLTNiMTctNGRhZS1hZjk1LWE3NzI1NWRmNjQ3MS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9mZDdhM2Y0OS1hZjE2
-        LTRiMDctOWRlYy1iNWFlOWUzNjNlY2MvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2FjNGJjMDY0LTgwMmQtNDU2OC1hNTMyLTY1
+        NTVlMWRkMDU2MS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9h
+        YzRiYzA2NC04MDJkLTQ1NjgtYTUzMi02NTU1ZTFkZDA1NjEvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vOTAwMDQxYjMtODNiYi00
+        ZDIyLWE1ODEtODliM2UyMDk5ZTRhLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:13 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOTU2MGFiNDMtM2IxNy00ZGFlLWFmOTUtYTc3MjU1ZGY2
-        NDcxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYWM0YmMwNjQtODAyZC00NTY4LWE1MzItNjU1NWUxZGQw
+        NTYxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:25 GMT
+      - Fri, 29 Jul 2022 11:31:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d63ac587498c4fa1a164f244ee2228c1
+      - eed477f737784cdea79e8b47619f2a22
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhZmYxNjMxLWQzNGItNDg2
-        NS1hYTZkLWJjNGM4MDQxNGFjMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2MzQyNmEwLTIyMTktNDM1
+        Ni04ODZjLTBjZjJjOGM0YmUxNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2aff1631-d34b-4865-aa6d-bc4c80414ac3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f63426a0-2219-4356-886c-0cf2c8c4be17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:25 GMT
+      - Fri, 29 Jul 2022 11:31:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 220589cbdcc04a548df7d3d809586f41
+      - 7836268413344934a829c5e222c12e04
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmFmZjE2MzEtZDM0
-        Yi00ODY1LWFhNmQtYmM0YzgwNDE0YWMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjUuMjkxOTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjYzNDI2YTAtMjIx
+        OS00MzU2LTg4NmMtMGNmMmM4YzRiZTE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MTMuOTk1OTY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImQ2M2FjNTg3NDk4YzRmYTFhMTY0ZjI0NGVl
-        MjIyOGMxIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MjUuMzIx
-        MTMxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDoyNS40OTM2
-        OTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImVlZDQ3N2Y3Mzc3ODRjZGVhNzllOGI0NzYx
+        OWYyYTIyIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MTQuMDU3
+        ODgyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMToxNC42MjEw
+        MzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZWZkNTBj
-        NWMtNGNmMi00ZjZmLTllMGEtZWZhNDhhZmQxYzU5LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDU3OGYx
+        YjktNTk3Zi00MjA4LWJlODgtYjk5OWQxYmE3ZjhmLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOTU2MGFiNDMtM2IxNy00ZGFlLWFmOTUtYTc3MjU1
-        ZGY2NDcxLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYWM0YmMwNjQtODAyZC00NTY4LWE1MzItNjU1NWUx
+        ZGQwNTYxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:25 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - '0697b00c59a442b5a97b57f8b35a6931'
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:25 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:25 GMT
+      - Fri, 29 Jul 2022 11:31:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2dd41cec00e54b64a6b2fe924a2d91f8
+      - c640d0e5f31f49d5b43a07eba3260514
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/4578f1b9-597f-4208-be88-b999d1ba7f8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:25 GMT
+      - Fri, 29 Jul 2022 11:31:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1524d30153f047308983a6d97a5cfa30
+      - 69aa6469e5bb470fb2229c6c8d9843ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNDU3OGYxYjktNTk3Zi00MjA4LWJlODgtYjk5OWQxYmE3ZjhmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MTQuMjQxMDgyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9hYzRiYzA2NC04MDJkLTQ1NjgtYTUzMi02NTU1ZTFkZDA1NjEv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2FjNGJjMDY0LTgwMmQtNDU2OC1hNTMyLTY1NTVl
+        MWRkMDU2MS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:14 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS80NTc4ZjFiOS01OTdmLTQyMDgtYmU4OC1iOTk5ZDFiYTdmOGYv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8132be1054f946949fafb05ac61499e5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBkZGJlNDExLTBkYzEtNDBm
+        MS1iNmRkLWE0NzNkYWY5Y2Q3Yi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:15 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0ddbe411-0dc1-40f1-b6dd-a473daf9cd7b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 67ad24c3dc744e048a5c96df66538041
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGRkYmU0MTEtMGRj
+        MS00MGYxLWI2ZGQtYTQ3M2RhZjljZDdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MTUuMDI1MzAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4MTMyYmUxMDU0Zjk0Njk0OWZhZmIwNWFj
+        NjE0OTllNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjE1LjA4
+        NDMxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MTUuNTY1
+        MDk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZDZk
+        YTg0NmQtNWJmYy00YmQ3LWFjM2ItZGVhODg3ZWM1NzBjLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:15 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/d6da846d-5bfc-4bd7-ac3b-dea887ec570c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 56c18018b00b4d6da3a32ec8ed6ab781
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2Q2ZGE4NDZkLTViZmMtNGJkNy1hYzNiLWRlYTg4N2VjNTcwYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjE1LjU0MzI0N1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNDU3OGYxYjktNTk3Zi00MjA4LWJlODgt
+        Yjk5OWQxYmE3ZjhmLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:15 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 52b7bbaab3d145669803a88fa1c7f5bf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:16 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 23dd13cd52f04e3bbc9f0ab015980d22
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:16 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 47aaa052dc5347548ebaf0279011ac1b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:25 GMT
+      - Fri, 29 Jul 2022 11:31:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3c738bd62fa54cf0a8a90d5ed22f5524
+      - 47c79cc7260e490b98a84f87b615737d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:25 GMT
+      - Fri, 29 Jul 2022 11:31:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 99becd3d1d1f43d0900651a5a1d376e9
+      - '0827d19ee4aa49b2845d7cf4ccc92d5b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1540588333064377b89dd0099529427c
+      - d020e25ca5c04cbf98fcd97394e21c99
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 676978855f2145a885bde0260a5e7711
+      - 06117ae9b8484d90b5d1d30c808bcacf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8165337c175144f8b9df9a919660537c
+      - 9111177fb5cb47648a341d7d3b877c3c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1c3b2f26e3d64dd28f9cae9f04e59a92
+      - 209ac371233041029b9103595d02032e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,37 +3153,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 526e00cac7c74e72afffe4ff3d774759
+      - 6f2fa631df174847b8dd8dc168d04ec0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:17 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTU2MGFiNDMtM2IxNy00ZGFlLWFm
-        OTUtYTc3MjU1ZGY2NDcxL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzg5NTdlYTk0LTZhMDct
-        NDZhZi04NjdkLWQzMzZiYjQ2OGQwYS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYt
-        YWVhZC1mZjg1MGI5MjZlNWMvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWM0YmMwNjQtODAyZC00NTY4LWE1
+        MzItNjU1NWUxZGQwNTYxL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzgyMTQyYzEyLTY3ZjUt
+        NGE5My04NDIyLTJmYWRhZDE3YThlZS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAt
+        YmQyYi05MDMzNmRkMzBjNGMvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
         YWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2771,7 +3196,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2789,21 +3214,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2a1159e981f1466892ba8f4274661597
+      - 968c3f912ab0405f81c474f9d864ce8e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyYzYxNWQ5LThlYzctNDhi
-        NC05NjE1LTg3NTQwZDI5NWMwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5NmUyNzZhLTkyZDUtNDY1
+        OC04OWI0LWZmOTMxZjcwODg3ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/22c615d9-8ec7-48b4-9615-87540d295c01/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b96e276a-92d5-4658-89b4-ff931f70887e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2824,55 +3249,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f4b60353a3f14f5a97f45238e06d6d09
+      - 39babef2f9514f0d9dfd8675fa87dd73
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '413'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjJjNjE1ZDktOGVj
-        Ny00OGI0LTk2MTUtODc1NDBkMjk1YzAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjYuMzk3NDc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjk2ZTI3NmEtOTJk
+        NS00NjU4LTg5YjQtZmY5MzFmNzA4ODdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MTcuMjI5NDIzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiMmExMTU5ZTk4MWYxNDY2ODkyYmE4ZjQyNzQ2
-        NjE1OTciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDoyNi40Mjg2
-        NTZaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjI2LjU3MDA1
-        NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiOTY4YzNmOTEyYWIwNDA1ZjgxYzQ3NGY5ZDg2
+        NGNlOGUiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMToxNy4yODk4
+        NDJaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjE3Ljc2MjEy
+        MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODk1N2Vh
-        OTQtNmEwNy00NmFmLTg2N2QtZDMzNmJiNDY4ZDBhL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODIxNDJj
+        MTItNjdmNS00YTkzLTg0MjItMmZhZGFkMTdhOGVlL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzg5NTdlYTk0LTZhMDctNDZhZi04NjdkLWQz
-        MzZiYjQ2OGQwYS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzk1NjBhYjQzLTNiMTctNGRhZS1hZjk1LWE3NzI1NWRmNjQ3
+        cG9zaXRvcmllcy9ycG0vcnBtLzgyMTQyYzEyLTY3ZjUtNGE5My04NDIyLTJm
+        YWRhZDE3YThlZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2FjNGJjMDY0LTgwMmQtNDU2OC1hNTMyLTY1NTVlMWRkMDU2
         MS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2880,7 +3305,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2893,41 +3318,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b8f6eadc004e4d17856537e71354baa9
+      - 579fb7cbc2d5428d8be270859e2856d5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMv
+        YWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQyYi05MDMzNmRkMzBjNGMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2935,7 +3360,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2948,7 +3373,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2966,21 +3391,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d93a8e8e1f0648c9943ea76f0ba2a9ad
+      - d9e12e5ed72147519218a8c754ad56fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,7 +3426,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3019,21 +3444,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 634d6bcc71454ef2bb383358fedd6f57
+      - f5c97469f00742ff9fa4fbab74c6714e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3041,7 +3466,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3054,7 +3479,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3072,21 +3497,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 61954e8d6e4e46bf975471ded24826e7
+      - 4970890c44c74f5983f41a833286e811
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3094,7 +3519,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3107,7 +3532,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3125,21 +3550,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56a39cec869a4f498b2d63b8cc92d8e5
+      - aedc04bcea26457ba2ef743d0ecc8ae7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3147,7 +3572,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3160,7 +3585,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:26 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3178,21 +3603,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e29a0f8b07ba4477a671dd19879a9c11
+      - 518e18530e2b40829e276da4ffe13efa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3200,7 +3625,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3213,41 +3638,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:27 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 533e1f7e9f904b1086425761d9ccd104
+      - e7f6ec78c5ae4deaa882d143b327f543
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMv
+        YWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQyYi05MDMzNmRkMzBjNGMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3255,7 +3680,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3268,7 +3693,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:27 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3286,21 +3711,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e2021a4f2b741a2a22e47e1ed8df2f0
+      - 55fbef0e08724008ae74980f6e55eb1b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3308,7 +3733,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3321,7 +3746,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:27 GMT
+      - Fri, 29 Jul 2022 11:31:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3339,21 +3764,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e8c26e38516149f2b9b14d89e597c54a
+      - 496d2d3a0980457fb37ddb833dfe05e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3361,7 +3786,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3374,7 +3799,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:27 GMT
+      - Fri, 29 Jul 2022 11:31:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3392,21 +3817,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 47846cf796a44540ae091ac81ece4031
+      - 42d9ae5f64db48e1bfea0864c7f7fa31
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3414,7 +3839,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3427,7 +3852,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:27 GMT
+      - Fri, 29 Jul 2022 11:31:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3445,21 +3870,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f941e34eaf2c4700be924290203f8061
+      - e3e503d2c6d2477385f0793d664d10b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3467,7 +3892,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3480,7 +3905,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:27 GMT
+      - Fri, 29 Jul 2022 11:31:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3498,16 +3923,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fe7f55ce65c6456aabcd7da862936126
+      - 6987d624db974f38b838d76c696d8482
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:19 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_nonmatching_package_exclusion_filter_copies_everything.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_nonmatching_package_exclusion_filter_copies_everything.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:49 GMT
+      - Fri, 29 Jul 2022 11:30:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 644ab466effb45fb9c6dfd013cc4620d
+      - 87521cd6efd848e49caba33113bb9f5f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yNWU3YTZkZi00MTM5LTRmNzgtOTlhNC03OTA3ZGQzMzA0ODkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo0My4zNzIwODNa
+        cnBtL3JwbS9mYzk0MTBjYy05YzMyLTQxYjctYjE1Ni03NjY4MTIzMzM3YWMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyOTo1Ny41NzUzMDla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yNWU3YTZkZi00MTM5LTRmNzgtOTlhNC03OTA3ZGQzMzA0ODkv
+        cnBtL3JwbS9mYzk0MTBjYy05YzMyLTQxYjctYjE1Ni03NjY4MTIzMzM3YWMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI1ZTdh
-        NmRmLTQxMzktNGY3OC05OWE0LTc5MDdkZDMzMDQ4OS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ZjOTQx
+        MGNjLTljMzItNDFiNy1iMTU2LTc2NjgxMjMzMzdhYy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:49 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:12 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:49 GMT
+      - Fri, 29 Jul 2022 11:30:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 63626ef8b7704e9197b51041012a0719
+      - eb7969f6f90c423d894b5570342d6835
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5NWI0OWFkLWNmZTgtNGVk
-        NC1iMTEzLWZkZThjNDM2M2FkMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0ZGRlZGViLWNkYWQtNGVi
+        Yi1hOWEyLWNkOWM0ZmM1ZmMyZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:49 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:49 GMT
+      - Fri, 29 Jul 2022 11:30:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e3968a610f61448a9632b5b8589aed9c
+      - 18f2112a424e49a3ae77c6cf25b5cb98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:49 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c95b49ad-cfe8-4ed4-b113-fde8c4363ad3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f4ddedeb-cdad-4ebb-a9a2-cd9c4fc5fc2f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:49 GMT
+      - Fri, 29 Jul 2022 11:30:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22c3787cd820401a9eaaa012905506be
+      - 38f46505d38d48ad9b68f39152e36d5e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzk1YjQ5YWQtY2Zl
-        OC00ZWQ0LWIxMTMtZmRlOGM0MzYzYWQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDkuNjEwMzQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjRkZGVkZWItY2Rh
+        ZC00ZWJiLWE5YTItY2Q5YzRmYzVmYzJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MTIuMjA4MjI3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2MzYyNmVmOGI3NzA0ZTkxOTdiNTEwNDEw
-        MTJhMDcxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjQ5LjY0
-        NjI2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NDkuNzYw
-        OTE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlYjc5NjlmNmY5MGM0MjNkODk0YjU1NzAz
+        NDJkNjgzNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjEyLjI2
+        NDU2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MTIuNjkw
+        MzA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjVlN2E2ZGYtNDEzOS00Zjc4
-        LTk5YTQtNzkwN2RkMzMwNDg5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmM5NDEwY2MtOWMzMi00MWI3
+        LWIxNTYtNzY2ODEyMzMzN2FjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:49 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:49 GMT
+      - Fri, 29 Jul 2022 11:30:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2fe7b3d8d694e50ba063a1f07ed2007
+      - 367fb0e402524668b7fa7552d4f629ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:49 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:49 GMT
+      - Fri, 29 Jul 2022 11:30:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7ee02226c5c74bc38a86b77214931050
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNWExZjdlNDMtN2RiMi00YWM5LWE2YTgtMmM2MTMzMDY2YWQz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MDUuODEwMDU3
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:12 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/5a1f7e43-7db2-4ac9-a6a8-2c6133066ad3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d6f1f9166ed246d49c6c3ee0fd1af5d0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4YzY1NjZmLTgyMmUtNDI4
+        ZC04MzY2LWViYjU4N2U2YTM4NS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:12 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f8c6566f-822e-428d-8366-ebb587e6a385/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:13 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 32caee522b3d4906a5ff7fd765bb1d57
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjhjNjU2NmYtODIy
+        ZS00MjhkLTgzNjYtZWJiNTg3ZTZhMzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MTIuOTU1OTc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkNmYxZjkxNjZlZDI0NmQ0OWM2YzNlZTBm
+        ZDFhZjVkMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjEzLjAx
+        MjMxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MTMuMDY2
+        NTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7de0ff38aa724aca9f487d95f7b4ccba
+      - 8fbd6eeab9c047e49a0cf4f04dc97bba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:49 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:49 GMT
+      - Fri, 29 Jul 2022 11:30:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08bbbfe348b64a1aa51a27ddaa235209'
+      - '096a2ee8278e459e9054fe6816e12e5b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:49 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eaee087ca1034e1088afe6af8887f02c
+      - bdbecf3d3bfc4d12b823fea971c3ecc8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a37f3ea1aacf45f783d2ecd3b53dca43
+      - 59b05995b66d499794c096de0b4e22d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:50 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f9c5453c69db4b89a8714b695cbf56ac
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/41bafc34-d382-4cca-bce2-1177c6653c5b/"
+      - "/pulp/api/v3/remotes/rpm/rpm/c3d93886-53e6-4adc-9274-8cbcd22d999d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6dee43937697429da87de9f8f44616ac
+      - 10ec7343d2de4588b9a8b29d259fc692
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQx
-        YmFmYzM0LWQzODItNGNjYS1iY2UyLTExNzdjNjY1M2M1Yi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjUwLjE5MjczMloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Mz
+        ZDkzODg2LTUzZTYtNGFkYy05Mjc0LThjYmNkMjJkOTk5ZC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjEzLjQ2NjU2OVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjUwLjE5Mjc1MloiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjEzLjQ2NjU5NFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/"
+      - "/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8a36cef4e3545fb8975046fafbb0149
+      - c116d19565044575b15c5caa88823ede
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZWY4NjEwOTUtYmUzNC00N2JhLTkzYWMtYzljYTI3NWY2Mzk2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NTAuMzA3MTAyWiIsInZl
+        cG0vOGNkM2E4MmUtNjI0Yi00NjY4LWExY2YtMzU1YWM3NmI2ODY4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MTMuNjYyNTkyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZWY4NjEwOTUtYmUzNC00N2JhLTkzYWMtYzljYTI3NWY2Mzk2L3ZlcnNp
+        cG0vOGNkM2E4MmUtNjI0Yi00NjY4LWExY2YtMzU1YWM3NmI2ODY4L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lZjg2MTA5NS1i
-        ZTM0LTQ3YmEtOTNhYy1jOWNhMjc1ZjYzOTYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84Y2QzYTgyZS02
+        MjRiLTQ2NjgtYTFjZi0zNTVhYzc2YjY4NjgvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6342afb2bae74af583636b059136fa32
+      - 6777f26773e240c198e057f829b8a941
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83YTUzOTAyYS03YzVhLTQ5ZDEtYTZkYS1iZDBhMDIxNmQzMjAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo0NC4wNjgzOTZa
+        cnBtL3JwbS84MDIwNGYxMC1iYmJlLTQ2NjQtOGNmMi1jNWFlNDU2ZWZhZmUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyOTo1OC43OTA5NzJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83YTUzOTAyYS03YzVhLTQ5ZDEtYTZkYS1iZDBhMDIxNmQzMjAv
+        cnBtL3JwbS84MDIwNGYxMC1iYmJlLTQ2NjQtOGNmMi1jNWFlNDU2ZWZhZmUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdhNTM5
-        MDJhLTdjNWEtNDlkMS1hNmRhLWJkMGEwMjE2ZDMyMC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzgwMjA0
+        ZjEwLWJiYmUtNDY2NC04Y2YyLWM1YWU0NTZlZmFmZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db28ee6423774deb8ef65e120414303c
+      - '01736874bf0845cf96e96af3e2994544'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkNWUwY2Q3LTEyYzgtNDIw
-        MS04OWNkLTMyODY3Njc4MDI1NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViNDNmYWJjLTlhZDctNDYx
+        ZC05NmU5LTFmNGU4MTUyZGM1NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c88a3431e3a24756a16edf6bc26c20b1
+      - 92f7682a8fcf41d2a3a83b8ddaa713be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vOGE5MGE1ODktNjhlYS00NTEyLWJjMjEtM2ZkODAzNmViOWUzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NDMuMjM4NTA2WiIsIm5h
+        cG0vNGY3MTBmYzAtYWZmMy00MWUyLWJkM2ItZDc0Zjc1NjA4NjkyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6NTcuMzg0NTY1WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo0NC4zODY2NjdaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMToyOTo1OS4zNjIxOTRaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/8a90a589-68ea-4512-bc21-3fd8036eb9e3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/4f710fc0-aff3-41e2-bd3b-d74f75608692/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6e83be0826c945ef872df0e846b15134
+      - bd5a1345faff4b8aa0b20c81eb80ce19
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5NGFkZjU0LWI0MjktNDFh
-        My1hMGNhLWJiZGRlZjk4MzE0YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5OWE5ODYyLWM4N2QtNGVk
+        YS1iZjAyLWQ4NDM2NzRhMGNkMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3d5e0cd7-12c8-4201-89cd-328676780255/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5b43fabc-9ad7-461d-96e9-1f4e8152dc55/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae5de3f4fb0e4118958ed2c94b0baee5
+      - 11b33a574f194e07a2be67ac76a8bea3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Q1ZTBjZDctMTJj
-        OC00MjAxLTg5Y2QtMzI4Njc2NzgwMjU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTAuNDY0MjE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWI0M2ZhYmMtOWFk
+        Ny00NjFkLTk2ZTktMWY0ZTgxNTJkYzU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MTMuOTYzMDI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkYjI4ZWU2NDIzNzc0ZGViOGVmNjVlMTIw
-        NDE0MzAzYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjUwLjQ5
-        NTE4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NTAuNTUw
-        MzAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMTczNjg3NGJmMDg0NWNmOTZlOTZhZjNl
+        Mjk5NDU0NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjE0LjAy
+        Njc4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MTQuMTY1
+        NTM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2E1MzkwMmEtN2M1YS00OWQx
-        LWE2ZGEtYmQwYTAyMTZkMzIwLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODAyMDRmMTAtYmJiZS00NjY0
+        LThjZjItYzVhZTQ1NmVmYWZlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/994adf54-b429-41a3-a0ca-bbddef98314a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/499a9862-c87d-4eda-bf02-d843674a0cd3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e06bbaac283a4b22add8e2e201694aff
+      - 58c39edcfca74bc281a199bba91382b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTk0YWRmNTQtYjQy
-        OS00MWEzLWEwY2EtYmJkZGVmOTgzMTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTAuNTUyMDU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDk5YTk4NjItYzg3
+        ZC00ZWRhLWJmMDItZDg0MzY3NGEwY2QzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MTQuMTQyMTY2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZTgzYmUwODI2Yzk0NWVmODcyZGYwZTg0
-        NmIxNTEzNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjUwLjU4
-        MzgxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NTAuNjI3
-        MzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZDVhMTM0NWZhZmY0YjhhYTBiMjBjODFl
+        YjgwY2UxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjE0LjIy
+        MjAyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MTQuNDc1
+        Mzg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhhOTBhNTg5LTY4ZWEtNDUxMi1iYzIx
-        LTNmZDgwMzZlYjllMy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmNzEwZmMwLWFmZjMtNDFlMi1iZDNi
+        LWQ3NGY3NTYwODY5Mi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1005f608d64d4c818b1f3c090520b5f2
+      - b39afd4f051540c9ab3db6c19a44f877
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c3a3812c43b04bbfbf4b428dd634f41f
+      - e010ffaf24fb43df9aabb4677c2dcb33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1549b2d3e664e46b63ed0cc7c963eea
+      - 855bd3110dcb4158b4bdbd0e986c3df1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9cdf71fa86ec4e2dbee194500ea2fece
+      - b57fc719336d4cbd8c45c629ce78c56a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 97798f86aa7447a7867eb35e7c34fd3d
+      - '08f4f6f063e6436091827ff88489cf5f'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:50 GMT
+      - Fri, 29 Jul 2022 11:30:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d75feb7c013c4344bb0514934644d213
+      - 2a04aec87bc348dba3f70db5cac2d861
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:50 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:14 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:51 GMT
+      - Fri, 29 Jul 2022 11:30:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/"
+      - "/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0da4101d342e4121a12bdb1fd7bd06ab
+      - 2c2d6133e5fe45eabf2d15f2fae10e5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOWJjYTA2ZTUtNGRjOS00M2NmLWEwY2QtMmMyMDA4MGM5MzQ5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NTEuMTAyODc3WiIsInZl
+        cG0vYzg3NWVlMWEtMDNiMC00MDMyLTljYWMtNmU1MzM5NmJhNGM3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MTUuMTM0NzY0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOWJjYTA2ZTUtNGRjOS00M2NmLWEwY2QtMmMyMDA4MGM5MzQ5L3ZlcnNp
+        cG0vYzg3NWVlMWEtMDNiMC00MDMyLTljYWMtNmU1MzM5NmJhNGM3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85YmNhMDZlNS00
-        ZGM5LTQzY2YtYTBjZC0yYzIwMDgwYzkzNDkvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jODc1ZWUxYS0w
+        M2IwLTQwMzItOWNhYy02ZTUzMzk2YmE0YzcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:51 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:15 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/41bafc34-d382-4cca-bce2-1177c6653c5b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c3d93886-53e6-4adc-9274-8cbcd22d999d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:51 GMT
+      - Fri, 29 Jul 2022 11:30:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f577f8cf14ad43b58200456bd6d7965a
+      - 05f4f43e4cb84743a438ff0483bb44ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1ZGE3ZDI1LTIwYjItNDg5
-        ZC1iNjJlLWUxMjA5ODkzMjU3Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc2Y2IxZGZkLWJlNmEtNGRi
+        ZC1iOWM0LTRiMmI0MTc5ODdlZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:51 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e5da7d25-20b2-489d-b62e-e1209893257f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/76cb1dfd-be6a-4dbd-b9c4-4b2b417987ed/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:51 GMT
+      - Fri, 29 Jul 2022 11:30:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e21928a35b004d06a4862f947f63e7b5
+      - 2fbcb2bedefd4c3ab017633662fb303c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVkYTdkMjUtMjBi
-        Mi00ODlkLWI2MmUtZTEyMDk4OTMyNTdmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTEuNDQ5OTM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzZjYjFkZmQtYmU2
+        YS00ZGJkLWI5YzQtNGIyYjQxNzk4N2VkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MTUuNjUxMDI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmNTc3ZjhjZjE0YWQ0M2I1ODIwMDQ1NmJk
-        NmQ3OTY1YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjUxLjQ4
-        MTkwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NTEuNTA2
-        Mjk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwNWY0ZjQzZTRjYjg0NzQzYTQzOGZmMDQ4
+        M2JiNDRlZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjE1Ljcx
+        OTI3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MTUuNzY0
+        OTcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQxYmFmYzM0LWQzODItNGNjYS1iY2Uy
-        LTExNzdjNjY1M2M1Yi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MzZDkzODg2LTUzZTYtNGFkYy05Mjc0
+        LThjYmNkMjJkOTk5ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:51 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQxYmFm
-        YzM0LWQzODItNGNjYS1iY2UyLTExNzdjNjY1M2M1Yi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MzZDkz
+        ODg2LTUzZTYtNGFkYy05Mjc0LThjYmNkMjJkOTk5ZC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:51 GMT
+      - Fri, 29 Jul 2022 11:30:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 654ead823e4146be9d8c69c1f03e39d1
+      - 3bfe85e564b2444681d9882927f23998
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY3MjgzNjUzLWU2YTgtNDU2
-        OS1iZmZmLWFlNWE4YTM4ZGUwYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4OTkxNDViLTIxY2ItNGE4
+        MC04MDk2LWMyNTEwMjExM2MzNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:51 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/67283653-e6a8-4569-bfff-ae5a8a38de0a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5899145b-21cb-4a80-8096-c25102113c34/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:53 GMT
+      - Fri, 29 Jul 2022 11:30:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c48b498a94f74bfcab179611e116b542
+      - 7655b6b64b364ac8b955d4ea69aaa56d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '598'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjcyODM2NTMtZTZh
-        OC00NTY5LWJmZmYtYWU1YThhMzhkZTBhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTEuNjQ3NTk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTg5OTE0NWItMjFj
+        Yi00YTgwLTgwOTYtYzI1MTAyMTEzYzM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MTUuOTkxNTg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI2NTRlYWQ4MjNlNDE0NmJlOWQ4
-        YzY5YzFmMDNlMzlkMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjUxLjY3ODg2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NTMuMjkzMzQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzYmZlODVlNTY0YjI0NDQ2ODFk
+        OTg4MjkyN2YyMzk5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjE2LjA2NjIwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MjAuNjc1MTIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY4NjEwOTUtYmUzNC00N2JhLTkzYWMt
-        YzljYTI3NWY2Mzk2L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2VmODYxMDk1LWJlMzQtNDdiYS05M2FjLWM5Y2EyNzVmNjM5Ni8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS80MWJhZmMzNC1kMzgy
-        LTRjY2EtYmNlMi0xMTc3YzY2NTNjNWIvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzhjZDNhODJlLTYyNGItNDY2OC1hMWNmLTM1
+        NWFjNzZiNjg2OC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84
+        Y2QzYTgyZS02MjRiLTQ2NjgtYTFjZi0zNTVhYzc2YjY4NjgvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYzNkOTM4ODYtNTNlNi00
+        YWRjLTkyNzQtOGNiY2QyMmQ5OTlkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:53 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:20 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZWY4NjEwOTUtYmUzNC00N2JhLTkzYWMtYzljYTI3NWY2
-        Mzk2L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vOGNkM2E4MmUtNjI0Yi00NjY4LWExY2YtMzU1YWM3NmI2
+        ODY4L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:53 GMT
+      - Fri, 29 Jul 2022 11:30:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f68eeb66515f47bc83ce01c0b27e85bb
+      - 3a9262e61a434d5c9c5eb238e0ec7962
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzNTcxOTk2LWI3NDQtNGZm
-        ZC04ZjkxLTU4MDIwNDRhMTU4ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IxYzQxZTQ5LTE5NWQtNGJj
+        OS1hMjE0LTk4YWJmMmY2YThmNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:53 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/13571996-b744-4ffd-8f91-5802044a158d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b1c41e49-195d-4bc9-a214-98abf2f6a8f6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:53 GMT
+      - Fri, 29 Jul 2022 11:30:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3707da6f4aab48dabcb1bb6e8af3eb8e
+      - 4ba8767a9bed4dc080ce82453bf17a30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTM1NzE5OTYtYjc0
-        NC00ZmZkLThmOTEtNTgwMjA0NGExNThkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTMuNTM5ODM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjFjNDFlNDktMTk1
+        ZC00YmM5LWEyMTQtOThhYmYyZjZhOGY2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjAuOTk3NDIyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImY2OGVlYjY2NTE1ZjQ3YmM4M2NlMDFjMGIy
-        N2U4NWJiIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NTMuNTY5
-        Mjk2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDo1My43NTQ5
-        NjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjNhOTI2MmU2MWE0MzRkNWM5YzVlYjIzOGUw
+        ZWM3OTYyIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MjEuMDY3
+        MTg2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMDoyMS41ODUz
+        MjFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYjEwZDMy
-        ZjQtYTRiYy00ZmRlLTkxYzUtNjIxZjEwYTQ2OTNlLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzU4ZjU1
+        YTYtOWQ0ZS00ZjU5LTg5YTAtYTI2NDk1YWI3YTAwLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZWY4NjEwOTUtYmUzNC00N2JhLTkzYWMtYzljYTI3
-        NWY2Mzk2LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vOGNkM2E4MmUtNjI0Yi00NjY4LWExY2YtMzU1YWM3
+        NmI2ODY4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:53 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 6309bef3b17b40a68f59477f055a61e7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3fc3e2d7685c45fdb624a7fdc18ed8a4
+      - 6e0ea5bf7e504071bd12306d09f3f3b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/c58f55a6-9d4e-4f59-89a0-a26495ab7a00/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5571068431fd4a67a3c83bf29003646c
+      - 8d0ba4e5bcb24d8584c3b7b79b57b1d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYzU4ZjU1YTYtOWQ0ZS00ZjU5LTg5YTAtYTI2NDk1YWI3YTAwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MjEuMTAxNzg5WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84Y2QzYTgyZS02MjRiLTQ2NjgtYTFjZi0zNTVhYzc2YjY4Njgv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzhjZDNhODJlLTYyNGItNDY2OC1hMWNmLTM1NWFj
+        NzZiNjg2OC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:21 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9jNThmNTVhNi05ZDRlLTRmNTktODlhMC1hMjY0OTVhYjdhMDAv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - df86d96a86044725ab88ce5f1d2ca7f4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIwNzc1ZjkxLWE5YjItNDhk
+        NC05ZTVhLWJhZDEyYmFkOTk0Ny8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:21 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/20775f91-a9b2-48d4-9e5a-bad12bad9947/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d3fc18695f03447d9292ec32e5999f4a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjA3NzVmOTEtYTli
+        Mi00OGQ0LTllNWEtYmFkMTJiYWQ5OTQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjEuOTY4OTA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkZjg2ZDk2YTg2MDQ0NzI1YWI4OGNlNWYx
+        ZDJjYTdmNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjIyLjAy
+        NjUwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MjIuNDU0
+        NDcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vY2Nh
+        ZTNlODItODhiNi00MDk5LWIzMTItZWExMjEwMDgzYjIzLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/ccae3e82-88b6-4099-b312-ea1210083b23/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1316a5b74b2c44ea8d4ef5eac3e0098e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2NjYWUzZTgyLTg4YjYtNDA5OS1iMzEyLWVhMTIxMDA4M2IyMy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjIyLjQzMTA3M1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYzU4ZjU1YTYtOWQ0ZS00ZjU5LTg5YTAt
+        YTI2NDk1YWI3YTAwLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3b3b003c054d432093bc8ec0c050a345
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2c348faacdba4cef8498d3af286aede2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:23 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 136e581233424565a51567a66e5d3d97
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5ab1dc0b50741af873265ee03a2c877
+      - 3584810ac53f4b9a98745b6670abc8ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 007bededba0b4ebb8f9b2ef5a1b1b274
+      - 5f24a1b6f7ca40b4ac191298d52bdc96
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd5ab77d7f0d43239cc5c04eba45d0c6
+      - 24a7afd205314971a26c55cec7c7df14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae98d866e2014950ac2f0ddcbb91d5cc
+      - 0e487e1f29c14736899801ac279d8377
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c27efcef69a84dd79a03f7b6960f82bb
+      - 96e5c336e4864d3aba2abd94bf02dd61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4f146ae269b04eddbee2c1fca9a8d65f
+      - 5ac902a0a380461a92a195fb9df048cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cabe9cf977bf4ef58294651c7d31999b
+      - 16c48272efbd470c8a0cdf79a9dbe174
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:24 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,94 +3208,94 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6fd7fa57b54a4d4cbe376e22ad825333
+      - a9eed5f5cfb34edebc8fb5622e028a88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M4ZGQwMzNjLWExNWMtNGM2
-        Zi1iNzIyLTFiMzExZGJjZDI5NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzOTVmMDk5LWUxYjMtNDU1
+        Ni1hMTdhLWNlZGYwNTFkOWZhZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:24 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY4NjEwOTUtYmUzNC00N2JhLTkz
-        YWMtYzljYTI3NWY2Mzk2L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzliY2EwNmU1LTRkYzkt
-        NDNjZi1hMGNkLTJjMjAwODBjOTM0OS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJl
-        ZC1hNTg0LTgxYTFkOGU0ZGFlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdk
-        ZWExNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzkwYTZjNmExLTM4NjUt
-        NDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMGI0NmU0OTAtYjM1Ny00YjRmLWIxYWQtOTg3MDNi
-        NWU3ZDEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8x
-        OWIzOTcyMy0wYjc1LTRkZmUtYWMzZi03NmZhZWJlODFmYjUvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFhNTc2NWVlLTcwNzgtNDMz
-        OC1hMDM2LWZkOTI3MzA0NTE5NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMWYyNDQ2MjEtMGNiYi00YmU4LTk2MjMtM2JkZGMzYjEw
-        ZWIxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJkNjJjZjg0LTRjNTUtNDg5NC05
-        NDRmLTg2MjczNzk3NTZkMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYx
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0MTJmLTRjMzQtNGE0Mi1hYWY2
-        LTYyOTc1NDliMDM4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzAxYmEwMzctNWY4Zi00N2JkLWE5MGEtNDU4MTFmZTNmZDgwLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83MGJkMTJiMS00
-        MDcxLTRjNTktODMxYS03YTdhMjg1YjBkM2IvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVkNzYtNDRhZC05OWFmLWIz
-        MjAzNTA0NmViZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvN2VlMTJmOWMtMTc1Zi00NDY3LWJkMjItMzU5YjA2MWI1OGE2LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84M2FlMzc4Ni02ZmZl
-        LTQ2OWUtYjM4Zi1hNTQ4ZWFlZjVmYTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2EzZTAzY2QxLTNjMzQtNGNiYi05Zjg2LWY5Mjdm
-        NmFjMWY5Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2MjE0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQz
-        NmItYmQwNy1iODQwN2EzZWY4NzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2FhZTgzMzVkLTg1ZjItNGVlMS04ODljLThiNGQyODBm
-        NWVkMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2
-        ZjcwZGEtNTlkOC00M2I3LThkYTItYzJiMTEwYTFmMWJlLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOGQ0ZTdhMS0wMzg3LTQ4YjEt
-        YTBkNi1jZjdhOThhZmRjNTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2I4ZTY0ZDRkLTIwZTAtNDdjMi05NTk2LTMzYTQzZjE0YmJi
-        NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRj
-        MWEtMGUwNy00MTZlLTg0YTctZWU0NTcyMzJiMDVkLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMWQ2OTMwYi0yNjFjLTRkZjQtOTY5
-        Yi1lMTU2MDVhZjNmMTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0OTk5ZDIxOWM0NC8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2RlNzUwNTQt
-        NDJkOS00MGVlLThlZTUtMDk1MWRmMzE3NWZhLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9jZTZmMTY5ZS1kOWZkLTRjMjQtODZjYi1j
-        MjUzYTZmZTU1MDkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2QwNmI3OTk2LTQyNWEtNGE4NS04MWJiLWEyNDZjODAwZTliOC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0
-        NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNiNy0yYTM4
-        MjZkMDFkNmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4ZjUwMmMzNDAxMi8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTVjYWUzZjMtYjJkMC00
-        MjJjLTllOTEtOGVkZDlkOWQxMTYyLyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2MtYjJjYS1kZWQzZTI3
-        ZmU2ZGEvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjp0cnVlfQ==
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGNkM2E4MmUtNjI0Yi00NjY4LWEx
+        Y2YtMzU1YWM3NmI2ODY4L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M4NzVlZTFhLTAzYjAt
+        NDAzMi05Y2FjLTZlNTMzOTZiYTRjNy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzIyNTBmMTdhLWJjMTgtNGNl
+        MS04YzZhLTA3YzRmMDY4MjU0Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy82NmYzNGYxYS0zNzA0LTQ4M2MtOGM1Ny0yM2IzOWVk
+        YTU1ZGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2E3YWZjYTk1LWIzYjYt
+        NGVjZC05YzQ2LTc3MWE0NGNkZGViOS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvMDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1
+        MjE1OGJiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
+        ZDRmNzdiMy0xNDgxLTRmNTItOWM3NS0xYmJhNzcwYjY3ZGUvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBk
+        Mi1hZjQzLTM4MDMxMzZkMTIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMGY3NTdkMjQtNjc4Mi00NTEwLTliZDctMWY0ZDg5ZjE5
+        OGNiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xMjMy
+        YzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2ZGE2OGEvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1i
+        ZjczLTc1MTgxOGZjNmYxNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgzNGQtNTdlYzRlZDlkNzlh
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zMzE5Y2Zh
+        MC1kZGZjLTQzYzAtOGE2ZS1kMWQ5OWQ0MWI2ZDgvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1
+        LTEzYTkzYjM5MmEwZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvNjkzYTRlYjItZDczOS00MDkyLTg5NmYtODM2MzBmZjNjNGZiLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4My0w
+        NjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFkZC1iNDU1LTgz
+        NGMyZjhkNTg4Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvNmViNWRlODEtZDYwNS00OTMxLThlNjQtNDZlMDFmMTUzMDAzLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3
+        LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhj
+        M2VlNzNiOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NzYyOWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84YWVmODliMC1kM2IzLTRk
+        NDItYmJlMS1mYTBkODkwMTMzNTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzhiODNhODk3LTU4NGMtNDZhMi04MjdmLThiMDdkYWU5
+        N2JhZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTJi
+        NjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgyLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5Zjkt
+        YTM2Yi04NTE4MDMzZjAzNjAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3
+        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFj
+        OWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0
+        MS1jN2JlODFmNzkyNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzL2FlMzViYWYwLTU2ZjgtNGY5YS04NGYzLTFiMzEyNTRjZWRkNy8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzkt
+        ZTA1Ni00NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1l
+        MGYzMzdmNTE3Y2QvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2QwMWMxYmUwLWJmMmEtNDIwOS1iMTgxLThkNTk5ZmQwNzkzMy8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDUwOTg5MWEtZjIy
+        Mi00OTI5LWFmMmQtYzkxMDBhNDhhNmNjLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5LTRjNTAtOWNjNy0yYzgy
+        YWU3ODc4OGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2U0OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRhODIyZDYtNGVmNC00
+        NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5
+        ODI2ZGYvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjp0cnVlfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2883,7 +3308,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2901,21 +3326,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 961b74a091784fb2b8b633394a3fa0c2
+      - ba471290d1be40f2b0ac512899d69087
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyMzMwOWFhLWQyODgtNGEz
-        Yy1hMzIzLTAxMTU0MGE4M2IxNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2MjY2MjhjLTRhZTAtNDhh
+        My1hNzMyLWJiNzNhYmFlOWFhNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c8dd033c-a15c-4c6f-b722-1b311dbcd295/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1395f099-e1b3-4556-a17a-cedf051d9faf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2936,51 +3361,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:54 GMT
+      - Fri, 29 Jul 2022 11:30:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 02f1cca38a5f4e09a99361d606d07c9e
+      - 2977f7468bd74209a6205b65acece829
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzhkZDAzM2MtYTE1
-        Yy00YzZmLWI3MjItMWIzMTFkYmNkMjk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTQuNzM3OTc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTM5NWYwOTktZTFi
+        My00NTU2LWExN2EtY2VkZjA1MWQ5ZmFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjQuMjI1MTY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmQ3ZmE1N2I1NGE0ZDRjYmUz
-        NzZlMjJhZDgyNTMzMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjU0Ljc2OTA5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NTQuODk3NjM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWVlZDVmNWNmYjM0ZWRlYmM4
+        ZmI1NjIyZTAyOGE4OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjI0LjI4NDUyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MjQuNzIyNTMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWJjYTA2ZTUtNGRj
-        OS00M2NmLWEwY2QtMmMyMDA4MGM5MzQ5LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzg3NWVlMWEtMDNi
+        MC00MDMyLTljYWMtNmU1MzM5NmJhNGM3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:54 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c8dd033c-a15c-4c6f-b722-1b311dbcd295/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1395f099-e1b3-4556-a17a-cedf051d9faf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3001,51 +3426,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e8e829a6ac5b417b97a5b11a405bd75c
+      - 3050adc708f94d068afd629e4831eea9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzhkZDAzM2MtYTE1
-        Yy00YzZmLWI3MjItMWIzMTFkYmNkMjk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTQuNzM3OTc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTM5NWYwOTktZTFi
+        My00NTU2LWExN2EtY2VkZjA1MWQ5ZmFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjQuMjI1MTY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmQ3ZmE1N2I1NGE0ZDRjYmUz
-        NzZlMjJhZDgyNTMzMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjU0Ljc2OTA5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NTQuODk3NjM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWVlZDVmNWNmYjM0ZWRlYmM4
+        ZmI1NjIyZTAyOGE4OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjI0LjI4NDUyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MjQuNzIyNTMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWJjYTA2ZTUtNGRj
-        OS00M2NmLWEwY2QtMmMyMDA4MGM5MzQ5LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzg3NWVlMWEtMDNi
+        MC00MDMyLTljYWMtNmU1MzM5NmJhNGM3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c8dd033c-a15c-4c6f-b722-1b311dbcd295/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1395f099-e1b3-4556-a17a-cedf051d9faf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3066,51 +3491,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab58465ae3d643869171227a11af095c
+      - f31f1abb579849398b98529ee6a1c2d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzhkZDAzM2MtYTE1
-        Yy00YzZmLWI3MjItMWIzMTFkYmNkMjk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTQuNzM3OTc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTM5NWYwOTktZTFi
+        My00NTU2LWExN2EtY2VkZjA1MWQ5ZmFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjQuMjI1MTY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmQ3ZmE1N2I1NGE0ZDRjYmUz
-        NzZlMjJhZDgyNTMzMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjU0Ljc2OTA5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NTQuODk3NjM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWVlZDVmNWNmYjM0ZWRlYmM4
+        ZmI1NjIyZTAyOGE4OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjI0LjI4NDUyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MjQuNzIyNTMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWJjYTA2ZTUtNGRj
-        OS00M2NmLWEwY2QtMmMyMDA4MGM5MzQ5LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzg3NWVlMWEtMDNi
+        MC00MDMyLTljYWMtNmU1MzM5NmJhNGM3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/b23309aa-d288-4a3c-a323-011540a83b17/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1395f099-e1b3-4556-a17a-cedf051d9faf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3131,55 +3556,120 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 787c3d98e920451799e4cb693a13fd11
+      - 30ba906fae504d1dbf4e8d361e4c94b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjIzMzA5YWEtZDI4
-        OC00YTNjLWEzMjMtMDExNTQwYTgzYjE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTQuNzk0NDM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTM5NWYwOTktZTFi
+        My00NTU2LWExN2EtY2VkZjA1MWQ5ZmFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjQuMjI1MTY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWVlZDVmNWNmYjM0ZWRlYmM4
+        ZmI1NjIyZTAyOGE4OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjI0LjI4NDUyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MjQuNzIyNTMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzg3NWVlMWEtMDNi
+        MC00MDMyLTljYWMtNmU1MzM5NmJhNGM3LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:25 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b626628c-4ae0-48a3-a732-bb73abae9aa5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fb797b896ba046d780ea610d2af7de81
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjYyNjYyOGMtNGFl
+        MC00OGEzLWE3MzItYmI3M2FiYWU5YWE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjQuMzQ5MzI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiOTYxYjc0YTA5MTc4NGZiMmI4YjYzMzM5NGEz
-        ZmEwYzIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDo1NC45Mjc1
-        MzNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjU1LjEzMjE5
-        OFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvM2ZhNmQwODItOTY4My00ZWZmLWFhNmQtMWVkMzQ1MTA3MmU1LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiYmE0NzEyOTBkMWJlNDBmMmIwYWM1MTI4OTlk
+        NjkwODciLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMDoyNC43Nzkx
+        NTFaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjI1LjQ0NzQx
+        MloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWJjYTA2
-        ZTUtNGRjOS00M2NmLWEwY2QtMmMyMDA4MGM5MzQ5L3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzg3NWVl
+        MWEtMDNiMC00MDMyLTljYWMtNmU1MzM5NmJhNGM3L3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzliY2EwNmU1LTRkYzktNDNjZi1hMGNkLTJj
-        MjAwODBjOTM0OS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2VmODYxMDk1LWJlMzQtNDdiYS05M2FjLWM5Y2EyNzVmNjM5
-        Ni8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2M4NzVlZTFhLTAzYjAtNDAzMi05Y2FjLTZl
+        NTMzOTZiYTRjNy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzhjZDNhODJlLTYyNGItNDY2OC1hMWNmLTM1NWFjNzZiNjg2
+        OC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3187,7 +3677,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3200,101 +3690,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 139072548dbb4615b5ef25c0cf3a97f6
+      - 31f0d618be6c426ea34a6830493fa03c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3302,7 +3792,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3315,7 +3805,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3333,21 +3823,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9f36bdd01dd443c6b0df43d7e4de6b76
+      - 6c4144c887d64df2a577c34a5983f459
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3355,7 +3845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3368,37 +3858,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c8e3c468ecf4472b34083a0e347c0e5
+      - 0a4952cfb5f144088c896af11a3f1344
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3414,8 +3904,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3443,8 +3933,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3472,8 +3962,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3491,10 +3981,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3502,7 +3992,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3515,7 +4005,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3533,21 +4023,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 06b2957db87c4505b57b4a451b6dda17
+      - 4028c478034b429490df0351e9bc248a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3555,7 +4045,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3568,7 +4058,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3586,21 +4076,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e0a80ea062894df2896fe4e047ba1aee
+      - 37ae19e297d043ffb2b6dedde8dbb8fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3608,7 +4098,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3621,7 +4111,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3639,21 +4129,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c633b351211e4940963f91126897efd8
+      - 4da6de3dc2b249b0b7d190062b5255ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3661,7 +4151,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3674,101 +4164,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 41fa03048d474fb4b02529d6c13b2b7a
+      - 6b608b49935d4d07bec61f8158b867b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3776,7 +4266,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3789,7 +4279,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3807,21 +4297,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 01c53a21e75f42b99159ff2a8501a9bb
+      - 2114b55827d444eb91e55d09b3477e67
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3829,7 +4319,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3842,37 +4332,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd186706599d4d8aa81c05c6b22fa10e
+      - 65b7cb46fc3e49bda593e43a6abe64ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3888,8 +4378,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3917,8 +4407,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3946,8 +4436,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3965,10 +4455,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3976,7 +4466,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3989,7 +4479,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4007,21 +4497,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4bcf3c1315048198bc64a6482d485e9
+      - 5989a32dee22409c85a2707fc96bd6bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4029,7 +4519,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4042,7 +4532,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4060,21 +4550,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 38103cce99a6474eb895c09c9b5e23ba
+      - 5ecf9fa6870d46f19524f745585c38e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4082,7 +4572,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4095,7 +4585,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:55 GMT
+      - Fri, 29 Jul 2022 11:30:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4113,16 +4603,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ae44eb9e687418a82ca66e2097ca8b0
+      - 49d69aeded264345a88920b5a5c5d7a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:55 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:26 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_nonmatching_package_includion_filter_copies_no_content.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_nonmatching_package_includion_filter_copies_no_content.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:56 GMT
+      - Fri, 29 Jul 2022 11:30:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5e7c9aa171a4c92999f3d50ebb5df5d
+      - c12f6664ad8844dfaf76e1bc601a1d62
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lZjg2MTA5NS1iZTM0LTQ3YmEtOTNhYy1jOWNhMjc1ZjYzOTYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo1MC4zMDcxMDJa
+        cnBtL3JwbS84Y2QzYTgyZS02MjRiLTQ2NjgtYTFjZi0zNTVhYzc2YjY4Njgv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDoxMy42NjI1OTJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lZjg2MTA5NS1iZTM0LTQ3YmEtOTNhYy1jOWNhMjc1ZjYzOTYv
+        cnBtL3JwbS84Y2QzYTgyZS02MjRiLTQ2NjgtYTFjZi0zNTVhYzc2YjY4Njgv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2VmODYx
-        MDk1LWJlMzQtNDdiYS05M2FjLWM5Y2EyNzVmNjM5Ni92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzhjZDNh
+        ODJlLTYyNGItNDY2OC1hMWNmLTM1NWFjNzZiNjg2OC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:28 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/ef861095-be34-47ba-93ac-c9ca275f6396/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/8cd3a82e-624b-4668-a1cf-355ac76b6868/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:56 GMT
+      - Fri, 29 Jul 2022 11:30:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 27fa49a1e8074deca55bc5110187098d
+      - 057abe8bdf0d4b9abd117be9d146bed0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiMjQxMWIxLWM3MGYtNDM2
-        ZC1iNjNlLWM0Y2E2OGU2YTUwNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZlMjcwMTkxLThkZWEtNDFm
+        ZS1iMDk3LWVkMjZlOWRmMjU2My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:56 GMT
+      - Fri, 29 Jul 2022 11:30:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 15a4d2f12f054d6bb11646a5d918fe1f
+      - 8db7c44a2fbb47248db68f072cfeb922
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:56 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4b2411b1-c70f-436d-b63e-c4ca68e6a506/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6e270191-8dea-41fe-b097-ed26e9df2563/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74426e0e7421401ea59d035d88c21a18
+      - '04894b77387a4297a17d1050cc7a1726'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGIyNDExYjEtYzcw
-        Zi00MzZkLWI2M2UtYzRjYTY4ZTZhNTA2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTYuODkwOTY0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmUyNzAxOTEtOGRl
+        YS00MWZlLWIwOTctZWQyNmU5ZGYyNTYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjguNjk4MjA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyN2ZhNDlhMWU4MDc0ZGVjYTU1YmM1MTEw
-        MTg3MDk4ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjU2Ljky
-        ODM0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NTcuMDUw
-        NzQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNTdhYmU4YmRmMGQ0YjlhYmQxMTdiZTlk
+        MTQ2YmVkMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjI4Ljc2
+        NTM5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MjkuMTYw
+        NjA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWY4NjEwOTUtYmUzNC00N2Jh
-        LTkzYWMtYzljYTI3NWY2Mzk2LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGNkM2E4MmUtNjI0Yi00NjY4
+        LWExY2YtMzU1YWM3NmI2ODY4LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9188460a954d4c1aba2f2cc14ab9874a
+      - 4eed744cf37340e2856053971e2372d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5457148ff3124bf89c6a5727c22a90d9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vY2NhZTNlODItODhiNi00MDk5LWIzMTItZWExMjEwMDgzYjIz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MjIuNDMxMDcz
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/ccae3e82-88b6-4099-b312-ea1210083b23/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - df370dada5a945f2b97515106fa77e6d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2ZDQyMGU5LWMyNzctNDNh
+        OS1iMWNlLTU2MDBlODk5YjNkYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b6d420e9-c277-43a9-b1ce-5600e899b3db/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4a8f77d64b104b21af435212d5764d57
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjZkNDIwZTktYzI3
+        Ny00M2E5LWIxY2UtNTYwMGU4OTliM2RiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MjkuNDQ5ODQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZjM3MGRhZGE1YTk0NWYyYjk3NTE1MTA2
+        ZmE3N2U2ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjI5LjUx
+        MTIxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MjkuNTcz
+        MDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 378cb883df774d43ba795eda41774ec5
+      - 43646f65495e4d918f3a6b4aaf8956e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b2509dd6589b415f93f4bfd4db9994fd
+      - e42fbabc3e0a463cbfc2c91254f1ebb5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 35ae0ae750fc4129a95a9528c7d791a7
+      - 58248bce19834d52894c8cafab52689d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3edb764f29e34772baf9768d0df43be3
+      - 1566094229b14f95853af0844a3f5b80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:57 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 72bc2095a3d94bd985117db7d91f4557
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:29 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/9963dcc4-962a-4541-a65a-38febbaf0d35/"
+      - "/pulp/api/v3/remotes/rpm/rpm/938727e1-cdf2-4332-ad8d-d4d836ba850f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b9b9527a06864a6390ae028ac7c1be18
+      - 0be446483de94f809197d31fa443fcd1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk5
-        NjNkY2M0LTk2MmEtNDU0MS1hNjVhLTM4ZmViYmFmMGQzNS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjU3LjUwMjMwOFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkz
+        ODcyN2UxLWNkZjItNDMzMi1hZDhkLWQ0ZDgzNmJhODUwZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjMwLjExODU0N1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjU3LjUwMjMyN1oiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjMwLjExODU3NVoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:30 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd8ad486cc4442e782af7db9b5d2c32e
+      - 9193ab07e40c4c9785ed18710b5a03a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTI0ZjI3NWQtODlhYi00MTFjLWFhNjEtYjM5ZDFlNTY0NzUxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NTcuNjE2MjE3WiIsInZl
+        cG0vZTA4ZDg3MTktNjYxNS00MDJjLTg4ZjMtNmNjMjk0ZWYxYTVkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MzAuMzE4MTA0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZTI0ZjI3NWQtODlhYi00MTFjLWFhNjEtYjM5ZDFlNTY0NzUxL3ZlcnNp
+        cG0vZTA4ZDg3MTktNjYxNS00MDJjLTg4ZjMtNmNjMjk0ZWYxYTVkL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMjRmMjc1ZC04
-        OWFiLTQxMWMtYWE2MS1iMzlkMWU1NjQ3NTEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMDhkODcxOS02
+        NjE1LTQwMmMtODhmMy02Y2MyOTRlZjFhNWQvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - face063e821c4f098b279ba0dd5706f2
+      - ffd84ae84a6342b5b3e2593fc8a03fd9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85YmNhMDZlNS00ZGM5LTQzY2YtYTBjZC0yYzIwMDgwYzkzNDkv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo1MS4xMDI4Nzda
+        cnBtL3JwbS9jODc1ZWUxYS0wM2IwLTQwMzItOWNhYy02ZTUzMzk2YmE0Yzcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDoxNS4xMzQ3NjRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85YmNhMDZlNS00ZGM5LTQzY2YtYTBjZC0yYzIwMDgwYzkzNDkv
+        cnBtL3JwbS9jODc1ZWUxYS0wM2IwLTQwMzItOWNhYy02ZTUzMzk2YmE0Yzcv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzliY2Ew
-        NmU1LTRkYzktNDNjZi1hMGNkLTJjMjAwODBjOTM0OS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M4NzVl
+        ZTFhLTAzYjAtNDAzMi05Y2FjLTZlNTMzOTZiYTRjNy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:30 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9bca06e5-4dc9-43cf-a0cd-2c20080c9349/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/c875ee1a-03b0-4032-9cac-6e53396ba4c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9bc22d719a074311937b7c6ef90b1986
+      - 2a98d7dca7c0478ab67a01ff2e9c786f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExMDVkODYzLTI1MDEtNDQy
-        OS04Y2YxLWVmY2M2OWU5ZDIwZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkYjkyYWNjLTgwNDItNDg4
+        OC1hZGZkLWRkZWNiZTVlYjcxOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a4f43c87c1c4778a649cea764efc9d7
+      - 26d49b6d9e4a4eed8176c921ab74a0ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNDFiYWZjMzQtZDM4Mi00Y2NhLWJjZTItMTE3N2M2NjUzYzViLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NTAuMTkyNzMyWiIsIm5h
+        cG0vYzNkOTM4ODYtNTNlNi00YWRjLTkyNzQtOGNiY2QyMmQ5OTlkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MTMuNDY2NTY5WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo1MS41MDA5NDRaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDoxNS43NTgyMzdaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:30 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/41bafc34-d382-4cca-bce2-1177c6653c5b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c3d93886-53e6-4adc-9274-8cbcd22d999d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:30 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2512388c4bdf4ae9acaf893225283194
+      - be641e5833f047cdb60a33b1eea179f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2OTM1ZjQzLTQ1MzUtNDg3
-        My1iZTA4LTYxMGIzYzQxNzA5OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUyOTNkY2Y3LWU5MzItNDBi
+        YS1hNGU5LWU4ZTA0YzFiM2VmOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:30 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a105d863-2501-4429-8cf1-efcc69e9d20f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/3db92acc-8042-4888-adfd-ddecbe5eb718/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f48f329e72524c8a815a3c499e724be0
+      - 68b92764275446e88fbc33868db16b74
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTEwNWQ4NjMtMjUw
-        MS00NDI5LThjZjEtZWZjYzY5ZTlkMjBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTcuNzc1OTg3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2RiOTJhY2MtODA0
+        Mi00ODg4LWFkZmQtZGRlY2JlNWViNzE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MzAuNjE1MzUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5YmMyMmQ3MTlhMDc0MzExOTM3YjdjNmVm
-        OTBiMTk4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjU3Ljgw
-        OTMxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NTcuODc0
-        MTI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyYTk4ZDdkY2E3YzA0NzhhYjY3YTAxZmYy
+        ZTljNzg2ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjMwLjY3
+        MjQxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MzEuMDQ0
+        OTcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWJjYTA2ZTUtNGRjOS00M2Nm
-        LWEwY2QtMmMyMDA4MGM5MzQ5LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzg3NWVlMWEtMDNiMC00MDMy
+        LTljYWMtNmU1MzM5NmJhNGM3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/56935f43-4535-4873-be08-610b3c417098/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5293dcf7-e932-40ba-a4e9-e8e04c1b3ef9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:57 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf066dd0e6d444acac1162a265c3e343
+      - f15794cc248f4fe6be6daa9de5e6f43d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTY5MzVmNDMtNDUz
-        NS00ODczLWJlMDgtNjEwYjNjNDE3MDk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTcuODcwNDU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTI5M2RjZjctZTkz
+        Mi00MGJhLWE0ZTktZThlMDRjMWIzZWY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MzAuODAwMjg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyNTEyMzg4YzRiZGY0YWU5YWNhZjg5MzIy
-        NTI4MzE5NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjU3Ljkw
-        MzcyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NTcuOTQ4
-        ODU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZTY0MWU1ODMzZjA0N2NkYjYwYTMzYjFl
+        ZWExNzlmMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjMwLjky
+        NzI5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MzEuMjE3
+        MzQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQxYmFmYzM0LWQzODItNGNjYS1iY2Uy
-        LTExNzdjNjY1M2M1Yi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MzZDkzODg2LTUzZTYtNGFkYy05Mjc0
+        LThjYmNkMjJkOTk5ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:57 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf22ab3bc0b24f6f82e74bdd72a5a1ac
+      - 1c55574d2acb4cc0ab04bfd5c6873ced
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eae87a67d54948a98f0dc8a315751bdb
+      - d30a523e3ce64adcb2329ea260fea7ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f323b493d5b54771b54f54521bc547dc
+      - 72b613e5b8784f19a5164eee659ee45c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8426e64eccb64d8aa33147e1ecdb26d1
+      - 997794e170f4425bb9e58225ed328f4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a983a6ac928240c29f24146f6fb98adf
+      - 64400fec924a4cabad51070b1dc8e4df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 59033aa46920480d847d4c3a1296e6a4
+      - 616ef3b0a1af4fbeb4d98222c18d1e64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/"
+      - "/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 404c04cd5cbe458eb164327b9e7a675e
+      - '033838667a0e4b23bf40d4e5a36380ef'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDc4Mjc0ZjctOWE1Yi00YTM5LWI2ZWUtODU1MWI5NzhlZGUzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NTguMzUwMzM3WiIsInZl
+        cG0vZGYyMTRiYzAtM2Y1NS00NDE3LTkyZjQtZThhNGJhMThkZWY2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MzEuODcyNzUwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDc4Mjc0ZjctOWE1Yi00YTM5LWI2ZWUtODU1MWI5NzhlZGUzL3ZlcnNp
+        cG0vZGYyMTRiYzAtM2Y1NS00NDE3LTkyZjQtZThhNGJhMThkZWY2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80NzgyNzRmNy05
-        YTViLTRhMzktYjZlZS04NTUxYjk3OGVkZTMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZjIxNGJjMC0z
+        ZjU1LTQ0MTctOTJmNC1lOGE0YmExOGRlZjYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:31 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/9963dcc4-962a-4541-a65a-38febbaf0d35/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/938727e1-cdf2-4332-ad8d-d4d836ba850f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b2d5ef7eff94180a8b9ab9e56c4d8e8
+      - 27f518337e71470e95f2f4bf638d9853
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3NjU0NjkzLTg3M2UtNDRj
-        NS05NTEyLWRiYzRkMjU1ODgyNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlZGRjOGZiLTlkNGYtNDQ2
+        Ni1hNGMxLTQwNTI4ZWVlMDA5NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d7654693-873e-44c5-9512-dbc4d2558824/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/eeddc8fb-9d4f-4466-a4c1-40528eee0095/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2092ce21738f44e5873a043b6972212f
+      - 1958e6a6901641ce97c82c13c35d415e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDc2NTQ2OTMtODcz
-        ZS00NGM1LTk1MTItZGJjNGQyNTU4ODI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTguNjc2Nzk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWVkZGM4ZmItOWQ0
+        Zi00NDY2LWE0YzEtNDA1MjhlZWUwMDk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MzIuMzI0MTY3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI2YjJkNWVmN2VmZjk0MTgwYThiOWFiOWU1
-        NmM0ZDhlOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjU4Ljcx
-        MDM5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NTguNzQw
-        MTkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyN2Y1MTgzMzdlNzE0NzBlOTVmMmY0YmY2
+        MzhkOTg1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjMyLjM4
+        MjM3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MzIuNDE5
+        MTg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk5NjNkY2M0LTk2MmEtNDU0MS1hNjVh
-        LTM4ZmViYmFmMGQzNS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkzODcyN2UxLWNkZjItNDMzMi1hZDhk
+        LWQ0ZDgzNmJhODUwZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk5NjNk
-        Y2M0LTk2MmEtNDU0MS1hNjVhLTM4ZmViYmFmMGQzNS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkzODcy
+        N2UxLWNkZjItNDMzMi1hZDhkLWQ0ZDgzNmJhODUwZi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:58 GMT
+      - Fri, 29 Jul 2022 11:30:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e4aa49d8cb2b445cb6c5978e2866cc69
+      - ca2b1210ce8b4a83a1db2810f5c0e9f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkYjAxMjBlLTM0NzUtNDQ2
-        MS1hYTJiLWRjNzg4YjM0NGY3ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyNzQ5YWNkLTc3MTMtNDg0
+        Yy05MTc0LTc2YTdlYWM2MDRmNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:58 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/edb0120e-3475-4461-aa2b-dc788b344f7d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e2749acd-7713-484c-9174-76a7eac604f7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:00 GMT
+      - Fri, 29 Jul 2022 11:30:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4c3944e80bbc426f8d1805eada3a63bd
+      - 309362705a11410699ddf9d1ba654f9b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '603'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWRiMDEyMGUtMzQ3
-        NS00NDYxLWFhMmItZGM3ODhiMzQ0ZjdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NTguODcyMTQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTI3NDlhY2QtNzcx
+        My00ODRjLTkxNzQtNzZhN2VhYzYwNGY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MzIuNTQ0ODcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJlNGFhNDlkOGNiMmI0NDVjYjZj
-        NTk3OGUyODY2Y2M2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjU4LjkwMzY2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MDAuNTE0NjU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJjYTJiMTIxMGNlOGI0YTgzYTFk
+        YjI4MTBmNWMwZTlmOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjMyLjYwMTAyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MzcuNDY4NzM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZTI0ZjI3NWQtODlhYi00MTFjLWFhNjEt
-        YjM5ZDFlNTY0NzUxL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2UyNGYyNzVkLTg5YWItNDExYy1hYTYxLWIzOWQxZTU2NDc1MS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS85OTYzZGNjNC05NjJh
-        LTQ1NDEtYTY1YS0zOGZlYmJhZjBkMzUvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2UwOGQ4NzE5LTY2MTUtNDAyYy04OGYzLTZj
+        YzI5NGVmMWE1ZC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9l
+        MDhkODcxOS02NjE1LTQwMmMtODhmMy02Y2MyOTRlZjFhNWQvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vOTM4NzI3ZTEtY2RmMi00
+        MzMyLWFkOGQtZDRkODM2YmE4NTBmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:37 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZTI0ZjI3NWQtODlhYi00MTFjLWFhNjEtYjM5ZDFlNTY0
-        NzUxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZTA4ZDg3MTktNjYxNS00MDJjLTg4ZjMtNmNjMjk0ZWYx
+        YTVkL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:00 GMT
+      - Fri, 29 Jul 2022 11:30:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 11fb9c92f93f4b2b862e5b918c5a9132
+      - fda570f38cb34c97b9173db37f5a04bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJlNmY1NmEwLWU2MjgtNDQy
-        Ny05NDc2LWIzNDIzMjQ0ZWFkZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3MjA5OWIwLTljMDMtNGMw
+        Yy1hOTk0LTU4OTA2OTBmMmUwZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:00 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2e6f56a0-e628-4427-9476-b3423244eadf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/372099b0-9c03-4c0c-a994-5890690f2e0f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:01 GMT
+      - Fri, 29 Jul 2022 11:30:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46fb312300204614805a5bc2f443f759
+      - 5299d5acd1aa492ba6204b2450528b4a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmU2ZjU2YTAtZTYy
-        OC00NDI3LTk0NzYtYjM0MjMyNDRlYWRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDAuNzIwOTM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzcyMDk5YjAtOWMw
+        My00YzBjLWE5OTQtNTg5MDY5MGYyZTBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MzcuODgwMDk2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjExZmI5YzkyZjkzZjRiMmI4NjJlNWI5MThj
-        NWE5MTMyIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MDAuNzU5
-        NzQyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNTowMC45NDIx
-        MjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImZkYTU3MGYzOGNiMzRjOTdiOTE3M2RiMzdm
+        NWEwNGJmIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MzcuOTUx
+        NzM3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMDozOC41MTEy
+        MThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYjNiYzE2
-        NGItZmRmNi00YzllLWJhZTAtNjdhMDM1ZjQxMWMwLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYjcxMzFj
+        MmQtYzU1My00ZDA2LWJlYjctMTQxMWM2NWRjODQ2LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZTI0ZjI3NWQtODlhYi00MTFjLWFhNjEtYjM5ZDFl
-        NTY0NzUxLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZTA4ZDg3MTktNjYxNS00MDJjLTg4ZjMtNmNjMjk0
+        ZWYxYTVkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 62658f9e07cf49d0a93e6abccc55f10d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:01 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:01 GMT
+      - Fri, 29 Jul 2022 11:30:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95d18f3c2f4844f7a873058d3cef75b4
+      - 17669c4f5c214516a22235ec1f15713d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/b7131c2d-c553-4d06-beb7-1411c65dc846/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:01 GMT
+      - Fri, 29 Jul 2022 11:30:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53d79d9252e0404c9f644b1c5782f262
+      - 34922fbe2d3d421c969d732b085d1223
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYjcxMzFjMmQtYzU1My00ZDA2LWJlYjctMTQxMWM2NWRjODQ2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MzcuOTgyMDc5WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMDhkODcxOS02NjE1LTQwMmMtODhmMy02Y2MyOTRlZjFhNWQv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2UwOGQ4NzE5LTY2MTUtNDAyYy04OGYzLTZjYzI5
+        NGVmMWE1ZC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:38 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9iNzEzMWMyZC1jNTUzLTRkMDYtYmViNy0xNDExYzY1ZGM4NDYv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c7716b0ed5694436aa6f01bcee83a4b2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlMDdiZjMzLTg1NzYtNDE4
+        NC1hZDk0LTk4NDFiODU5NDVmYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ee07bf33-8576-4184-ad94-9841b85945fa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6cf817874e39455694ed407fc662f1ea
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWUwN2JmMzMtODU3
+        Ni00MTg0LWFkOTQtOTg0MWI4NTk0NWZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MzguODQzMjgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJjNzcxNmIwZWQ1Njk0NDM2YWE2ZjAxYmNl
+        ZTgzYTRiMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjM4Ljky
+        NDc5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MzkuMzY4
+        NDQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vN2Ji
+        OWRmNTUtMjFhZi00MTgxLTlkMWMtNDM1YmE0MTA5ODcxLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/7bb9df55-21af-4181-9d1c-435ba4109871/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 014be80e5282406fa636d960960ce1d9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzdiYjlkZjU1LTIxYWYtNDE4MS05ZDFjLTQzNWJhNDEwOTg3MS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjM5LjMzODIwNVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYjcxMzFjMmQtYzU1My00ZDA2LWJlYjct
+        MTQxMWM2NWRjODQ2LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0a2d19e6753542c5b5ca99ba436cd49b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7e66933871174879962d1d4bdf804904
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7646d682709e49d6a8ddac042f7f9a56
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:01 GMT
+      - Fri, 29 Jul 2022 11:30:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 69da21b961fd40758fd5737ffc1b22b4
+      - 70641c46da4e41ec9e7e7692b19cd72e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:01 GMT
+      - Fri, 29 Jul 2022 11:30:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c87fd50a810a411588c57deca47ba500
+      - 0d800be2410049b68e4b1f8a82a92b05
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:01 GMT
+      - Fri, 29 Jul 2022 11:30:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49b7e9bce1b141f28917698b9c803c76
+      - a62931d93250427aa098fa11d1cd9f44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:40 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2540,7 +2965,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2553,7 +2978,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:01 GMT
+      - Fri, 29 Jul 2022 11:30:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2571,21 +2996,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6034b80a46c64897b674a61cf412064d
+      - b2e5f6093c8a47759d0ff7f5e544cf64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE3ZWY3NDZhLTUxMzktNDJh
-        ZS1hNzFlLTg2ZjgyOGJiMmFmMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1NTQ0OTViLWZhNzgtNDlm
+        Zi1hYWY3LWRiM2QzMjZiNDhlNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:01 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/17ef746a-5139-42ae-a71e-86f828bb2af0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9554495b-fa78-49ff-aaf7-db3d326b48e4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2606,51 +3031,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:02 GMT
+      - Fri, 29 Jul 2022 11:30:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8f56315b18b54e9185370765a0521453
+      - 5fa3797e34c7429f946ba3c671bc9b63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdlZjc0NmEtNTEz
-        OS00MmFlLWE3MWUtODZmODI4YmIyYWYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDEuODYzMTE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTU1NDQ5NWItZmE3
+        OC00OWZmLWFhZjctZGIzZDMyNmI0OGU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NDAuOTYzODQ4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2MDM0YjgwYTQ2YzY0ODk3YjY3
-        NGE2MWNmNDEyMDY0ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjAxLjg5MzcwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MDIuMDI2MjAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiMmU1ZjYwOTNjOGE0Nzc1OWQw
+        ZmY3ZjVlNTQ0Y2Y2NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjQxLjA1MTAwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        NDEuNjA1NzQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDc4Mjc0ZjctOWE1
-        Yi00YTM5LWI2ZWUtODU1MWI5NzhlZGUzLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGYyMTRiYzAtM2Y1
+        NS00NDE3LTkyZjQtZThhNGJhMThkZWY2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2658,7 +3083,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2671,40 +3096,40 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:02 GMT
+      - Fri, 29 Jul 2022 11:30:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '621'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b1c11a1484af476fa5b27df3b7d483e9
+      - 0700740b1ebd4e6c91648fc812de071c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '283'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDc4Mjc0ZjctOWE1Yi00YTM5LWI2ZWUtODU1MWI5NzhlZGUzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NTguMzUwMzM3WiIsInZl
+        cG0vZGYyMTRiYzAtM2Y1NS00NDE3LTkyZjQtZThhNGJhMThkZWY2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MzEuODcyNzUwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDc4Mjc0ZjctOWE1Yi00YTM5LWI2ZWUtODU1MWI5NzhlZGUzL3ZlcnNp
+        cG0vZGYyMTRiYzAtM2Y1NS00NDE3LTkyZjQtZThhNGJhMThkZWY2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80NzgyNzRmNy05
-        YTViLTRhMzktYjZlZS04NTUxYjk3OGVkZTMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZjIxNGJjMC0z
+        ZjU1LTQ0MTctOTJmNC1lOGE0YmExOGRlZjYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -2712,10 +3137,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2723,7 +3148,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2736,7 +3161,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:02 GMT
+      - Fri, 29 Jul 2022 11:30:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2754,21 +3179,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c6203e939e74363b1b68002b64cae8f
+      - 005b570dd2714dd99d89d2365abfc385
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2776,7 +3201,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2789,7 +3214,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:02 GMT
+      - Fri, 29 Jul 2022 11:30:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2807,21 +3232,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6648729972f34d87aec8b23d5ece7179
+      - 1181852a74304ed5998d383ada925a18
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2829,7 +3254,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2842,7 +3267,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:02 GMT
+      - Fri, 29 Jul 2022 11:30:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2860,21 +3285,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ca652088872c44689d3a7f959214877d
+      - d6f9c19743824adca99adc21f07f382b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2882,7 +3307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2895,7 +3320,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:02 GMT
+      - Fri, 29 Jul 2022 11:30:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2913,21 +3338,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ada044e29fe14b3bb6a61142404458db
+      - 99cdd25538d949c98744c288c40c3584
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2935,7 +3360,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2948,7 +3373,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:02 GMT
+      - Fri, 29 Jul 2022 11:30:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2966,21 +3391,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c92c32933a3e4f06aa667daae1a55acb
+      - b32f582ff30e4d6fb4345e3356966d99
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/versions/0/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2988,7 +3413,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3001,7 +3426,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:02 GMT
+      - Fri, 29 Jul 2022 11:30:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3019,16 +3444,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 153260c05118485d975127dbc04758a4
+      - 5d2f3e461047470dafab026cdd8583b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:02 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:42 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_all_duplicate_content_with_dep_solving.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_all_duplicate_content_with_dep_solving.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 505b4bf9f60745cf962dcf81054b9dff
+      - 7aab42fee4614656b5be5f7edcbc244f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81Y2QxNTkyOC1hYmI1LTQ3ZjItYjM1MS1mZGE4ZWQxYjQ2ZjEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNToxMS4xOTc2NDha
+        cnBtL3JwbS82MGM0NWQ4Zi03MGFjLTRlMmUtYjQxYS03YTdhNDQwN2MzZDkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyODo1My43MjAyMDZa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81Y2QxNTkyOC1hYmI1LTQ3ZjItYjM1MS1mZGE4ZWQxYjQ2ZjEv
+        cnBtL3JwbS82MGM0NWQ4Zi03MGFjLTRlMmUtYjQxYS03YTdhNDQwN2MzZDkv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzVjZDE1
-        OTI4LWFiYjUtNDdmMi1iMzUxLWZkYThlZDFiNDZmMS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzYwYzQ1
+        ZDhmLTcwYWMtNGUyZS1iNDFhLTdhN2E0NDA3YzNkOS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:07 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31526791ff11461ca781a6febcc9a86d
+      - 2286f5deab5e474f91687adf0e604219
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlZjg1NDEyLWIwMzAtNDgw
-        Ni05MWRmLWIzZGFiY2YwMWI4ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzZWNiOTNhLTNjYmQtNDFk
+        Ni05Njc4LWMzNjMzM2E3NGZmNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 211081a2d0564e589eea036b73478078
+      - c5e416674a8d4337a8faab511130d1f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fef85412-b030-4806-91df-b3dabcf01b8e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b3ecb93a-3cbd-41d6-9678-c36333a74ff7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a1407090167a427ebdac183ecc7262ab
+      - 951232c6070940ff8e8509d7bf8107e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmVmODU0MTItYjAz
-        MC00ODA2LTkxZGYtYjNkYWJjZjAxYjhlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTkuMzExNzg5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjNlY2I5M2EtM2Ni
+        ZC00MWQ2LTk2NzgtYzM2MzMzYTc0ZmY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDcuOTc5NzAwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzMTUyNjc5MWZmMTE0NjFjYTc4MWE2ZmVi
-        Y2M5YTg2ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjE5LjM0
-        NTk0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MTkuNDcx
-        NDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMjg2ZjVkZWFiNWU0NzRmOTE2ODdhZGYw
+        ZTYwNDIxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjA4LjA0
+        NjE0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MDguMzA2
+        MzY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWNkMTU5MjgtYWJiNS00N2Yy
-        LWIzNTEtZmRhOGVkMWI0NmYxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjBjNDVkOGYtNzBhYy00ZTJl
+        LWI0MWEtN2E3YTQ0MDdjM2Q5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4429be39de9e45bea6e2ece32f48659a
+      - f507966f8e15419d8dad9ed096b44a0a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 48dbfdcc55024a3d99d7cf486c2f41c8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vYjZkZWVmZjYtOGNiOC00Y2UyLTliY2YtM2M4ZjkxNzQyODhj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MDEuNzY3ODMw
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/b6deeff6-8cb8-4ce2-9bcf-3c8f9174288c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d239f720de3f409894dc52b36abb3ed7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQxM2MzZDAwLTAxMTktNGZi
+        YS1iNmUxLTkyNjUyZTcwMDBmOS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/413c3d00-0119-4fba-b6e1-92652e7000f9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 760f7dbbc70c43a7b9b95d922cf4019b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDEzYzNkMDAtMDEx
+        OS00ZmJhLWI2ZTEtOTI2NTJlNzAwMGY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDguNDk3OTkzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkMjM5ZjcyMGRlM2Y0MDk4OTRkYzUyYjM2
+        YWJiM2VkNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjA4LjU0
+        NDgyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MDguNTky
+        MDk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dda02ce622004ba4895c3656afe5ff8a
+      - cccd81d68a5d4b649086a833e16dc996
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f997619adf2d4b89a4b3e2fd2e004149
+      - 8aa9e2d91a184134a6b3b5121556dbe5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd3b8cb6ca664b889ac42d6b05e30274
+      - 9bdc929975b44dc995423e744b4352a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0cbd90094fca4d29b97afd7754f07d85
+      - 771bc208f0344bc8b3218a77959031c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:19 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 9f6abce305124e56a03024f1c1af6bf4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:19 GMT
+      - Fri, 29 Jul 2022 11:29:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/bf8edf11-b43f-45d7-81fe-07e8908286c7/"
+      - "/pulp/api/v3/remotes/rpm/rpm/7644d956-964f-4486-8d26-68731d6cecc7/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9da02ef4bbcd49fdb3729d90ea19e39d
+      - c01f53fc70b14ae599d2763455937693
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Jm
-        OGVkZjExLWI0M2YtNDVkNy04MWZlLTA3ZTg5MDgyODZjNy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjE5Ljk1MzY2NVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc2
+        NDRkOTU2LTk2NGYtNDQ4Ni04ZDI2LTY4NzMxZDZjZWNjNy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjA4Ljk3ODk4NFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjE5Ljk1MzY4NFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjA4Ljk3OTAwOVoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:19 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:08 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/"
+      - "/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4fe796d2f1464b3d9d7d462c1e125d49
+      - e6a33038b12546458eb438e417fd7567
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMmU2Zjc1YjktYjM4NS00YWY0LTg2MDctZjRkMmQ0YTk0N2MzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MjAuMTQzMTE0WiIsInZl
+        cG0vM2I2YmI4YTYtODdiNS00OGM4LWE1MDctMWNmODNhYjFhM2Y0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MDkuMTg2MDU3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMmU2Zjc1YjktYjM4NS00YWY0LTg2MDctZjRkMmQ0YTk0N2MzL3ZlcnNp
+        cG0vM2I2YmI4YTYtODdiNS00OGM4LWE1MDctMWNmODNhYjFhM2Y0L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yZTZmNzViOS1i
-        Mzg1LTRhZjQtODYwNy1mNGQyZDRhOTQ3YzMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zYjZiYjhhNi04
+        N2I1LTQ4YzgtYTUwNy0xY2Y4M2FiMWEzZjQvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a31b6ed811484da68d24505a7be96c3e
+      - 30afed3cdc7a4b40a8c214875e6b135f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '308'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hMGM1YWYyZi1lY2VlLTQ2MTQtYjdmMy0wYWQwMjRkZmFkNTEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNToxMS45ODQ0MDda
+        cnBtL3JwbS9iMjczYWRmMi03ODk1LTQ0ZDYtOTQxNS1kNDM2ZGI3YmMyNDQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyODo1NC44Nzk5Nzla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hMGM1YWYyZi1lY2VlLTQ2MTQtYjdmMy0wYWQwMjRkZmFkNTEv
+        cnBtL3JwbS9iMjczYWRmMi03ODk1LTQ0ZDYtOTQxNS1kNDM2ZGI3YmMyNDQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2EwYzVh
-        ZjJmLWVjZWUtNDYxNC1iN2YzLTBhZDAyNGRmYWQ1MS92ZXJzaW9ucy8zLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IyNzNh
+        ZGYyLTc4OTUtNDRkNi05NDE1LWQ0MzZkYjdiYzI0NC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8e2fec30455648da88f9ebc5763b16c5
+      - 6d7e2696ac05443d93adca53045591d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M0Mzg3MTVkLTY1MTQtNDkw
-        Yy1hM2I5LWFjNjg2NjFiNDkyNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzNDBlMDRlLTQ4M2ItNGE2
+        Ny04YmZhLWVlZWQ3NzBjODAxNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '608'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a5199e7904547aabb7ad4545bc8d304
+      - 771d16fb535a490cbd0a9212eecbab5d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYjY4NTFiNjgtMjQ0OC00MjIxLThjOWMtZGQ5Njc5MjgzYmI4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MTEuMDg0MjI0WiIsIm5h
-        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
-        ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
-        bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
-        cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNToxMi4zMjM3NjlaIiwiZG93bmxv
-        YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
-        Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
-        Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
-        InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
-        dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+        cG0vYjNmNWMyMDktNDU2MC00ZmM4LTgxM2MtZjY4MmUxOTI2ZTk1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6NTMuNTM4MDU2WiIsIm5h
+        bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5v
+        cmcvc3JwbS11bnNpZ25lZC8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2Vy
+        dCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjIt
+        MDctMjlUMTE6Mjg6NTUuNDE4MDIwWiIsImRvd25sb2FkX2NvbmN1cnJlbmN5
+        IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRl
+        IiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYw
+        LjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGlt
+        ZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJz
+        bGVzX2F1dGhfdG9rZW4iOm51bGx9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/b6851b68-2448-4221-8c9c-dd9679283bb8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b3f5c209-4560-4fc8-813c-f682e1926e95/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c0f51af3ebd4215b3fc80a288e7e0f7
+      - ab91864cc2eb4be199189540c5fa6eaf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0NmUxMGVjLTE1ODMtNDc0
-        Yi1iZGJiLTU4ZGI2MGVjMTZhNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4NWIyOWU1LTc0MjktNDYz
+        OS1iMjY3LTkyODUzODg1MjNiNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c438715d-6514-490c-a3b9-ac68661b4927/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/6340e04e-483b-4a67-8bfa-eeed770c8017/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc1b826bf51c4b67b887c23650aa882e
+      - 774e2285f4c042c0aea03137dad06c74
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzQzODcxNWQtNjUx
-        NC00OTBjLWEzYjktYWM2ODY2MWI0OTI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjAuMzU5MDk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjM0MGUwNGUtNDgz
+        Yi00YTY3LThiZmEtZWVlZDc3MGM4MDE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDkuNDc5NjI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4ZTJmZWMzMDQ1NTY0OGRhODhmOWViYzU3
-        NjNiMTZjNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjIwLjM5
-        MTE0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MjAuNDUy
-        MDQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZDdlMjY5NmFjMDU0NDNkOTNhZGNhNTMw
+        NDU1OTFkNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjA5LjUy
+        NjYyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MDkuNjUw
+        MjM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBjNWFmMmYtZWNlZS00NjE0
-        LWI3ZjMtMGFkMDI0ZGZhZDUxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjI3M2FkZjItNzg5NS00NGQ2
+        LTk0MTUtZDQzNmRiN2JjMjQ0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/946e10ec-1583-474b-bdbb-58db60ec16a5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d85b29e5-7429-4639-b267-9285388523b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d438ab7dcc34f94bbfbd33e8d0a04fa
+      - ac8d9910b8d040968b643aac224b3eb6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQ2ZTEwZWMtMTU4
-        My00NzRiLWJkYmItNThkYjYwZWMxNmE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjAuNDUxMTc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDg1YjI5ZTUtNzQy
+        OS00NjM5LWIyNjctOTI4NTM4ODUyM2I1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDkuNjQ0NzI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwYzBmNTFhZjNlYmQ0MjE1YjNmYzgwYTI4
-        OGU3ZTBmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjIwLjQ4
-        NTQ0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MjAuNTMw
-        Nzc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhYjkxODY0Y2MyZWI0YmUxOTkxODk1NDBj
+        NWZhNmVhZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjA5LjY5
+        Nzg2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MDkuNzY5
+        Mjg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I2ODUxYjY4LTI0NDgtNDIyMS04Yzlj
-        LWRkOTY3OTI4M2JiOC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IzZjVjMjA5LTQ1NjAtNGZjOC04MTNj
+        LWY2ODJlMTkyNmU5NS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c39c4e6b3ba4dcd96973cd1e6287fa8
+      - ea29f2b102c54f238131d506c227c46a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74e4228e5c4f48fc854fc9cea46813bc
+      - cd21280373e746fd868ab584a7493dd1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5e89c889a8240c2b3633c3d1b51cee0
+      - ce2236c8d16a426195a3f595686c01da
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e6d1290dda749f9879d6ab06a22a0c6
+      - fdaf8cf1a95f4a7298247815f997b8d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8a4f51376daa42b1a874fee150379f8a
+      - 06b18c528e3a492eac48c53b05f75da9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ca63d9df17b441aa7b6703dcb42d693
+      - a8b9ed19f067407d9b2c2c582c53753a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:10 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:20 GMT
+      - Fri, 29 Jul 2022 11:29:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/"
+      - "/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cde691c0fb354e34b941142ad0adc81a
+      - 6441039c591b431584c8a4b423659157
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzhiY2YyZWUtMmZkYi00NDJiLTk3MjctMzY1YWE4NmVkYjA3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MjAuOTQyMjg3WiIsInZl
+        cG0vMmIzYTc4ZTktZGU2Ny00MTMzLTk2MzgtOWE3Yjg3MWQ5ZTZjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MTAuMzk1NzE0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzhiY2YyZWUtMmZkYi00NDJiLTk3MjctMzY1YWE4NmVkYjA3L3ZlcnNp
+        cG0vMmIzYTc4ZTktZGU2Ny00MTMzLTk2MzgtOWE3Yjg3MWQ5ZTZjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83OGJjZjJlZS0y
-        ZmRiLTQ0MmItOTcyNy0zNjVhYTg2ZWRiMDcvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yYjNhNzhlOS1k
+        ZTY3LTQxMzMtOTYzOC05YTdiODcxZDllNmMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:10 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/bf8edf11-b43f-45d7-81fe-07e8908286c7/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/7644d956-964f-4486-8d26-68731d6cecc7/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:21 GMT
+      - Fri, 29 Jul 2022 11:29:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7337d5ccec5c425abb9adbf85d5b8779
+      - 3f4d8c7b46d74a4aa666983f994e2039
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3MzI1OWRkLTNlYjgtNDg1
-        Ny05MmFmLTZhN2IzN2M3MDRiYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2NTAyYjEzLTc0Y2UtNGQ4
+        Ny04NzhjLWUwZjMyMmUxOWYwZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/473259dd-3eb8-4857-92af-6a7b37c704ba/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c6502b13-74ce-4d87-878c-e0f322e19f0e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:21 GMT
+      - Fri, 29 Jul 2022 11:29:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c75b4191824a455080dd79d70027db94
+      - b4d792ec033c4bcca3a0a6abfc1ecbfa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDczMjU5ZGQtM2Vi
-        OC00ODU3LTkyYWYtNmE3YjM3YzcwNGJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjEuMzkwMzY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzY1MDJiMTMtNzRj
+        ZS00ZDg3LTg3OGMtZTBmMzIyZTE5ZjBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTAuODMyNTg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI3MzM3ZDVjY2VjNWM0MjVhYmI5YWRiZjg1
-        ZDViODc3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjIxLjQz
-        NDM3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MjEuNDYx
-        NTA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzZjRkOGM3YjQ2ZDc0YTRhYTY2Njk4M2Y5
+        OTRlMjAzOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjEwLjkw
+        ODcwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MTAuOTM5
+        MDM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JmOGVkZjExLWI0M2YtNDVkNy04MWZl
-        LTA3ZTg5MDgyODZjNy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc2NDRkOTU2LTk2NGYtNDQ4Ni04ZDI2
+        LTY4NzMxZDZjZWNjNy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JmOGVk
-        ZjExLWI0M2YtNDVkNy04MWZlLTA3ZTg5MDgyODZjNy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc2NDRk
+        OTU2LTk2NGYtNDQ4Ni04ZDI2LTY4NzMxZDZjZWNjNy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:21 GMT
+      - Fri, 29 Jul 2022 11:29:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a6f2acda5424547902ebd7286262761
+      - 1af7a0ec49e6400dbf72ddab82b67b98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAyY2RiZDk0LWQyMDItNGVh
-        Yy1iZjdlLTQ0Yzk0MDJjYzEwNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2ZmUwYmRkLTA1OWYtNDhk
+        Yi05ZTQxLTdmNjdhMDVlMDA1OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/02cdbd94-d202-4eac-bf7e-44c9402cc104/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e6fe0bdd-059f-48db-9e41-7f67a05e0059/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,82 +1787,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:23 GMT
+      - Fri, 29 Jul 2022 11:29:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4176d795924b481f880ce2dc7da5ec1a
+      - 748a1c75044f4d59b5ead493f2a37eb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '596'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDJjZGJkOTQtZDIw
-        Mi00ZWFjLWJmN2UtNDRjOTQwMmNjMTA0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjEuNTc4Mzg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTZmZTBiZGQtMDU5
+        Zi00OGRiLTllNDEtN2Y2N2EwNWUwMDU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTEuMTI4MzQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwYTZmMmFjZGE1NDI0NTQ3OTAy
-        ZWJkNzI4NjI2Mjc2MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjIxLjYxMDYxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MjMuMTk2NDU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxYWY3YTBlYzQ5ZTY0MDBkYmY3
+        MmRkYWI4MmI2N2I5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjExLjE3NDY5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MTUuNDg3NzkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
         IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBh
-        Y2thZ2VzIiwiY29kZSI6InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRl
-        IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgi
-        Om51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5hZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
-        OiJVbi1Bc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRp
-        bmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
         ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
         bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMmU2Zjc1YjktYjM4NS00YWY0LTg2MDct
-        ZjRkMmQ0YTk0N2MzL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzJlNmY3NWI5LWIzODUtNGFmNC04NjA3LWY0ZDJkNGE5NDdjMy8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9iZjhlZGYxMS1iNDNm
-        LTQ1ZDctODFmZS0wN2U4OTA4Mjg2YzcvIl19
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzNiNmJiOGE2LTg3YjUtNDhjOC1hNTA3LTFj
+        ZjgzYWIxYTNmNC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8z
+        YjZiYjhhNi04N2I1LTQ4YzgtYTUwNy0xY2Y4M2FiMWEzZjQvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNzY0NGQ5NTYtOTY0Zi00
+        NDg2LThkMjYtNjg3MzFkNmNlY2M3LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:15 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMmU2Zjc1YjktYjM4NS00YWY0LTg2MDctZjRkMmQ0YTk0
-        N2MzL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vM2I2YmI4YTYtODdiNS00OGM4LWE1MDctMWNmODNhYjFh
+        M2Y0L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:23 GMT
+      - Fri, 29 Jul 2022 11:29:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e00bcda148ff47bbb0f10e6932aaf92f
+      - c5be5e6c7b7e467483b36aade3ea7bcc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjMzFlZjg1LTliZjEtNDE3
-        ZC1hZjM2LTdhNmFiZGU1ZTQ0Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmNjFiMDVlLTQ4YzAtNGQ3
+        MC05MGQyLWYyMjBjYjA1NDc0ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:15 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6c31ef85-9bf1-417d-af36-7a6abde5e447/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ff61b05e-48c0-4d70-90d2-f220cb05474d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:23 GMT
+      - Fri, 29 Jul 2022 11:29:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 199142de42504eb182f18d015802d160
+      - f25687274da84fddb61440442cdb1257
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmMzMWVmODUtOWJm
-        MS00MTdkLWFmMzYtN2E2YWJkZTVlNDQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjMuMzgxODMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmY2MWIwNWUtNDhj
+        MC00ZDcwLTkwZDItZjIyMGNiMDU0NzRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTUuNzUwMTAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImUwMGJjZGExNDhmZjQ3YmJiMGYxMGU2OTMy
-        YWFmOTJmIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MjMuNDEy
-        NTkyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNToyMy41OTQ5
-        MjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImM1YmU1ZTZjN2I3ZTQ2NzQ4M2IzNmFhZGUz
+        ZWE3YmNjIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MTUuODA4
+        Mzg2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOToxNi4yOTIx
+        OTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vM2E0YTFl
-        NGQtMTJhYi00MzA2LTgyMTktODY3OTcyMzFjZDM5LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vODlkNDg1
+        NWQtYzYzNS00MWE1LWI0ZDYtZGE1ZDgwMDIyZGE5LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMmU2Zjc1YjktYjM4NS00YWY0LTg2MDctZjRkMmQ0
-        YTk0N2MzLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vM2I2YmI4YTYtODdiNS00OGM4LWE1MDctMWNmODNh
+        YjFhM2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:23 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 686d2780565c481d996d9a486ab480ab
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:23 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:23 GMT
+      - Fri, 29 Jul 2022 11:29:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f856245aa44f4da081fb535aaf1ed218
+      - ed4a33f5071e48cdb74df86360eedcd4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:16 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/89d4855d-c635-41a5-b4d6-da5d80022da9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a8402c9d6a2241ec9ae667c96832501a
+      - cbdbe51a4d2644ee8cb1dd9445ad7030
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vODlkNDg1NWQtYzYzNS00MWE1LWI0ZDYtZGE1ZDgwMDIyZGE5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MTUuODQxMzY1WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8zYjZiYjhhNi04N2I1LTQ4YzgtYTUwNy0xY2Y4M2FiMWEzZjQv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzNiNmJiOGE2LTg3YjUtNDhjOC1hNTA3LTFjZjgz
+        YWIxYTNmNC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:16 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS84OWQ0ODU1ZC1jNjM1LTQxYTUtYjRkNi1kYTVkODAwMjJkYTkv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 151c5cb668964a98836c14b1cfcbb7cd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg3OThjODdkLTdkM2QtNGRk
+        NC1hZjc2LTY1YTk4Nzg5MDc3NC8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:16 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8798c87d-7d3d-4dd4-af76-65a987890774/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4e76397bb79f44058fd74b93e14c7b1a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODc5OGM4N2QtN2Qz
+        ZC00ZGQ0LWFmNzYtNjVhOTg3ODkwNzc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTYuNjAyMDk0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIxNTFjNWNiNjY4OTY0YTk4ODM2YzE0YjFj
+        ZmNiYjdjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjE2LjY2
+        NzIyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MTcuMDU5
+        OTY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDhh
+        ZTE0ZWUtMjZlZi00ZWE4LWI5MTgtZGZmZmMwZmVhMDM3LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/08ae14ee-26ef-4ea8-b918-dfffc0fea037/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2679fd06fb024a8abdb3bb3895228113
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzA4YWUxNGVlLTI2ZWYtNGVhOC1iOTE4LWRmZmZjMGZlYTAzNy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjE3LjAzNDA2NVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vODlkNDg1NWQtYzYzNS00MWE1LWI0ZDYt
+        ZGE1ZDgwMDIyZGE5LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c09bead95c5b4434a0b32b2dc4b3d672
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - '02820e39c8c44b9d85882be9b8fb8a18'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1d76f7330286422c9bebb3d2652d882e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cb1f096ed3ca48eeb1982c1d168a2a81
+      - 7cac75b197234cec837430fc48c07525
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fbdb17c1b71c4230bf227bc330484a3f
+      - 5bea5d23568941f8b7cbf8ce2b80c4ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 913d81d02d7046ddbe75ed64bab6c874
+      - 807bca5834cc411a9b6c9d75f32d2921
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:17 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 286ff8b3823c4a7f851b2154d1728fa2
+      - 1d01e7260cf04973922f5fbd19be7760
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed8697cb17604f50a537d9ce00b8d455
+      - c7296ade722444f78152cf47838d6d27
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c3b03de36a3d46d6a59a4c911b12d694
+      - 5d61144d819e4db68198dc35ab3df104
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2366bd96a0684aad81c419c7f7be5d7e
+      - 607e02563da3423480c624ef078bd8cb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,37 +3208,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86c69c1278cb4cb5a0a48067a75a9352
+      - 307205ea6f474ca8bed276e0e147a853
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczZDhlMTYzLTE4NmItNDdj
-        Mi1iZWU3LWVkYzYwYzU4YWRkNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2MTA1M2NlLWUxNTctNDQw
+        Zi1hY2NjLTkwNGRhNzQ5NGUyZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:18 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmU2Zjc1YjktYjM4NS00YWY0LTg2
-        MDctZjRkMmQ0YTk0N2MzL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzc4YmNmMmVlLTJmZGIt
-        NDQyYi05NzI3LTM2NWFhODZlZGIwNy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMt
-        OWU5MS04ZWRkOWQ5ZDExNjIvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjp0
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2I2YmI4YTYtODdiNS00OGM4LWE1
+        MDctMWNmODNhYjFhM2Y0L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJiM2E3OGU5LWRlNjct
+        NDEzMy05NjM4LTlhN2I4NzFkOWU2Yy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEt
+        YjVhOC1lMGYzMzdmNTE3Y2QvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjp0
         cnVlfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2826,7 +3251,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2844,21 +3269,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf4bfc427d074da38df308525b60a261
+      - 888148b9eca049dbae00379874aab90a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2MzRhMzY3LWRkMDUtNDZl
-        ZC1iMzM0LThhZTIyNDdhYjlmYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2ZjcwMWRjLWY5MWQtNGNl
+        Zi05ZDFhLTdjZWZkMjRkNTEwYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/73d8e163-186b-47c2-bee7-edc60c58add5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/661053ce-e157-440f-accc-904da7494e2e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2879,51 +3304,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:24 GMT
+      - Fri, 29 Jul 2022 11:29:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dcdf9e10086d45838f36544369f2158a
+      - 5bef1a4090474c34bf8ac1004f939772
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzNkOGUxNjMtMTg2
-        Yi00N2MyLWJlZTctZWRjNjBjNThhZGQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjQuNjUwODk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjYxMDUzY2UtZTE1
+        Ny00NDBmLWFjY2MtOTA0ZGE3NDk0ZTJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTguNjM3NTU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4NmM2OWMxMjc4Y2I0Y2I1YTBh
-        NDgwNjdhNzVhOTM1MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjI0LjY4MzU5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MjQuODE5MzQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMDcyMDVlYTZmNDc0Y2E4YmVk
+        Mjc2ZTBlMTQ3YTg1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjE4LjY5NDI1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MTkuMTczMjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzhiY2YyZWUtMmZk
-        Yi00NDJiLTk3MjctMzY1YWE4NmVkYjA3LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4ZTktZGU2
+        Ny00MTMzLTk2MzgtOWE3Yjg3MWQ5ZTZjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:24 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/73d8e163-186b-47c2-bee7-edc60c58add5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/661053ce-e157-440f-accc-904da7494e2e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2944,51 +3369,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 265cd3dca33644f8b949a79ce084252e
+      - 63accccf3e144c2d869106ae189bbad9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzNkOGUxNjMtMTg2
-        Yi00N2MyLWJlZTctZWRjNjBjNThhZGQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjQuNjUwODk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjYxMDUzY2UtZTE1
+        Ny00NDBmLWFjY2MtOTA0ZGE3NDk0ZTJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTguNjM3NTU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4NmM2OWMxMjc4Y2I0Y2I1YTBh
-        NDgwNjdhNzVhOTM1MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjI0LjY4MzU5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MjQuODE5MzQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMDcyMDVlYTZmNDc0Y2E4YmVk
+        Mjc2ZTBlMTQ3YTg1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjE4LjY5NDI1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MTkuMTczMjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzhiY2YyZWUtMmZk
-        Yi00NDJiLTk3MjctMzY1YWE4NmVkYjA3LyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4ZTktZGU2
+        Ny00MTMzLTk2MzgtOWE3Yjg3MWQ5ZTZjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f634a367-dd05-46ed-b334-8ae2247ab9fc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/661053ce-e157-440f-accc-904da7494e2e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3009,55 +3434,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10b0fa05f44c4e88b0c09365579a0a35
+      - 6ceed4c4eaf240b0994b59e135185d10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '418'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjYzNGEzNjctZGQw
-        NS00NmVkLWIzMzQtOGFlMjI0N2FiOWZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjQuNzAxNjE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjYxMDUzY2UtZTE1
+        Ny00NDBmLWFjY2MtOTA0ZGE3NDk0ZTJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTguNjM3NTU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMDcyMDVlYTZmNDc0Y2E4YmVk
+        Mjc2ZTBlMTQ3YTg1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjE4LjY5NDI1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MTkuMTczMjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4ZTktZGU2
+        Ny00MTMzLTk2MzgtOWE3Yjg3MWQ5ZTZjLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/661053ce-e157-440f-accc-904da7494e2e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '613'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a1c95e49565549a399f6197436d8a1cb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjYxMDUzY2UtZTE1
+        Ny00NDBmLWFjY2MtOTA0ZGE3NDk0ZTJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTguNjM3NTU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMDcyMDVlYTZmNDc0Y2E4YmVk
+        Mjc2ZTBlMTQ3YTg1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjE4LjY5NDI1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MTkuMTczMjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4ZTktZGU2
+        Ny00MTMzLTk2MzgtOWE3Yjg3MWQ5ZTZjLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/16f701dc-f91d-4cef-9d1a-7cefd24d510a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 40e1aeba322c4b20a35f917f5026bbb8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTZmNzAxZGMtZjkx
+        ZC00Y2VmLTlkMWEtN2NlZmQyNGQ1MTBhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MTguNzI4MzA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiY2Y0YmZjNDI3ZDA3NGRhMzhkZjMwODUyNWI2
-        MGEyNjEiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNToyNC44NTE2
-        NDlaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjI1LjAzNzM2
-        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvMGRmMThhZmYtNjRiOC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiODg4MTQ4YjllY2EwNDlkYmFlMDAzNzk4NzRh
+        YWI5MGEiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOToxOS4yMzc2
+        MTdaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjE5LjgzODQ0
+        OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzhiY2Yy
-        ZWUtMmZkYi00NDJiLTk3MjctMzY1YWE4NmVkYjA3L3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4
+        ZTktZGU2Ny00MTMzLTk2MzgtOWE3Yjg3MWQ5ZTZjL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzc4YmNmMmVlLTJmZGItNDQyYi05NzI3LTM2
-        NWFhODZlZGIwNy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzJlNmY3NWI5LWIzODUtNGFmNC04NjA3LWY0ZDJkNGE5NDdj
-        My8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzJiM2E3OGU5LWRlNjctNDEzMy05NjM4LTlh
+        N2I4NzFkOWU2Yy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzNiNmJiOGE2LTg3YjUtNDhjOC1hNTA3LTFjZjgzYWIxYTNm
+        NC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3065,7 +3620,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3078,46 +3633,46 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '403'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0677d19e26ce44b489fb6d6482154c22
+      - a2793e50dc984a4daad72732ef2a0ec2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '216'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMv
+        YWNrYWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZTVjYWUzZjMtYjJkMC00MjJjLTllOTEtOGVkZDlkOWQxMTYyLyJ9
+        a2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUxN2NkLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzgzYWUzNzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7
+        Z2VzLzc2MjlmMzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wYjQ2ZTQ5MC1iMzU3LTRiNGYtYjFhZC05ODcwM2I1ZTdkMTIvIn1dfQ==
+        cy82ZWI1ZGU4MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3125,7 +3680,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3138,7 +3693,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3156,21 +3711,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ae622dcaa3c4d87b1d1c67b8d1da6d7
+      - dee49c62af37403abd101cced2694231
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3178,7 +3733,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3191,7 +3746,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3209,21 +3764,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6a0aed018fda471bae65b5f5ea2620ca
+      - 3c62d8d974e24228b3799df19b9e8cb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3231,7 +3786,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3244,7 +3799,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3262,21 +3817,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f10d2afb9cec4729a9684888366bfe0f
+      - e0b603c2a4ee48e19f79f3ac5ac2d705
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3284,7 +3839,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3297,7 +3852,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3315,21 +3870,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dbc188dceacd4f25a12bdbfbe011602b
+      - 79b04758de924a3ea2fc6e81845f5529
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3337,7 +3892,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3350,7 +3905,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3368,21 +3923,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 88bae28faad2467abc5e5d3602298238
+      - 342bfd7a14b34544a70de31d7a400660
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3390,7 +3945,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3403,46 +3958,46 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '403'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f6a0cb8f6014b65956080b99c652ba0
+      - 36d76c2965fd48128bcb664cc64d5533
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '216'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMv
+        YWNrYWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZTVjYWUzZjMtYjJkMC00MjJjLTllOTEtOGVkZDlkOWQxMTYyLyJ9
+        a2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUxN2NkLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzgzYWUzNzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7
+        Z2VzLzc2MjlmMzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wYjQ2ZTQ5MC1iMzU3LTRiNGYtYjFhZC05ODcwM2I1ZTdkMTIvIn1dfQ==
+        cy82ZWI1ZGU4MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3450,7 +4005,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3463,7 +4018,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3481,21 +4036,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cc3c1a4332644ef89e65caf013cd4b1a
+      - dd1027862bf44a199da43aa0335567b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3503,7 +4058,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3516,7 +4071,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3534,21 +4089,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a3e4297ffd4a4ea68d291f234d16d8f2
+      - 27808a1cce564b6cbf893b6eec00d114
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3556,7 +4111,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3569,7 +4124,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3587,21 +4142,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 58170a33cd07427497d05918abcb3473
+      - 13214543d410488ebbebd059b1013325
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3609,7 +4164,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3622,7 +4177,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3640,21 +4195,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8ae0ca7ea4c742c7a1425b7562086ce8
+      - 7a44ab6cbd1a4aea8bbad9f94e340b23
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3662,7 +4217,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3675,7 +4230,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:25 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3693,21 +4248,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 642e807bb93e4e66be6aabd728ddbd04
+      - f675cee363294edeb4cd6171df7b4d73
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:25 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3715,7 +4270,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3728,7 +4283,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3746,21 +4301,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 568a924e5b5d4c81a7ff776ec7263aaa
+      - 247754add40a4166985bb9c149782e10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3768,7 +4323,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3781,7 +4336,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3799,21 +4354,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d91b7e3d95a43c79025b7e63f7a2f0a
+      - 5a59849e11dc40c4968b737fdf002214
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3821,7 +4376,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3834,7 +4389,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3852,21 +4407,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1045becb8d014728a2356b02a04fe930
+      - 7455adecaafe404fb848887c551b2353
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2e6f75b9-b385-4af4-8607-f4d2d4a947c3/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3874,7 +4429,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3887,7 +4442,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3905,21 +4460,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f33a54dd45c64a84ab161fe7f9773246
+      - 76bf01d7baf3486a83f2d323fa16d46e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:21 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -3929,7 +4484,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3942,7 +4497,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3960,37 +4515,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 715e15b872ed44f6a8a9ed7a1ac9c417
+      - 96d743ed7e36484aaeb74b5859301861
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3YWQ2YjhmLTBkN2ItNDAw
-        OC1iZGJmLWE3YmJjYWM4YjY4NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjYjk3NjhkLTNkZjItNGYx
+        NS04MTVkLTNmN2EwMGMxYzJkZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:22 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmU2Zjc1YjktYjM4NS00YWY0LTg2
-        MDctZjRkMmQ0YTk0N2MzL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzc4YmNmMmVlLTJmZGIt
-        NDQyYi05NzI3LTM2NWFhODZlZGIwNy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMt
-        OWU5MS04ZWRkOWQ5ZDExNjIvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjp0
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2I2YmI4YTYtODdiNS00OGM4LWE1
+        MDctMWNmODNhYjFhM2Y0L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJiM2E3OGU5LWRlNjct
+        NDEzMy05NjM4LTlhN2I4NzFkOWU2Yy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEt
+        YjVhOC1lMGYzMzdmNTE3Y2QvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjp0
         cnVlfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4003,7 +4558,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4021,21 +4576,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2c1bf7767ab4035b00d703dc60d33cd
+      - 32dd4e59e66949edb7a6c1cef22d9599
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiMTA1ZDA4LWE4NmUtNGIy
-        OC1iZjAyLTRhYTIyYjVjMmVmMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JkNGRlOTg0LTBkNjgtNDI0
+        OC05M2U2LTEzZDc5MTMzNGEyZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/77ad6b8f-0d7b-4008-bdbf-a7bbcac8b685/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/dcb9768d-3df2-4f15-815d-3f7a00c1c2dd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4056,53 +4611,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e316a77d9b846338a6b9ea23ae26bc0
+      - b3987802bb554f38a88a20ba3fe3bbe6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzdhZDZiOGYtMGQ3
-        Yi00MDA4LWJkYmYtYTdiYmNhYzhiNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjYuMzkxNjUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNiOTc2OGQtM2Rm
+        Mi00ZjE1LTgxNWQtM2Y3YTAwYzFjMmRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjIuMDMzMDE3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MTVlMTViODcyZWQ0NGY2YThh
-        OWVkN2ExYWM5YzQxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjI2LjQyNTkxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MjYuNTcwNjM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5NmQ3NDNlZDdlMzY0ODRhYWVi
+        NzRiNTg1OTMwMTg2MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjIyLjEwNDA3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MjIuNDA2NTczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83OGJjZjJlZS0yZmRiLTQ0MmItOTcyNy0zNjVhYTg2ZWRiMDcvdmVyc2lv
+        bS8yYjNhNzhlOS1kZTY3LTQxMzMtOTYzOC05YTdiODcxZDllNmMvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzhiY2YyZWUtMmZkYi00NDJi
-        LTk3MjctMzY1YWE4NmVkYjA3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4ZTktZGU2Ny00MTMz
+        LTk2MzgtOWE3Yjg3MWQ5ZTZjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/77ad6b8f-0d7b-4008-bdbf-a7bbcac8b685/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/dcb9768d-3df2-4f15-815d-3f7a00c1c2dd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4123,53 +4678,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f7b8736876b44045bda5fc36e8fda98d
+      - a46caed071f541efa2731a2474d99d62
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzdhZDZiOGYtMGQ3
-        Yi00MDA4LWJkYmYtYTdiYmNhYzhiNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjYuMzkxNjUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNiOTc2OGQtM2Rm
+        Mi00ZjE1LTgxNWQtM2Y3YTAwYzFjMmRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjIuMDMzMDE3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MTVlMTViODcyZWQ0NGY2YThh
-        OWVkN2ExYWM5YzQxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjI2LjQyNTkxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MjYuNTcwNjM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5NmQ3NDNlZDdlMzY0ODRhYWVi
+        NzRiNTg1OTMwMTg2MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjIyLjEwNDA3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MjIuNDA2NTczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83OGJjZjJlZS0yZmRiLTQ0MmItOTcyNy0zNjVhYTg2ZWRiMDcvdmVyc2lv
+        bS8yYjNhNzhlOS1kZTY3LTQxMzMtOTYzOC05YTdiODcxZDllNmMvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzhiY2YyZWUtMmZkYi00NDJi
-        LTk3MjctMzY1YWE4NmVkYjA3LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4ZTktZGU2Ny00MTMz
+        LTk2MzgtOWE3Yjg3MWQ5ZTZjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/77ad6b8f-0d7b-4008-bdbf-a7bbcac8b685/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bd4de984-0d68-4248-93e6-13d791334a2d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4190,122 +4745,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:26 GMT
+      - Fri, 29 Jul 2022 11:29:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce480fe5393b4ac2815af8873ec8ce2d
+      - e2bd3bf5321549f19d916a8c9ea09da3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '389'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzdhZDZiOGYtMGQ3
-        Yi00MDA4LWJkYmYtYTdiYmNhYzhiNjg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjYuMzkxNjUyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3MTVlMTViODcyZWQ0NGY2YThh
-        OWVkN2ExYWM5YzQxNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjI2LjQyNTkxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MjYuNTcwNjM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
-        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
-        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS83OGJjZjJlZS0yZmRiLTQ0MmItOTcyNy0zNjVhYTg2ZWRiMDcvdmVyc2lv
-        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzhiY2YyZWUtMmZkYi00NDJi
-        LTk3MjctMzY1YWE4NmVkYjA3LyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/bb105d08-a86e-4b28-bf02-4aa22b5c2ef3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:26 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 88bcb18030e84dc6b597f6ef2f93abfc
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '417'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmIxMDVkMDgtYTg2
-        ZS00YjI4LWJmMDItNGFhMjJiNWMyZWYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MjYuNDQ3MzA3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmQ0ZGU5ODQtMGQ2
+        OC00MjQ4LTkzZTYtMTNkNzkxMzM0YTJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjIuMTMyODAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiYzJjMWJmNzc2N2FiNDAzNWIwMGQ3MDNkYzYw
-        ZDMzY2QiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNToyNi42MDEw
-        NjNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjI2Ljc4MjI5
-        OFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiMzJkZDRlNTllNjY5NDllZGI3YTZjMWNlZjIy
+        ZDk1OTkiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOToyMi40NTQ2
+        MDdaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjIyLjk4Njc2
+        NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzhiY2Yy
-        ZWUtMmZkYi00NDJiLTk3MjctMzY1YWE4NmVkYjA3L3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4
+        ZTktZGU2Ny00MTMzLTk2MzgtOWE3Yjg3MWQ5ZTZjL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzc4YmNmMmVlLTJmZGItNDQyYi05NzI3LTM2
-        NWFhODZlZGIwNy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzJlNmY3NWI5LWIzODUtNGFmNC04NjA3LWY0ZDJkNGE5NDdj
-        My8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzJiM2E3OGU5LWRlNjctNDEzMy05NjM4LTlh
+        N2I4NzFkOWU2Yy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzNiNmJiOGE2LTg3YjUtNDhjOC1hNTA3LTFjZjgzYWIxYTNm
+        NC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:26 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4313,7 +4801,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4326,46 +4814,46 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:27 GMT
+      - Fri, 29 Jul 2022 11:29:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '403'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e04fb69bd2504ebfb18094d2a025863e
+      - 2c0969095f174d8d9c2df5ef2197f204
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '216'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMv
+        YWNrYWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZTVjYWUzZjMtYjJkMC00MjJjLTllOTEtOGVkZDlkOWQxMTYyLyJ9
+        a2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgtZTBmMzM3ZjUxN2NkLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzgzYWUzNzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7
+        Z2VzLzc2MjlmMzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8wYjQ2ZTQ5MC1iMzU3LTRiNGYtYjFhZC05ODcwM2I1ZTdkMTIvIn1dfQ==
+        cy82ZWI1ZGU4MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4373,7 +4861,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4386,7 +4874,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:27 GMT
+      - Fri, 29 Jul 2022 11:29:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4404,21 +4892,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d02a1bab2d94f5e8f0b413178562525
+      - bdb6f616b405470ca1938521aac30e00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4426,7 +4914,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4439,7 +4927,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:27 GMT
+      - Fri, 29 Jul 2022 11:29:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4457,21 +4945,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ece4e79f188b4d7e8a3a9359dc3887dc
+      - f483db566fe04d4d86d055076233ed7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4479,7 +4967,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4492,7 +4980,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:27 GMT
+      - Fri, 29 Jul 2022 11:29:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4510,21 +4998,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 05437c98c3b34cf89c8a3a13b1bd0d11
+      - 4a9bf1d1980747f4940a192808035302
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4532,7 +5020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4545,7 +5033,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:27 GMT
+      - Fri, 29 Jul 2022 11:29:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4563,21 +5051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 65254f2edf6b4ed78fc77ab919009f31
+      - 4d2757a9c0474092b8e2e226083dd51b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/78bcf2ee-2fdb-442b-9727-365aa86edb07/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4585,7 +5073,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4598,7 +5086,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:27 GMT
+      - Fri, 29 Jul 2022 11:29:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4616,16 +5104,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b093c8d9bc494622a4f2f005551bcf41
+      - de191955070f433db4135edaf69b0efd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:27 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:23 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_duplicate_content.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_duplicate_content.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3aeddca645314c50868f03f3317fb24b
+      - 010a2ece2ec548049aa3dca954c40719
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83YzQwYzU3NC04ODU1LTRiMzQtYTc5Ni1lYjEzNjZlY2RiYzUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNTowNC4wODM1NzJa
+        cnBtL3JwbS9lMDhkODcxOS02NjE1LTQwMmMtODhmMy02Y2MyOTRlZjFhNWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDozMC4zMTgxMDRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83YzQwYzU3NC04ODU1LTRiMzQtYTc5Ni1lYjEzNjZlY2RiYzUv
+        cnBtL3JwbS9lMDhkODcxOS02NjE1LTQwMmMtODhmMy02Y2MyOTRlZjFhNWQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdjNDBj
-        NTc0LTg4NTUtNGIzNC1hNzk2LWViMTM2NmVjZGJjNS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UwOGQ4
+        NzE5LTY2MTUtNDAyYy04OGYzLTZjYzI5NGVmMWE1ZC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:44 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e08d8719-6615-402c-88f3-6cc294ef1a5d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ec1f69ad6d54e10a962220b16695efc
+      - 17cb998aa8d5498c86a52985634afd5f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhYWY5ODk4LTM5NjMtNDZm
-        Ni04ZGUyLTQwZGYzOGRjZWEzMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RhZmNhNzZmLTg3NzEtNDA3
+        NC05NzEyLWI4Y2E2YjM4Zjg2MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6dd603dbb2f846048680811975d52793
+      - dd2cf9168f6741e5b81c94c17cc405e0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/9aaf9898-3963-46f6-8de2-40df38dcea30/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/dafca76f-8771-4074-9712-b8ca6b38f860/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b655248b546d400eaac4acb77b2f6dc5
+      - 3e1814d95d1d473cb7bee1b9fd692e33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWFhZjk4OTgtMzk2
-        My00NmY2LThkZTItNDBkZjM4ZGNlYTMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTAuNTA2MDQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGFmY2E3NmYtODc3
+        MS00MDc0LTk3MTItYjhjYTZiMzhmODYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NDQuNDEzMzY0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyZWMxZjY5YWQ2ZDU0ZTEwYTk2MjIyMGIx
-        NjY5NWVmYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjEwLjU0
-        OTcyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MTAuNjgw
-        MjY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxN2NiOTk4YWE4ZDU0OThjODZhNTI5ODU2
+        MzRhZmQ1ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjQ0LjQ3
+        NjMwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6NDQuOTE1
+        NTIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2M0MGM1NzQtODg1NS00YjM0
-        LWE3OTYtZWIxMzY2ZWNkYmM1LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTA4ZDg3MTktNjYxNS00MDJj
+        LTg4ZjMtNmNjMjk0ZWYxYTVkLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f48462fea49e47a49f114ba90a5795c0
+      - 9d5533205e714602b329c70ec97768eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 57e565f62f8b4fb3b33419c60aa64dc9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vN2JiOWRmNTUtMjFhZi00MTgxLTlkMWMtNDM1YmE0MTA5ODcx
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MzkuMzM4MjA1
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/7bb9df55-21af-4181-9d1c-435ba4109871/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 43d30a1f2af240bdba2138e8ea21c69c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2OWYxZDYyLTI0ZDktNGQ1
+        ZC04ODkzLTQ0ZTM4NDkzOTkzZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/169f1d62-24d9-4d5d-8893-44e38493993e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 90a763b3bffa415aa9a85ab1e12058eb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTY5ZjFkNjItMjRk
+        OS00ZDVkLTg4OTMtNDRlMzg0OTM5OTNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NDUuMTY3Njk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0M2QzMGExZjJhZjI0MGJkYmEyMTM4ZThl
+        YTIxYzY5YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjQ1LjIx
+        NjQ4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6NDUuMjYx
+        MDQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4df30d4603d045c39630f4fb7df8fc36
+      - 796ab939383d47438d4a7e55f19b7656
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2124554d4133401187a4e213890704aa
+      - 2071fabc306d45cdbf5ed43d80e1dba8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 62f91c6ec14f4fd6b9c947b31c5f39b9
+      - 133d3c54c3ff46309e09f5772bed6970
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:10 GMT
+      - Fri, 29 Jul 2022 11:30:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ac4591cd523345f5811e468691da252f
+      - f0f0e893bfce455087773c3a2faebbb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:10 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e006ee7c30104a0f87b69ad8a7558df6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:10 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/b6851b68-2448-4221-8c9c-dd9679283bb8/"
+      - "/pulp/api/v3/remotes/rpm/rpm/200741da-456f-4eb8-890a-d430f452056e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e934363c8bd04017af55be502a80ec48
+      - ccf12d2424f6454caa8605b017e5ee97
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I2
-        ODUxYjY4LTI0NDgtNDIyMS04YzljLWRkOTY3OTI4M2JiOC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjExLjA4NDIyNFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzIw
+        MDc0MWRhLTQ1NmYtNGViOC04OTBhLWQ0MzBmNDUyMDU2ZS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjQ1LjYyNTkwMVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjExLjA4NDI0NFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjQ1LjYyNjAxMFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/"
+      - "/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 06a7c123d3f547a09db87069abb4344f
+      - 4256c7137e2947cf9a74bf01a72e658d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNWNkMTU5MjgtYWJiNS00N2YyLWIzNTEtZmRhOGVkMWI0NmYxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MTEuMTk3NjQ4WiIsInZl
+        cG0vNDdmMGUzN2UtYWIzMy00Zjg3LWI5MzItMDc5ZTM5NTY4NmYyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6NDUuODI0MjM4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNWNkMTU5MjgtYWJiNS00N2YyLWIzNTEtZmRhOGVkMWI0NmYxL3ZlcnNp
+        cG0vNDdmMGUzN2UtYWIzMy00Zjg3LWI5MzItMDc5ZTM5NTY4NmYyL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81Y2QxNTkyOC1h
-        YmI1LTQ3ZjItYjM1MS1mZGE4ZWQxYjQ2ZjEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80N2YwZTM3ZS1h
+        YjMzLTRmODctYjkzMi0wNzllMzk1Njg2ZjIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 215de729ab1c408cac3c4000b1091894
+      - bb937e8f31114b6cb039af361f64ecc6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '309'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83N2E5MDVmMi05YjdkLTRiMmEtOTkzZi01ZmI1ZTAxZWYzY2Yv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNTowNC44MDA3MTBa
+        cnBtL3JwbS9kZjIxNGJjMC0zZjU1LTQ0MTctOTJmNC1lOGE0YmExOGRlZjYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDozMS44NzI3NTBa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83N2E5MDVmMi05YjdkLTRiMmEtOTkzZi01ZmI1ZTAxZWYzY2Yv
+        cnBtL3JwbS9kZjIxNGJjMC0zZjU1LTQ0MTctOTJmNC1lOGE0YmExOGRlZjYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzc3YTkw
-        NWYyLTliN2QtNGIyYS05OTNmLTVmYjVlMDFlZjNjZi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2RmMjE0
+        YmMwLTNmNTUtNDQxNy05MmY0LWU4YTRiYTE4ZGVmNi92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:46 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/df214bc0-3f55-4417-92f4-e8a4ba18def6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 378436a9b2eb4d8b8f85cc20a2c6e601
+      - e7bbced63e994050a823ea954e117728
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4NWM4YjhjLTE0OTktNDdi
-        NS05MmQyLTk3N2QzNDA2YjI1YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlNDJmNjg4LTRiYmEtNDg5
+        MC1hOGQ4LWYyNjNjZjViNTQxYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bfdfd9ee63ea4c27bf1ac0fb9ff6defb
+      - 4217eef9fd1e4c7b84ae7cd6aad642f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZGVkODQ3ZTYtYTY5MC00MjFmLWI4MjgtNGFiYmQzZDY0OTJlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MDMuOTcyMTQ0WiIsIm5h
+        cG0vOTM4NzI3ZTEtY2RmMi00MzMyLWFkOGQtZDRkODM2YmE4NTBmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MzAuMTE4NTQ3WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNTowNS4xMTcxNzRaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMTozMDozMi40MTA2MjhaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:46 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/ded847e6-a690-421f-b828-4abbd3d6492e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/938727e1-cdf2-4332-ad8d-d4d836ba850f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 349cb1f44f84401da341762317b8f7ee
+      - ee547c28a672453a99d7d5ca7f56704e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4MzQ2MWIzLTQyYWUtNDIz
-        YS04NGY0LTljNWYxNTBkMzQxYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjNmNlMDMzLTAwNzAtNDU2
+        Yy1hZGY4LWI5MTU3OWI0ZDgwYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/085c8b8c-1499-47b5-92d2-977d3406b25a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1e42f688-4bba-4890-a8d8-f263cf5b541c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 69a12714a9cc445d9b0370e92498708b
+      - cc905abd06b94c64ba38f54313a86b2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDg1YzhiOGMtMTQ5
-        OS00N2I1LTkyZDItOTc3ZDM0MDZiMjVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTEuMzc1NTg2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWU0MmY2ODgtNGJi
+        YS00ODkwLWE4ZDgtZjI2M2NmNWI1NDFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NDYuMTU0NTEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNzg0MzZhOWIyZWI0ZDhiOGY4NWNjMjBh
-        MmM2ZTYwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjExLjQy
-        OTEyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MTEuNDg4
-        MjE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlN2JiY2VkNjNlOTk0MDUwYTgyM2VhOTU0
+        ZTExNzcyOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjQ2LjIy
+        ODg2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6NDYuNTUy
+        NDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzdhOTA1ZjItOWI3ZC00YjJh
-        LTk5M2YtNWZiNWUwMWVmM2NmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGYyMTRiYzAtM2Y1NS00NDE3
+        LTkyZjQtZThhNGJhMThkZWY2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/183461b3-42ae-423a-84f4-9c5f150d341c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/dc6ce033-0070-456c-adf8-b91579b4d80c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fc439337984b4d669a55d6dbe8793bd5
+      - 441f07d8b1544db28746f73b9f19d068
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTgzNDYxYjMtNDJh
-        ZS00MjNhLTg0ZjQtOWM1ZjE1MGQzNDFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTEuNDg2NTk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGM2Y2UwMzMtMDA3
+        MC00NTZjLWFkZjgtYjkxNTc5YjRkODBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NDYuMzg5Njg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNDljYjFmNDRmODQ0MDFkYTM0MTc2MjMx
-        N2I4ZjdlZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjExLjUy
-        MDI0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MTEuNTY5
-        ODYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlZTU0N2MyOGE2NzI0NTNhOTlkN2Q1Y2E3
+        ZjU2NzA0ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjQ2LjQ4
+        NzU5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6NDYuNzg1
+        NDI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2RlZDg0N2U2LWE2OTAtNDIxZi1iODI4
-        LTRhYmJkM2Q2NDkyZS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkzODcyN2UxLWNkZjItNDMzMi1hZDhk
+        LWQ0ZDgzNmJhODUwZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5696f25313f849e4bfe10bd8c42ad9a6
+      - a174367126ef45bcbece3af7fe6fd30e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb187ce7a5074c4880ee714d987b603d
+      - 22ec03ec68334180a4e87ba660b7ac7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d488315bf5d44b40982fe05a0e7d186c
+      - ac59d3fad49c42a7b072e84fd2aa3399
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - abd40c30b924408a8dc77e058eaad105
+      - dac2d2a100db490da32d46dcb742c7b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f0285484d3194abe8205d8fb2354a552
+      - 9515deb51e654ab48ec704f27f5d03cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bac409d851924f318bd45c504d06356b
+      - 6c0ea6d349474083baf51f595314806a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:11 GMT
+      - Fri, 29 Jul 2022 11:30:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af87c9b398634f1eb6db81a0d8b5d858
+      - dab5b6d2956647ed8072ba9e1908b153
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTBjNWFmMmYtZWNlZS00NjE0LWI3ZjMtMGFkMDI0ZGZhZDUxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MTEuOTg0NDA3WiIsInZl
+        cG0vZDkxN2NhY2ItYjdjZi00OGNmLTk4MTYtMmY0MTQyMDE3MDViLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6NDcuNTgxMTMxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTBjNWFmMmYtZWNlZS00NjE0LWI3ZjMtMGFkMDI0ZGZhZDUxL3ZlcnNp
+        cG0vZDkxN2NhY2ItYjdjZi00OGNmLTk4MTYtMmY0MTQyMDE3MDViL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hMGM1YWYyZi1l
-        Y2VlLTQ2MTQtYjdmMy0wYWQwMjRkZmFkNTEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kOTE3Y2FjYi1i
+        N2NmLTQ4Y2YtOTgxNi0yZjQxNDIwMTcwNWIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:11 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:47 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/b6851b68-2448-4221-8c9c-dd9679283bb8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/200741da-456f-4eb8-890a-d430f452056e/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:12 GMT
+      - Fri, 29 Jul 2022 11:30:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4aaf62fff8b34287aef61b75a7c7e9dc
+      - 4c36c88f6bd244bdb86730d4a848a24a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4MWU2OWEyLTRlYjgtNGZi
-        Yi1hYzhiLTJhMzE1OTE1MWVhZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxZDE3MjlmLTk1ZmItNGUx
+        Yy05ZGJkLWVkOTIxZjVlZDc5My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/481e69a2-4eb8-4fbb-ac8b-2a3159151eaf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e1d1729f-95fb-4e1c-9dbd-ed921f5ed793/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:12 GMT
+      - Fri, 29 Jul 2022 11:30:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 936a8684f2ba41f09e0f79f256c67176
+      - 1365d85dc1884c3599726081c6ec9730
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDgxZTY5YTItNGVi
-        OC00ZmJiLWFjOGItMmEzMTU5MTUxZWFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTIuMjc0OTg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTFkMTcyOWYtOTVm
+        Yi00ZTFjLTlkYmQtZWQ5MjFmNWVkNzkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NDguMTk5MzYzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI0YWFmNjJmZmY4YjM0Mjg3YWVmNjFiNzVh
-        N2M3ZTlkYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjEyLjMw
-        NTk2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MTIuMzI4
-        NDk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI0YzM2Yzg4ZjZiZDI0NGJkYjg2NzMwZDRh
+        ODQ4YTI0YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjQ4LjI3
+        MDg0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6NDguMzE1
+        OTAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I2ODUxYjY4LTI0NDgtNDIyMS04Yzlj
-        LWRkOTY3OTI4M2JiOC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzIwMDc0MWRhLTQ1NmYtNGViOC04OTBh
+        LWQ0MzBmNDUyMDU2ZS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:48 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I2ODUx
-        YjY4LTI0NDgtNDIyMS04YzljLWRkOTY3OTI4M2JiOC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzIwMDc0
+        MWRhLTQ1NmYtNGViOC04OTBhLWQ0MzBmNDUyMDU2ZS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:12 GMT
+      - Fri, 29 Jul 2022 11:30:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4db9f510700c4e5cb4b1c4699bb7300a
+      - 0a12f40825c54751b355f72f0b9ddeb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4MzViMTcxLTcwZWEtNDg2
-        MS04M2FhLTU0M2RkMDhlMGNiZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0MWYzNTVlLTZhOTktNDQ5
+        NS1hOGRlLTI2ZDVhZDRlOGQxYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:12 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0835b171-70ea-4861-83aa-543dd08e0cbe/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/941f355e-6a99-4495-a8de-26d5ad4e8d1c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:14 GMT
+      - Fri, 29 Jul 2022 11:30:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '0682bdab6032458490bc18b4fb2a3923'
+      - 675288f971c547aa805c49d13e3e47dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '599'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDgzNWIxNzEtNzBl
-        YS00ODYxLTgzYWEtNTQzZGQwOGUwY2JlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTIuNDUzMDM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQxZjM1NWUtNmE5
+        OS00NDk1LWE4ZGUtMjZkNWFkNGU4ZDFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NDguNTU1NTg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI0ZGI5ZjUxMDcwMGM0ZTVjYjRi
-        MWM0Njk5YmI3MzAwYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjEyLjQ4MzAxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MTQuMTcwNzc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwYTEyZjQwODI1YzU0NzUxYjM1
+        NWY3MmYwYjlkZGViMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjQ4LjYyNjU4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        NTMuMTIwNzM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vNWNkMTU5MjgtYWJiNS00N2YyLWIzNTEt
-        ZmRhOGVkMWI0NmYxL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzVjZDE1OTI4LWFiYjUtNDdmMi1iMzUxLWZkYThlZDFiNDZmMS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9iNjg1MWI2OC0yNDQ4
-        LTQyMjEtOGM5Yy1kZDk2NzkyODNiYjgvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzQ3ZjBlMzdlLWFiMzMtNGY4Ny1iOTMyLTA3
+        OWUzOTU2ODZmMi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80
+        N2YwZTM3ZS1hYjMzLTRmODctYjkzMi0wNzllMzk1Njg2ZjIvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMjAwNzQxZGEtNDU2Zi00
+        ZWI4LTg5MGEtZDQzMGY0NTIwNTZlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNWNkMTU5MjgtYWJiNS00N2YyLWIzNTEtZmRhOGVkMWI0
-        NmYxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNDdmMGUzN2UtYWIzMy00Zjg3LWI5MzItMDc5ZTM5NTY4
+        NmYyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:14 GMT
+      - Fri, 29 Jul 2022 11:30:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8eb6c47eefb4a5395f9198a09a50d39
+      - 11a23701b0fc4c3ea8310b8adee43b6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMxNTJjYjZhLTUzNzctNDY0
-        Mi1iZTc0LWUxNjljNjIyNTg0YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgwY2ZlMWIwLWY3MDYtNDc0
+        NC05ZDEyLWJiZTEwNzFhMTgyYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3152cb6a-5377-4642-be74-e169c622584a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/80cfe1b0-f706-4744-9d12-bbe1071a182b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:14 GMT
+      - Fri, 29 Jul 2022 11:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3ae99c42eaf1430b8fb13d3cdde0afdd
+      - e4f4a9f1a0934594ac9a26637a56ec43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzE1MmNiNmEtNTM3
-        Ny00NjQyLWJlNzQtZTE2OWM2MjI1ODRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTQuMzI2OTExWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODBjZmUxYjAtZjcw
+        Ni00NzQ0LTlkMTItYmJlMTA3MWExODJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NTMuNTY2MDUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImM4ZWI2YzQ3ZWVmYjRhNTM5NWY5MTk4YTA5
-        YTUwZDM5Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MTQuMzYw
-        MDAwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNToxNC41Njkz
-        NTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjExYTIzNzAxYjBmYzRjM2VhODMxMGI4YWRl
+        ZTQzYjZiIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6NTMuNjQy
+        MjgwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMDo1NC4xODI0
+        ODNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTM5Y2Iy
-        ZjktN2NjNi00ZWNlLTlhNzgtM2FhN2JlYmY2MDBmLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZjM0MTRj
+        NjEtOTIxMC00YzBmLWIxY2UtMTkxMmMwOGNjOGRkLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNWNkMTU5MjgtYWJiNS00N2YyLWIzNTEtZmRhOGVk
-        MWI0NmYxLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNDdmMGUzN2UtYWIzMy00Zjg3LWI5MzItMDc5ZTM5
+        NTY4NmYyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,35 +1998,335 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:14 GMT
+      - Fri, 29 Jul 2022 11:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b2e63a7a760499caf2ad57ea7b9c359
+      - ec14f032eeb5451d852064a79640ea3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/f3414c61-9210-4c0f-b1ce-1912c08cc8dd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 145c88891c0348e09cf446aa4e36b22e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vZjM0MTRjNjEtOTIxMC00YzBmLWIxY2UtMTkxMmMwOGNjOGRkLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6NTMuNzA0OTg5WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80N2YwZTM3ZS1hYjMzLTRmODctYjkzMi0wNzllMzk1Njg2ZjIv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzQ3ZjBlMzdlLWFiMzMtNGY4Ny1iOTMyLTA3OWUz
+        OTU2ODZmMi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:54 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9mMzQxNGM2MS05MjEwLTRjMGYtYjFjZS0xOTEyYzA4Y2M4ZGQv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 309b5c66d87840f0bbf8d89647f7123d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmNTYxMGQ2LTI4ZWYtNDQ1
+        ZC1iZjNiLTczZDg0ZDZmMjkxZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8f5610d6-28ef-445d-bf3b-73d84d6f291f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 193f126e08b44cf3a511dcda8060a487
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGY1NjEwZDYtMjhl
+        Zi00NDVkLWJmM2ItNzNkODRkNmYyOTFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NTQuNTE3MjgyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzMDliNWM2NmQ4Nzg0MGYwYmJmOGQ4OTY0
+        N2Y3MTIzZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjU0LjU3
+        NjU0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6NTUuMDI2
+        NzkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNDI2
+        OWJkYTAtODkwNy00OGNiLTgyZGUtYzQzODgxMjlkM2RjLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:55 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/4269bda0-8907-48cb-82de-c4388129d3dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9618f80c138344c88e0e20cbed9ac5d0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzQyNjliZGEwLTg5MDctNDhjYi04MmRlLWM0Mzg4MTI5ZDNkYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjU0Ljk5NTI4NloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vZjM0MTRjNjEtOTIxMC00YzBmLWIxY2Ut
+        MTkxMmMwOGNjOGRkLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:55 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4189033fb21d4ad6a164138a8548194b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
         LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
         YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
@@ -1909,24 +2334,24 @@ http_interactions:
         IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
         cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
         X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
         aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
         SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
         YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
         cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
         bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
         cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
         Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
         NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
         QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
         YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
         MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
         cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
         LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
         ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
@@ -1934,244 +2359,244 @@ http_interactions:
         dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
         dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
         OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
         LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
         OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
         Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
         ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
         b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
         LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
         YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
         Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2179,7 +2604,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2192,7 +2617,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:14 GMT
+      - Fri, 29 Jul 2022 11:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2635,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7deabd5b35b74f7ca6d80676267cf81d
+      - 324fa7d541d84765a87bc94e22e30c27
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2657,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2670,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:14 GMT
+      - Fri, 29 Jul 2022 11:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d706e8cefd3944168cd5a34d3da0981a
+      - 8cdeb1591c044c0c957cf80a57fa2030
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:14 GMT
+      - Fri, 29 Jul 2022 11:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0754d693bb6a4ad9bb29eb0e08e511b0
+      - b4d8b837e6014da4b755068903c6d69e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:14 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6472a688104d4225a036cc209c745ac3
+      - 66492af3155c491f88c66e440eddf322
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da9055b76c0e44ecb7001a3ab5cecac6
+      - 3b4a200321d34278ac9d4564a7e20c3d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a06abf3a27174926966a61c8963b249b
+      - b44b5e6c427e4eac8924e60455c3debf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa4ab08bb1d542beb101654d938620fe
+      - 060cf2a2da004fb09013bf0bda1a185e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 590e85ef51414787ad5b3fa49d57bd01
+      - 69cbb8cbdca8456582d3e991c7f46351
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 181001b59b0f41fd9a5dd8221ff54c8e
+      - 0fe63437d8c04860b262164e6f90daf1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,94 +3208,94 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a5d557aeab7144b5843c59e04ce8fee6
+      - 38d6a2ffb18d4fb1a8a6bce2d3facbbc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIxZWQ0MTI0LWI3ZDQtNDYy
-        Zi05MWY5LTJmNjJmYjdlMmI0NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VhM2VkYzQyLTI4NzAtNDJl
+        NC04ZWYzLTk2OGI5OGM0ZTMzYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:56 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWNkMTU5MjgtYWJiNS00N2YyLWIz
-        NTEtZmRhOGVkMWI0NmYxL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2EwYzVhZjJmLWVjZWUt
-        NDYxNC1iN2YzLTBhZDAyNGRmYWQ1MS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJl
-        ZC1hNTg0LTgxYTFkOGU0ZGFlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdk
-        ZWExNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzkwYTZjNmExLTM4NjUt
-        NDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZXMvMGI0NmU0OTAtYjM1Ny00YjRmLWIxYWQtOTg3MDNi
-        NWU3ZDEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8x
-        OWIzOTcyMy0wYjc1LTRkZmUtYWMzZi03NmZhZWJlODFmYjUvIiwiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFhNTc2NWVlLTcwNzgtNDMz
-        OC1hMDM2LWZkOTI3MzA0NTE5NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvMWYyNDQ2MjEtMGNiYi00YmU4LTk2MjMtM2JkZGMzYjEw
-        ZWIxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJkNjJjZjg0LTRjNTUtNDg5NC05
-        NDRmLTg2MjczNzk3NTZkMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYx
-        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0MTJmLTRjMzQtNGE0Mi1hYWY2
-        LTYyOTc1NDliMDM4OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNzAxYmEwMzctNWY4Zi00N2JkLWE5MGEtNDU4MTFmZTNmZDgwLyIs
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83MGJkMTJiMS00
-        MDcxLTRjNTktODMxYS03YTdhMjg1YjBkM2IvIiwiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVkNzYtNDRhZC05OWFmLWIz
-        MjAzNTA0NmViZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvN2VlMTJmOWMtMTc1Zi00NDY3LWJkMjItMzU5YjA2MWI1OGE2LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84M2FlMzc4Ni02ZmZl
-        LTQ2OWUtYjM4Zi1hNTQ4ZWFlZjVmYTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2EzZTAzY2QxLTNjMzQtNGNiYi05Zjg2LWY5Mjdm
-        NmFjMWY5Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        YTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2MjE0LyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQz
-        NmItYmQwNy1iODQwN2EzZWY4NzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzL2FhZTgzMzVkLTg1ZjItNGVlMS04ODljLThiNGQyODBm
-        NWVkMy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2
-        ZjcwZGEtNTlkOC00M2I3LThkYTItYzJiMTEwYTFmMWJlLyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iOGQ0ZTdhMS0wMzg3LTQ4YjEt
-        YTBkNi1jZjdhOThhZmRjNTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2I4ZTY0ZDRkLTIwZTAtNDdjMi05NTk2LTMzYTQzZjE0YmJi
-        NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRj
-        MWEtMGUwNy00MTZlLTg0YTctZWU0NTcyMzJiMDVkLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMWQ2OTMwYi0yNjFjLTRkZjQtOTY5
-        Yi1lMTU2MDVhZjNmMTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0OTk5ZDIxOWM0NC8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2RlNzUwNTQt
-        NDJkOS00MGVlLThlZTUtMDk1MWRmMzE3NWZhLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9jZTZmMTY5ZS1kOWZkLTRjMjQtODZjYi1j
-        MjUzYTZmZTU1MDkvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2QwNmI3OTk2LTQyNWEtNGE4NS04MWJiLWEyNDZjODAwZTliOC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRlM2I4NmUtZmE0
-        NC00YjY2LWFlYWQtZmY4NTBiOTI2ZTVjLyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNiNy0yYTM4
-        MjZkMDFkNmMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4ZjUwMmMzNDAxMi8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTVjYWUzZjMtYjJkMC00
-        MjJjLTllOTEtOGVkZDlkOWQxMTYyLyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2MtYjJjYS1kZWQzZTI3
-        ZmU2ZGEvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDdmMGUzN2UtYWIzMy00Zjg3LWI5
+        MzItMDc5ZTM5NTY4NmYyL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q5MTdjYWNiLWI3Y2Yt
+        NDhjZi05ODE2LTJmNDE0MjAxNzA1Yi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzIyNTBmMTdhLWJjMTgtNGNl
+        MS04YzZhLTA3YzRmMDY4MjU0Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy82NmYzNGYxYS0zNzA0LTQ4M2MtOGM1Ny0yM2IzOWVk
+        YTU1ZGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2E3YWZjYTk1LWIzYjYt
+        NGVjZC05YzQ2LTc3MWE0NGNkZGViOS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvMDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1
+        MjE1OGJiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8w
+        ZDRmNzdiMy0xNDgxLTRmNTItOWM3NS0xYmJhNzcwYjY3ZGUvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBk
+        Mi1hZjQzLTM4MDMxMzZkMTIyYS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMGY3NTdkMjQtNjc4Mi00NTEwLTliZDctMWY0ZDg5ZjE5
+        OGNiLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xMjMy
+        YzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2ZGE2OGEvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1i
+        ZjczLTc1MTgxOGZjNmYxNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgzNGQtNTdlYzRlZDlkNzlh
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zMzE5Y2Zh
+        MC1kZGZjLTQzYzAtOGE2ZS1kMWQ5OWQ0MWI2ZDgvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1
+        LTEzYTkzYjM5MmEwZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvNjkzYTRlYjItZDczOS00MDkyLTg5NmYtODM2MzBmZjNjNGZiLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4My0w
+        NjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFkZC1iNDU1LTgz
+        NGMyZjhkNTg4Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvNmViNWRlODEtZDYwNS00OTMxLThlNjQtNDZlMDFmMTUzMDAzLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3
+        LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhj
+        M2VlNzNiOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        NzYyOWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84YWVmODliMC1kM2IzLTRk
+        NDItYmJlMS1mYTBkODkwMTMzNTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzhiODNhODk3LTU4NGMtNDZhMi04MjdmLThiMDdkYWU5
+        N2JhZi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTJi
+        NjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgyLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5Zjkt
+        YTM2Yi04NTE4MDMzZjAzNjAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3
+        Yi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTU2NmFj
+        OWMtNTAwMC00MjEwLWJkMmItOTAzMzZkZDMwYzRjLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0
+        MS1jN2JlODFmNzkyNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzL2FlMzViYWYwLTU2ZjgtNGY5YS04NGYzLTFiMzEyNTRjZWRkNy8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzkt
+        ZTA1Ni00NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1l
+        MGYzMzdmNTE3Y2QvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2QwMWMxYmUwLWJmMmEtNDIwOS1iMTgxLThkNTk5ZmQwNzkzMy8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDUwOTg5MWEtZjIy
+        Mi00OTI5LWFmMmQtYzkxMDBhNDhhNmNjLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5LTRjNTAtOWNjNy0yYzgy
+        YWU3ODc4OGMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2U0OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZTRhODIyZDYtNGVmNC00
+        NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5
+        ODI2ZGYvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2883,7 +3308,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2901,21 +3326,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4754fa7c6f1c41aea105346d59306249
+      - addc8f8788ed4adaa45aba0e369171ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViY2YyYjcyLWE2MjctNGZj
-        MS1iNDAxLTdiNjNhMzUyYWExMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzYjMyNjUwLTg3NDgtNDJl
+        Yy1hMTcwLTFjMzg0ZjE4NDVkMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/21ed4124-b7d4-462f-91f9-2f62fb7e2b45/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ea3edc42-2870-42e4-8ef3-968b98c4e33b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2936,51 +3361,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5fcd34ad923642acb86e720097a28a4c
+      - cc5a72b26526443bbf5eb36a8dfa5440
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjFlZDQxMjQtYjdk
-        NC00NjJmLTkxZjktMmY2MmZiN2UyYjQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTUuNDcyMTUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWEzZWRjNDItMjg3
+        MC00MmU0LThlZjMtOTY4Yjk4YzRlMzNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NTYuNzI5NDEyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNWQ1NTdhZWFiNzE0NGI1ODQz
-        YzU5ZTA0Y2U4ZmVlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjE1LjUwNzY4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MTUuNjQzODUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzOGQ2YTJmZmIxOGQ0ZmIxYThh
+        NmJjZTJkM2ZhY2JiYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjU2LjgwNDgxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        NTcuMjUyODkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBjNWFmMmYtZWNl
-        ZS00NjE0LWI3ZjMtMGFkMDI0ZGZhZDUxLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2NhY2ItYjdj
+        Zi00OGNmLTk4MTYtMmY0MTQyMDE3MDViLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/21ed4124-b7d4-462f-91f9-2f62fb7e2b45/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ea3edc42-2870-42e4-8ef3-968b98c4e33b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3001,51 +3426,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1042ec86a2643578ee4d6d83dd60075
+      - 6439616735b14a948cff306484c2ee0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjFlZDQxMjQtYjdk
-        NC00NjJmLTkxZjktMmY2MmZiN2UyYjQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTUuNDcyMTUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWEzZWRjNDItMjg3
+        MC00MmU0LThlZjMtOTY4Yjk4YzRlMzNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NTYuNzI5NDEyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNWQ1NTdhZWFiNzE0NGI1ODQz
-        YzU5ZTA0Y2U4ZmVlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjE1LjUwNzY4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MTUuNjQzODUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzOGQ2YTJmZmIxOGQ0ZmIxYThh
+        NmJjZTJkM2ZhY2JiYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjU2LjgwNDgxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        NTcuMjUyODkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBjNWFmMmYtZWNl
-        ZS00NjE0LWI3ZjMtMGFkMDI0ZGZhZDUxLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2NhY2ItYjdj
+        Zi00OGNmLTk4MTYtMmY0MTQyMDE3MDViLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/21ed4124-b7d4-462f-91f9-2f62fb7e2b45/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ea3edc42-2870-42e4-8ef3-968b98c4e33b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3066,51 +3491,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 51a07bd99c4443e88637d9d5a650f800
+      - '092371e78432466bbac00bbe3f27514d'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjFlZDQxMjQtYjdk
-        NC00NjJmLTkxZjktMmY2MmZiN2UyYjQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTUuNDcyMTUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWEzZWRjNDItMjg3
+        MC00MmU0LThlZjMtOTY4Yjk4YzRlMzNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NTYuNzI5NDEyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNWQ1NTdhZWFiNzE0NGI1ODQz
-        YzU5ZTA0Y2U4ZmVlNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjE1LjUwNzY4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MTUuNjQzODUwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzOGQ2YTJmZmIxOGQ0ZmIxYThh
+        NmJjZTJkM2ZhY2JiYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjU2LjgwNDgxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        NTcuMjUyODkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBjNWFmMmYtZWNl
-        ZS00NjE0LWI3ZjMtMGFkMDI0ZGZhZDUxLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2NhY2ItYjdj
+        Zi00OGNmLTk4MTYtMmY0MTQyMDE3MDViLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ebcf2b72-a627-4fc1-b401-7b63a352aa13/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ea3edc42-2870-42e4-8ef3-968b98c4e33b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3131,55 +3556,120 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:15 GMT
+      - Fri, 29 Jul 2022 11:30:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d9728a597b746c0bca5eaa021d5b197
+      - eb08d1d7ac9640c8b0fab33c13b31d77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '416'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWJjZjJiNzItYTYy
-        Ny00ZmMxLWI0MDEtN2I2M2EzNTJhYTEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTUuNTMyNjk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWEzZWRjNDItMjg3
+        MC00MmU0LThlZjMtOTY4Yjk4YzRlMzNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NTYuNzI5NDEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzOGQ2YTJmZmIxOGQ0ZmIxYThh
+        NmJjZTJkM2ZhY2JiYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjU2LjgwNDgxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        NTcuMjUyODkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2NhY2ItYjdj
+        Zi00OGNmLTk4MTYtMmY0MTQyMDE3MDViLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:58 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b3b32650-8748-42ec-a170-1c384f1845d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7373ecc0fa8e45d79a09c23478bba2f1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjNiMzI2NTAtODc0
+        OC00MmVjLWExNzAtMWMzODRmMTg0NWQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6NTYuODM5MTE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiNDc1NGZhN2M2ZjFjNDFhZWExMDUzNDZkNTkz
-        MDYyNDkiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNToxNS42ODEy
-        NDlaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjE1Ljg1Nzk4
+        dCIsImxvZ2dpbmdfY2lkIjoiYWRkYzhmODc4OGVkNGFkYWE0NWFiYTBlMzY5
+        MTcxY2EiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMDo1Ny4zMjc3
+        MTVaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjU3Ljk2MzQ2
         M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBjNWFm
-        MmYtZWNlZS00NjE0LWI3ZjMtMGFkMDI0ZGZhZDUxL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2Nh
+        Y2ItYjdjZi00OGNmLTk4MTYtMmY0MTQyMDE3MDViL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2EwYzVhZjJmLWVjZWUtNDYxNC1iN2YzLTBh
-        ZDAyNGRmYWQ1MS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzVjZDE1OTI4LWFiYjUtNDdmMi1iMzUxLWZkYThlZDFiNDZm
-        MS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2Q5MTdjYWNiLWI3Y2YtNDhjZi05ODE2LTJm
+        NDE0MjAxNzA1Yi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzQ3ZjBlMzdlLWFiMzMtNGY4Ny1iOTMyLTA3OWUzOTU2ODZm
+        Mi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:15 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3187,7 +3677,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3200,101 +3690,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3e92ed94f1d4e13b13f21cf0171e22e
+      - a7d2274186444fca9364b20a5961c565
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3302,7 +3792,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3315,7 +3805,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3333,21 +3823,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 48688a7d997048d89ceb023859c074da
+      - 6c2cee0a8d2642d3b6c6dcdb1aad9b43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3355,7 +3845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3368,37 +3858,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 24ed104dcfd54e7fb31817d85c4631b0
+      - e962551ed50049a7a483050e590b4551
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3414,8 +3904,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3443,8 +3933,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3472,8 +3962,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3491,10 +3981,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3502,7 +3992,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3515,7 +4005,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3533,21 +4023,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf0f823f0a624b349fdd79ee3fe5a7cb
+      - 3ea8ecdf8dc143c09b4a749cda80730e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3555,7 +4045,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3568,7 +4058,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3586,21 +4076,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cacc80cf4ab249a58e650d8abf4fe040
+      - 5da6552950864ffcb50f155775a66713
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3608,7 +4098,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3621,7 +4111,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3639,21 +4129,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6361c66f7a474ffe9ef485b603093f91
+      - cf747bf5874547d6868cd948f00e75c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3661,7 +4151,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3674,101 +4164,101 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2868'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7003c34cbf2e4ee8bf3fdc32b3cff45d
+      - ddadfd8e4ca84c98a08c4bf2d7083665
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '863'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgzYWUz
-        Nzg2LTZmZmUtNDY5ZS1iMzhmLWE1NDhlYWVmNWZhMi8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkw
-        Zi1lZjBlLTRhZWYtYjNiNy0yYTM4MjZkMDFkNmMvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGI0NmU0OTAt
-        YjM1Ny00YjRmLWIxYWQtOTg3MDNiNWU3ZDEyLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc3MDJiYWQ2LTVk
-        NzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTkyNDRiNi0xNjdh
-        LTQwODQtODc1YS03OGY1MDJjMzQwMTIvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYmFmMjRjMWEtMGUwNy00
-        MTZlLTg0YTctZWU0NTcyMzJiMDVkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNl
-        Yi04MGIwLTk0OTk5ZDIxOWM0NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYjY2ZjcwZGEtNTlkOC00M2I3LThk
-        YTItYzJiMTEwYTFmMWJlLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzcwYmQxMmIxLTQwNzEtNGM1OS04MzFh
-        LTdhN2EyODViMGQzYi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy82YTc2NDEyZi00YzM0LTRhNDItYWFmNi02
-        Mjk3NTQ5YjAzODgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvYWFlODMzNWQtODVmMi00ZWUxLTg4OWMtOGI0
-        ZDI4MGY1ZWQzLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2NlNmYxNjllLWQ5ZmQtNGMyNC04NmNiLWMyNTNh
-        NmZlNTUwOS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2Yx
-        NGJiYjUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3
-        NWZhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIx
-        NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy83ZWUxMmY5Yy0xNzVmLTQ0NjctYmQyMi0zNTliMDYxYjU4YTYv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzYy
+        OWYzMGEtMTRmNy00NDU1LWEzY2EtMjRiZDhjNmI0ODM5LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q1MDk4
+        OTFhLWYyMjItNDkyOS1hZjJkLWM5MTAwYTQ4YTZjYy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4
+        MS1kNjA1LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ0Zjc3YjMt
+        MTQ4MS00ZjUyLTljNzUtMWJiYTc3MGI2N2RlLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhhZWY4OWIwLWQz
+        YjMtNGQ0Mi1iYmUxLWZhMGQ4OTAxMzM1MS8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hZTM1YmFmMC01NmY4
+        LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjJkZmYxM2UtZjg5Mi00
+        Yzc3LWI0YjQtNTg3Y2E3OTgyNmRmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkYzhjMDc2LWQ1MWQtNDFk
+        ZC1iNDU1LTgzNGMyZjhkNTg4Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2Mt
+        ODBjYi1mY2EzOTgwMDBjNzYvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1M2QtMTliYS00NmM3LTgz
+        NGQtNTdlYzRlZDlkNzlhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBlMjY4NzNhLWViMzctNDBkMi1hZjQz
+        LTM4MDMxMzZkMTIyYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0y
+        MTNiZjhlYTlkZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNzMzYTRhMDAtODg0ZS00YTAxLWIyNDAtNmUz
+        OGMzZWU3M2I5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkz
+        YjM5MmEwZC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy8xMjMyYzA1OC1mNmRkLTQ0NjctYjhlYi01Y2NjMGQ2
+        ZGE2OGEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIyNTA1OTFi
+        MjMyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzL2UxMTc0ZGIxLTc2MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMDFjMWJlMC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVhYWYxLyJ9
+        a2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3MC8ifSx7
+        Z2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZkOC8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEvIn0seyJw
+        cy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        ZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzJk
-        NjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yZDVl
-        NjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTliMzk3
-        MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVscF9ocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4ZDRlN2Ex
-        LTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBm
+        NzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNWNk
+        YmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTVjOTEw
+        NGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZhYzlj
+        LTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3776,7 +4266,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3789,7 +4279,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3807,21 +4297,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab689aa6df8547088b90edd4f4fab04c
+      - 5f6ecd1931e94316baa9f952694fc501
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3829,7 +4319,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3842,37 +4332,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '4276'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 751cae0e6b5b45c88d2608d35e64782e
+      - 4e9d8cc3a77b4712a44e04ae959836eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3888,8 +4378,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3917,8 +4407,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -3946,8 +4436,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -3965,10 +4455,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3976,7 +4466,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3989,7 +4479,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4007,21 +4497,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e6b87139bb14fe7b56257c7f1702788
+      - b7ada516e81f4e7eaafad70b814fb886
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4029,7 +4519,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4042,7 +4532,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4060,21 +4550,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 236ee32602d14e2d911875e0b6955d06
+      - 717e473fbb984465891c0bd9a61c8d5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4082,7 +4572,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4095,7 +4585,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:16 GMT
+      - Fri, 29 Jul 2022 11:30:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4113,21 +4603,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8de9596dd3541eb9a757c1361263d7e
+      - 7902c77a585d49758a6cf1e47fc43fce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4135,7 +4625,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4148,7 +4638,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4166,21 +4656,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94542ecb0d3841e582e47df1264bae61
+      - 30dc72d3600a4c4bb38ee9d08dad10d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4188,7 +4678,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4201,7 +4691,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4219,21 +4709,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e5e9be02860f40d995e18e1f8e073981
+      - 65740cd67f1d4ad1bab6cd161ee259b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4241,7 +4731,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4254,7 +4744,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4272,21 +4762,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3887a9d82a37487fab8c9ebbe7f27f71
+      - '07966c20c1b140c4bf3869c5afd07815'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5cd15928-abb5-47f2-b351-fda8ed1b46f1/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/47f0e37e-ab33-4f87-b932-079e395686f2/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4294,7 +4784,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4307,7 +4797,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4325,21 +4815,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7c07b3415a4548fd8d1d4f3bd1195af8
+      - e3429b905d0a4ab2adab2e46c0b019e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:00 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -4349,7 +4839,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4362,7 +4852,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4380,37 +4870,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5183e0ca2ddf45e2a1b4988b10784775
+      - e466f3f2d97049339b79711995295d50
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAzNDY4ODA3LWNhM2YtNDMw
-        NS04ODc1LTQ3OTI4MmE5NzQ2Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2OTUyZjlmLWFjNWMtNDgz
+        Ny05NWM3LTQzNWY4MjI1N2E4Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:00 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWNkMTU5MjgtYWJiNS00N2YyLWIz
-        NTEtZmRhOGVkMWI0NmYxL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2EwYzVhZjJmLWVjZWUt
-        NDYxNC1iN2YzLTBhZDAyNGRmYWQ1MS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMt
-        OWU5MS04ZWRkOWQ5ZDExNjIvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDdmMGUzN2UtYWIzMy00Zjg3LWI5
+        MzItMDc5ZTM5NTY4NmYyL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q5MTdjYWNiLWI3Y2Yt
+        NDhjZi05ODE2LTJmNDE0MjAxNzA1Yi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEt
+        YjVhOC1lMGYzMzdmNTE3Y2QvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
         YWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4423,7 +4913,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4441,21 +4931,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2055e5ae649846d983cbfc9a79d1cd18
+      - 9ef3b5d2358a4aac8e2c0de029e83233
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjNmUwMzQ1LTJmYzMtNGJj
-        MS04MTZiLWRmN2I2N2YwMDE0Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczNGNiYjUwLWFjYWMtNDc3
+        OS1iYTY1LWJiZWE4OWU0ZTY1NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/03468807-ca3f-4305-8875-479282a97466/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/26952f9f-ac5c-4837-95c7-435f82257a82/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4476,53 +4966,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cbb889ded7d945edab9c666900aee594
+      - beeee33839d44b46acedd1b8f04beffa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '387'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDM0Njg4MDctY2Ez
-        Zi00MzA1LTg4NzUtNDc5MjgyYTk3NDY2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTcuMzYwNTI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjY5NTJmOWYtYWM1
+        Yy00ODM3LTk1YzctNDM1ZjgyMjU3YTgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDAuNDEyMzA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1MTgzZTBjYTJkZGY0NWUyYTFi
-        NDk4OGIxMDc4NDc3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjE3LjM5NDY5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MTcuNTUzODM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlNDY2ZjNmMmQ5NzA0OTMzOWI3
+        OTcxMTk5NTI5NWQ1MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjAwLjQ3MzM2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        MDAuOTI0NzYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hMGM1YWYyZi1lY2VlLTQ2MTQtYjdmMy0wYWQwMjRkZmFkNTEvdmVyc2lv
+        bS9kOTE3Y2FjYi1iN2NmLTQ4Y2YtOTgxNi0yZjQxNDIwMTcwNWIvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBjNWFmMmYtZWNlZS00NjE0
-        LWI3ZjMtMGFkMDI0ZGZhZDUxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2NhY2ItYjdjZi00OGNm
+        LTk4MTYtMmY0MTQyMDE3MDViLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/03468807-ca3f-4305-8875-479282a97466/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/26952f9f-ac5c-4837-95c7-435f82257a82/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4543,53 +5033,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8cf3c66c8ab24421b7797935eb618c18
+      - 49c907468d3542849196ff71832773a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '387'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDM0Njg4MDctY2Ez
-        Zi00MzA1LTg4NzUtNDc5MjgyYTk3NDY2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTcuMzYwNTI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjY5NTJmOWYtYWM1
+        Yy00ODM3LTk1YzctNDM1ZjgyMjU3YTgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDAuNDEyMzA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1MTgzZTBjYTJkZGY0NWUyYTFi
-        NDk4OGIxMDc4NDc3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjE3LjM5NDY5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MTcuNTUzODM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlNDY2ZjNmMmQ5NzA0OTMzOWI3
+        OTcxMTk5NTI5NWQ1MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjAwLjQ3MzM2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        MDAuOTI0NzYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9hMGM1YWYyZi1lY2VlLTQ2MTQtYjdmMy0wYWQwMjRkZmFkNTEvdmVyc2lv
+        bS9kOTE3Y2FjYi1iN2NmLTQ4Y2YtOTgxNi0yZjQxNDIwMTcwNWIvdmVyc2lv
         bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBjNWFmMmYtZWNlZS00NjE0
-        LWI3ZjMtMGFkMDI0ZGZhZDUxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2NhY2ItYjdjZi00OGNm
+        LTk4MTYtMmY0MTQyMDE3MDViLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/dc6e0345-2fc3-4bc1-816b-df7b67f0014b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/26952f9f-ac5c-4837-95c7-435f82257a82/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4610,55 +5100,122 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:17 GMT
+      - Fri, 29 Jul 2022 11:31:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '697'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c0e4b82d1b694c0a84fe878b829988ea
+      - 8fb94c0869da4f6eae2dbba2f755aaa9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '414'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGM2ZTAzNDUtMmZj
-        My00YmMxLTgxNmItZGY3YjY3ZjAwMTRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MTcuNDEzOTE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjY5NTJmOWYtYWM1
+        Yy00ODM3LTk1YzctNDM1ZjgyMjU3YTgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDAuNDEyMzA1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlNDY2ZjNmMmQ5NzA0OTMzOWI3
+        OTcxMTk5NTI5NWQ1MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjAwLjQ3MzM2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        MDAuOTI0NzYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9kOTE3Y2FjYi1iN2NmLTQ4Y2YtOTgxNi0yZjQxNDIwMTcwNWIvdmVyc2lv
+        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2NhY2ItYjdjZi00OGNm
+        LTk4MTYtMmY0MTQyMDE3MDViLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/734cbb50-acac-4779-ba65-bbea89e4e655/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b8e520d5b8ce41a492ef5143afe39b83
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzM0Y2JiNTAtYWNh
+        Yy00Nzc5LWJhNjUtYmJlYTg5ZTRlNjU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MDAuNTA3MTI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiMjA1NWU1YWU2NDk4NDZkOTgzY2JmYzlhNzlk
-        MWNkMTgiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNToxNy41ODcy
-        MzFaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjE3Ljc0NTIz
-        NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiOWVmM2I1ZDIzNThhNGFhYzhlMmMwZGUwMjll
+        ODMyMzMiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMTowMC45OTE5
+        NjNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjAxLjQ4OTMw
+        NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBjNWFm
-        MmYtZWNlZS00NjE0LWI3ZjMtMGFkMDI0ZGZhZDUxL3ZlcnNpb25zLzMvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDkxN2Nh
+        Y2ItYjdjZi00OGNmLTk4MTYtMmY0MTQyMDE3MDViL3ZlcnNpb25zLzMvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2EwYzVhZjJmLWVjZWUtNDYxNC1iN2YzLTBh
-        ZDAyNGRmYWQ1MS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzVjZDE1OTI4LWFiYjUtNDdmMi1iMzUxLWZkYThlZDFiNDZm
-        MS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2Q5MTdjYWNiLWI3Y2YtNDhjZi05ODE2LTJm
+        NDE0MjAxNzA1Yi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzQ3ZjBlMzdlLWFiMzMtNGY4Ny1iOTMyLTA3OWUzOTU2ODZm
+        Mi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4666,7 +5223,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4679,41 +5236,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:18 GMT
+      - Fri, 29 Jul 2022 11:31:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c558fcdea49c4037aac0828dbfb0d7f4
+      - 05aee1fcc18748598e07599dd21086db
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDExNjIv
+        YWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3Y2Qv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4721,7 +5278,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4734,7 +5291,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:18 GMT
+      - Fri, 29 Jul 2022 11:31:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4752,21 +5309,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 53fa48248c74475e8fa06c816bb9a6d1
+      - c31d2c1dfd7b49ca9531ae893205cc46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4774,7 +5331,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4787,7 +5344,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:18 GMT
+      - Fri, 29 Jul 2022 11:31:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4805,21 +5362,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a801e966d5904311a2ef8a2e42e6b495
+      - 828f6f6ad7914722ac9dfde8dce8d59b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4827,7 +5384,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4840,7 +5397,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:18 GMT
+      - Fri, 29 Jul 2022 11:31:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4858,21 +5415,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e269a7237637438f99a543dc01de387b
+      - ec2dbd175c46466aa6d1488f246d6e74
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4880,7 +5437,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4893,7 +5450,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:18 GMT
+      - Fri, 29 Jul 2022 11:31:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4911,21 +5468,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 29f18145f9384626ac7d5cfed9dff96b
+      - a95919eff06046e7a9de5488506c7ac9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/a0c5af2f-ecee-4614-b7f3-0ad024dfad51/versions/3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d917cacb-b7cf-48cf-9816-2f414201705b/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4933,7 +5490,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4946,7 +5503,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:18 GMT
+      - Fri, 29 Jul 2022 11:31:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4964,16 +5521,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74884a3da41e4334a10b6bd04a223f59
+      - '096301f9ab5443b49531f13fe4f1ba62'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:02 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_errata_exclusion_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_errata_exclusion_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a970064feddf44fc964af1bdeaff15dd
+      - bfe837aaa589424d8f9c9e8c37ebede3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yMjFiYmQ0Mi1lZmVmLTRkZTktODY1Yy0yODJjODcxN2Q1MDIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNToyOS4wNjkzOTNa
+        cnBtL3JwbS9lMmUwNmNkMC1kNDk4LTRmZDAtOGMxYS01MWVjMzU2M2VmMTMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMToyMy4yMjA0NzFa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yMjFiYmQ0Mi1lZmVmLTRkZTktODY1Yy0yODJjODcxN2Q1MDIv
+        cnBtL3JwbS9lMmUwNmNkMC1kNDk4LTRmZDAtOGMxYS01MWVjMzU2M2VmMTMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzIyMWJi
-        ZDQyLWVmZWYtNGRlOS04NjVjLTI4MmM4NzE3ZDUwMi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UyZTA2
+        Y2QwLWQ0OTgtNGZkMC04YzFhLTUxZWMzNTYzZWYxMy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:38 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/221bbd42-efef-4de9-865c-282c8717d502/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 719b28e30de4454ba4c4f3ca5d49985d
+      - 0c13b0f28d4e41c68257fbb2d0be7e82
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiN2NjYTc0LWRkM2UtNDgx
-        NC1iYWI4LWNkZGJiNWQyNjExYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkNmFjYzk5LWExMjItNDI4
+        OS1iODJhLWFhNmQ2Y2VlMjBmNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c13bad86744b40f8b0fda4fdd467d08a
+      - 1db8a7e37670451dbacb324061e22186
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fb7cca74-dd3e-4814-bab8-cddbb5d2611c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fd6acc99-a122-4289-b82a-aa6d6cee20f5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3cbf1addd48945b184850ad897276ddb
+      - 498e2ef11ea3443e8049e2ca978a1e17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmI3Y2NhNzQtZGQz
-        ZS00ODE0LWJhYjgtY2RkYmI1ZDI2MTFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzUuMjc3NTg5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmQ2YWNjOTktYTEy
+        Mi00Mjg5LWI4MmEtYWE2ZDZjZWUyMGY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MzguNTczNzExWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MTliMjhlMzBkZTQ0NTRiYTRjNGYzY2E1
-        ZDQ5OTg1ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjM1LjMw
-        ODQwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MzUuNDMx
-        ODA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwYzEzYjBmMjhkNGU0MWM2ODI1N2ZiYjJk
+        MGJlN2U4MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjM4LjY3
+        Njg3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MzkuMDM2
+        NjM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjIxYmJkNDItZWZlZi00ZGU5
-        LTg2NWMtMjgyYzg3MTdkNTAyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTJlMDZjZDAtZDQ5OC00ZmQw
+        LThjMWEtNTFlYzM1NjNlZjEzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - added87a4859467ba93902b1eb79237a
+      - 48a361f619d94507908fc9da5c806cec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8f41cf8c8cb642a688f74abea465f52f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMjg4YmIyNjYtMmQ0NC00NTBjLWJlZDUtYjFiNzU0YmNhMmRk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MzIuMzQzODkz
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/288bb266-2d44-450c-bed5-b1b754bca2dd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - df09b1d46ccd411e85f066f0416b6299
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1MTI3ZmI0LTRiNjMtNDhj
+        ZS1iY2JjLWExZjYyZjZkZDcxOS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/35127fb4-4b63-48ce-bcbc-a1f62f6dd719/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 52857d9188b54f7bab7d81b7aeff0420
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzUxMjdmYjQtNGI2
+        My00OGNlLWJjYmMtYTFmNjJmNmRkNzE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MzkuMjYwNDYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZjA5YjFkNDZjY2Q0MTFlODVmMDY2ZjA0
+        MTZiNjI5OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjM5LjMx
+        ODU2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MzkuNTQy
+        NTUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49659db73c9945d49a34d2e0d7c7cf01
+      - 88d4114c57fc42bea11fdb4a25f6d878
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 357e3f6c714b409daf62dfbe76591063
+      - 2b76143731b84a4b89a81f48acd6f06f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0fc2e35acd0243d6a861627bee22805f
+      - c0674e7e7ce044228cdfcb1dd023c826
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d952aa507c2543fe85eaeb5aea91daad
+      - 4a524089f8934d8181d92aa394b99ff8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 9e5db2e6747b4e208b07ff48683cb602
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:39 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/5ea411d0-e98e-4f16-bebc-b68407ec783a/"
+      - "/pulp/api/v3/remotes/rpm/rpm/ae4b90f4-f7e8-42df-82cf-a28dc75872a1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c0ab2c1c0464d5e8ab16646592d5831
+      - a4b88a0104464fc295f4afe878c3a885
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVl
-        YTQxMWQwLWU5OGUtNGYxNi1iZWJjLWI2ODQwN2VjNzgzYS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjM1Ljg0ODgxN1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Fl
+        NGI5MGY0LWY3ZTgtNDJkZi04MmNmLWEyOGRjNzU4NzJhMS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjQwLjAwMjg0MFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjM1Ljg0ODgzNloiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjQwLjAwMjg4MFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:40 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:35 GMT
+      - Fri, 29 Jul 2022 11:31:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5744cf58f484407a97e345ff0550325d
+      - df65863c8fcd4af2bbdfbc423966306d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZDQ0NWE0NjctMjc1My00MDVjLWI4MTgtYmIwMWNjMmI5MzhiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MzUuOTYzMDgyWiIsInZl
+        cG0vZTBiMTZlZDgtN2I5NS00MGY2LWJkNjItYTc0OWE4MzZmZTFlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6NDAuMTk2Nzc1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZDQ0NWE0NjctMjc1My00MDVjLWI4MTgtYmIwMWNjMmI5MzhiL3ZlcnNp
+        cG0vZTBiMTZlZDgtN2I5NS00MGY2LWJkNjItYTc0OWE4MzZmZTFlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kNDQ1YTQ2Ny0y
-        NzUzLTQwNWMtYjgxOC1iYjAxY2MyYjkzOGIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGIxNmVkOC03
+        Yjk1LTQwZjYtYmQ2Mi1hNzQ5YTgzNmZlMWUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 024ebee5b53d46af89168e3853dced2c
+      - c1b28ed3fbf54054a5d566daea3dee09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83ZDc1NDJjMi03YzdhLTQ2NTAtOThkZC01ZDc4MzJiMWUxMWQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNToyOS43ODAwNTla
+        cnBtL3JwbS9kOTk1YWYwZS0zM2VjLTQ5NDktOThiYy0zNDIzOTU0ZmQzYWEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMToyNC42NDI4NDha
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83ZDc1NDJjMi03YzdhLTQ2NTAtOThkZC01ZDc4MzJiMWUxMWQv
+        cnBtL3JwbS9kOTk1YWYwZS0zM2VjLTQ5NDktOThiYy0zNDIzOTU0ZmQzYWEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdkNzU0
-        MmMyLTdjN2EtNDY1MC05OGRkLTVkNzgzMmIxZTExZC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q5OTVh
+        ZjBlLTMzZWMtNDk0OS05OGJjLTM0MjM5NTRmZDNhYS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:40 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7d7542c2-7c7a-4650-98dd-5d7832b1e11d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 52a46c5f87e941098b32b6cb1edfcc44
+      - e9afd2428a7a441cb6e8147cb6610159
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzYTA3ZjEwLTdmYjgtNGUw
-        Ni05NDJiLWM4MDhiNDc4NzBlZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3OGVjZTBhLWMyZTctNGU0
+        Yy05NDdiLWQwMDRiOTg0NWVkMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7bff4f47c1e34e468bd8224d34b16771
+      - fa62361409bd42d2a4391e0e9d32ae3f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vNzdlNzkxYTYtYmE4OC00YjU3LWJiYTYtMGFlMTQzYjc5MDcwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MjguOTA5ODg4WiIsIm5h
+        cG0vMmY2YmI4MzEtMzE5Ni00ZDc1LWE2N2UtMTdkNDBjYjdkMWVmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MjMuMDM2NDU1WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNTozMC4xMzI5MjJaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMTozMToyNS40MDEwODlaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:40 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/77e791a6-ba88-4b57-bba6-0ae143b79070/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/2f6bb831-3196-4d75-a67e-17d40cb7d1ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d124868ff9544d08956a35ffe071705
+      - c8b89a208b5b4428b6233038c6dd0afb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UwNzQ4MmY4LTFhNTgtNDc4
-        Ny1hNDFjLTdmZjVhYWUxNDE2MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiMGU5OWFkLWQ2ZGQtNGZi
+        MS1hODE1LTI2NzVjZWMwNzY0ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d3a07f10-7fb8-4e06-942b-c808b47870ed/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/078ece0a-c2e7-4e4c-947b-d004b9845ed3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed33d4ed1f564e7aacda46c1d2f82726
+      - e7d2e256d7ec4fecb9cd16bd756708cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDNhMDdmMTAtN2Zi
-        OC00ZTA2LTk0MmItYzgwOGI0Nzg3MGVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzYuMTQ0Mjg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDc4ZWNlMGEtYzJl
+        Ny00ZTRjLTk0N2ItZDAwNGI5ODQ1ZWQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NDAuNDkyOTg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MmE0NmM1Zjg3ZTk0MTA5OGIzMmI2Y2Ix
-        ZWRmY2M0NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjM2LjE5
-        MTkwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MzYuMjU1
-        MzQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlOWFmZDI0MjhhN2E0NDFjYjZlODE0N2Ni
+        NjYxMDE1OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjQwLjU0
+        NzQ3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NDAuODI3
+        MDExWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2Q3NTQyYzItN2M3YS00NjUw
-        LTk4ZGQtNWQ3ODMyYjFlMTFkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDk5NWFmMGUtMzNlYy00OTQ5
+        LTk4YmMtMzQyMzk1NGZkM2FhLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e07482f8-1a58-4787-a41c-7ff5aae14161/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8b0e99ad-d6dd-4fb1-a815-2675cec0764d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c49ae27adc324f559b989d7d37c16162
+      - e5b7be8dc90d44b4a6685bcbcb1eecaf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTA3NDgyZjgtMWE1
-        OC00Nzg3LWE0MWMtN2ZmNWFhZTE0MTYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzYuMjU0NTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGIwZTk5YWQtZDZk
+        ZC00ZmIxLWE4MTUtMjY3NWNlYzA3NjRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NDAuNjM3OTUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzZDEyNDg2OGZmOTU0NGQwODk1NmEzNWZm
-        ZTA3MTcwNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjM2LjI4
-        OTY0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MzYuMzMz
-        ODE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjOGI4OWEyMDhiNWI0NDI4YjYyMzMwMzhj
+        NmRkMGFmYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjQwLjcy
+        NDc1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NDAuOTUy
+        NjU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc3ZTc5MWE2LWJhODgtNGI1Ny1iYmE2
-        LTBhZTE0M2I3OTA3MC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzJmNmJiODMxLTMxOTYtNGQ3NS1hNjdl
+        LTE3ZDQwY2I3ZDFlZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 98dff35c698542ca8499d8efba589b21
+      - 1d58b308d70041ecbed7dd0639bcc0dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 727d69eb289640cfbdb0bac00caa540e
+      - 9e481a20299c4e5c9f3139c7b0f58db9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ebed45ca4b346f2b5d07ee815c9bb32
+      - e020a836f98a4511aaf67ff1602d1ca1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d6eef99df454ecfa2e72c862e33853d
+      - 25ad0521d003474fbde16a63626b2373
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f113b70c94234e80acb17fa77957cd69
+      - 8485c9be7d2545a1ac04be013400f11c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - efa8525b9a3e490d8491d6842e28eff9
+      - ee9935379fbf4772afddfa48141ce24c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:36 GMT
+      - Fri, 29 Jul 2022 11:31:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/"
+      - "/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d02356b0a9714199b1c5fa5acfb28aec
+      - 71ade04c757a4436bf50b55bba39ed04
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzU1MTRlYzYtNzFiNC00YTZmLTllZjEtMTNjMzhmZDg2ZjIzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MzYuNzYxMDk1WiIsInZl
+        cG0vNDllNWJmY2EtOWFjMi00MDYyLTg3MjctN2I0NjQwODE5NzM2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6NDEuNjM5NjY1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzU1MTRlYzYtNzFiNC00YTZmLTllZjEtMTNjMzhmZDg2ZjIzL3ZlcnNp
+        cG0vNDllNWJmY2EtOWFjMi00MDYyLTg3MjctN2I0NjQwODE5NzM2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNTUxNGVjNi03
-        MWI0LTRhNmYtOWVmMS0xM2MzOGZkODZmMjMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80OWU1YmZjYS05
+        YWMyLTQwNjItODcyNy03YjQ2NDA4MTk3MzYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:41 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/5ea411d0-e98e-4f16-bebc-b68407ec783a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/ae4b90f4-f7e8-42df-82cf-a28dc75872a1/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:37 GMT
+      - Fri, 29 Jul 2022 11:31:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 055fd24b40e24121b58f6d2b48f3a9b3
+      - acc51a20f5204161bfc87ba142540c10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4YTVkOTYxLWE1NTEtNDE5
-        ZC1iZDY1LWQxNGNkNjFhNTg5Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhZWYwNjU1LWIwMjgtNDE0
+        Ni1iOWVlLWQ2MzlkMWY5YWQyNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/98a5d961-a551-419d-bd65-d14cd61a589f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0aef0655-b028-4146-b9ee-d639d1f9ad24/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:37 GMT
+      - Fri, 29 Jul 2022 11:31:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 370d855ed1b748a5a77d362caf1ad28b
+      - 8dc6b32696d14d008493547740b16d76
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOThhNWQ5NjEtYTU1
-        MS00MTlkLWJkNjUtZDE0Y2Q2MWE1ODlmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzcuMDcwMzcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGFlZjA2NTUtYjAy
+        OC00MTQ2LWI5ZWUtZDYzOWQxZjlhZDI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NDIuMTAxMTg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwNTVmZDI0YjQwZTI0MTIxYjU4ZjZkMmI0
-        OGYzYTliMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjM3LjEy
-        MDQ5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MzcuMTQ1
-        ODIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhY2M1MWEyMGY1MjA0MTYxYmZjODdiYTE0
+        MjU0MGMxMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjQyLjMy
+        OTQ3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NDIuMzY1
+        MTc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVlYTQxMWQwLWU5OGUtNGYxNi1iZWJj
-        LWI2ODQwN2VjNzgzYS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2FlNGI5MGY0LWY3ZTgtNDJkZi04MmNm
+        LWEyOGRjNzU4NzJhMS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVlYTQx
-        MWQwLWU5OGUtNGYxNi1iZWJjLWI2ODQwN2VjNzgzYS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2FlNGI5
+        MGY0LWY3ZTgtNDJkZi04MmNmLWEyOGRjNzU4NzJhMS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:37 GMT
+      - Fri, 29 Jul 2022 11:31:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a7b1e04321904d899dc62bcb0b007169
+      - 721e0c5b9a154b66880e382057b81ff7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0ZjllNmZmLWIwMjktNDQx
-        Yy05YTc1LTgzYThkODZmMzhhOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIwMzdhNDQwLTVlZWQtNGQ2
+        MS1iNTU1LTI2OWM3Y2FiOWZkNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:42 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a4f9e6ff-b029-441c-9a75-83a8d86f38a8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2037a440-5eed-4d61-b555-269c7cab9fd6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,82 +1787,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:39 GMT
+      - Fri, 29 Jul 2022 11:31:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73218aa422ef468dacc74af60d312723
+      - f82ca09b6fea4effad92ef3ad7b89b88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '599'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTRmOWU2ZmYtYjAy
-        OS00NDFjLTlhNzUtODNhOGQ4NmYzOGE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzcuMzAxOTkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjAzN2E0NDAtNWVl
+        ZC00ZDYxLWI1NTUtMjY5YzdjYWI5ZmQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NDIuNTM1NTQ5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJhN2IxZTA0MzIxOTA0ZDg5OWRj
-        NjJiY2IwYjAwNzE2OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjM3LjMzNDI1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MzguOTQ3OTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI3MjFlMGM1YjlhMTU0YjY2ODgw
+        ZTM4MjA1N2I4MWZmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjQyLjU5NDU2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        NDcuMTA0MDAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
-        IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
-        bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
-        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
-        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZDQ0NWE0NjctMjc1My00MDVjLWI4MTgt
-        YmIwMWNjMmI5MzhiL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2Q0NDVhNDY3LTI3NTMtNDA1Yy1iODE4LWJiMDFjYzJiOTM4Yi8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS81ZWE0MTFkMC1lOThl
-        LTRmMTYtYmViYy1iNjg0MDdlYzc4M2EvIl19
+        IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5hZHZp
+        c29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6
+        NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBNZXRh
+        ZGF0YSBGaWxlcyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5nLm1ldGFkYXRh
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NSwi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFj
+        dHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2Rl
+        IjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
+        ZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFj
+        a2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6
+        MzIsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2UwYjE2ZWQ4LTdiOTUtNDBmNi1iZDYyLWE3
+        NDlhODM2ZmUxZS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9l
+        MGIxNmVkOC03Yjk1LTQwZjYtYmQ2Mi1hNzQ5YTgzNmZlMWUvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYWU0YjkwZjQtZjdlOC00
+        MmRmLTgyY2YtYTI4ZGM3NTg3MmExLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZDQ0NWE0NjctMjc1My00MDVjLWI4MTgtYmIwMWNjMmI5
-        MzhiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZTBiMTZlZDgtN2I5NS00MGY2LWJkNjItYTc0OWE4MzZm
+        ZTFlL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:39 GMT
+      - Fri, 29 Jul 2022 11:31:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9fe3b53d6cb042a6b24aee30577fc153
+      - a2bd930fddd3499281fc7f7c7aaa446d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyZTE1Y2M5LWMyMjUtNGZl
-        Yy1hMTI2LTUyMTcwOGY0NWIxOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyZjU1ZGI5LTRjNWYtNGQx
+        YS05NjEzLTk5YWZmNWYwZjlmMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c2e15cc9-c225-4fec-a126-521708f45b18/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/c2f55db9-4c5f-4d1a-9613-99aff5f0f9f0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:39 GMT
+      - Fri, 29 Jul 2022 11:31:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b572852e0544cd5a2460b7863eb7513
+      - d37e05c4faa34ba089997d3c8ad161e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '474'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJlMTVjYzktYzIy
-        NS00ZmVjLWExMjYtNTIxNzA4ZjQ1YjE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MzkuMTI1NzI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJmNTVkYjktNGM1
+        Zi00ZDFhLTk2MTMtOTlhZmY1ZjBmOWYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NDcuNDAzNDQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjlmZTNiNTNkNmNiMDQyYTZiMjRhZWUzMDU3
-        N2ZjMTUzIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MzkuMTU2
-        MDAyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNTozOS4zNDU3
-        ODBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImEyYmQ5MzBmZGRkMzQ5OTI4MWZjN2Y3Yzdh
+        YWE0NDZkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NDcuNDU3
+        NzE3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMTo0Ny45NDg3
+        MTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZTNmZDcy
-        ZmItYzYyNS00YzUzLWFkNmEtMGI4ZTIxZWExOTg0LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTI5MDg0
+        ZDgtMDc3YS00MWJjLWFlZWQtMWU0OTAzZTk5MTAxLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZDQ0NWE0NjctMjc1My00MDVjLWI4MTgtYmIwMWNj
-        MmI5MzhiLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZTBiMTZlZDgtN2I5NS00MGY2LWJkNjItYTc0OWE4
+        MzZmZTFlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:39 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 642cb66cfb484adebdfac7483303eeec
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:39 GMT
+      - Fri, 29 Jul 2022 11:31:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e42b370975e46078b320e7242c2864b
+      - 3cd7480da6a442c3b26a93c17ccbe22e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/129084d8-077a-41bc-aeed-1e4903e99101/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:39 GMT
+      - Fri, 29 Jul 2022 11:31:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 57b5446530304a6da5325aeaa6a93934
+      - f268486998f84e9cb12c83c3472aa23b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMTI5MDg0ZDgtMDc3YS00MWJjLWFlZWQtMWU0OTAzZTk5MTAxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6NDcuNjI5NzkzWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMGIxNmVkOC03Yjk1LTQwZjYtYmQ2Mi1hNzQ5YTgzNmZlMWUv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2UwYjE2ZWQ4LTdiOTUtNDBmNi1iZDYyLWE3NDlh
+        ODM2ZmUxZS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:48 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8xMjkwODRkOC0wNzdhLTQxYmMtYWVlZC0xZTQ5MDNlOTkxMDEv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e09eff6f17844ca88e489afda1a4e862
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5Yjc3NThjLTZhYWMtNGFm
+        OC05YzdmLWQ0ZTQ0MTkwNTRlYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e9b7758c-6aac-4af8-9c7f-d4e4419054ec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8ac29be1208541f88a2191c4ded127b7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTliNzc1OGMtNmFh
+        Yy00YWY4LTljN2YtZDRlNDQxOTA1NGVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NDguMjM3ODM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlMDllZmY2ZjE3ODQ0Y2E4OGU0ODlhZmRh
+        MWE0ZTg2MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjQ4LjQ1
+        MjY2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6NDguNzA4
+        NTg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNzVl
+        MWFkYzUtNGY5OC00ZjNiLThlNzYtZjUzOTkyMzJkZDQ2LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/75e1adc5-4f98-4f3b-8e76-f5399232dd46/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e35b43ff93884e06b9683b12b467f68c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzc1ZTFhZGM1LTRmOTgtNGYzYi04ZTc2LWY1Mzk5MjMyZGQ0Ni8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjQ4LjY4NDE1NloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMTI5MDg0ZDgtMDc3YS00MWJjLWFlZWQt
+        MWU0OTAzZTk5MTAxLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0b72724e36404eb68d9aefafb1bb30f4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ac815b59b4824c5eae2f5eccea5f261d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4d811429362b4e419bc0e6740f7df9e4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:39 GMT
+      - Fri, 29 Jul 2022 11:31:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b1194443a9ab4c6a94556b815608850b
+      - f76c7f187da6419aa742e815b54591b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:39 GMT
+      - Fri, 29 Jul 2022 11:31:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96383bec3b714cc0ab87bad350bdc76a
+      - 5e00286015d84e62805fb9ca21b7aec4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:39 GMT
+      - Fri, 29 Jul 2022 11:31:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3735f6c42c0f48bb852e2352ff9817aa
+      - 4491f4899b744aef93de6efcbb0ff575
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c1b2b0b904d431a9def9a3197ca6624
+      - 9f905f69cc0244dabeee23eea3e55e33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f2eebd26dae44eed951d6bbd793de6d1
+      - 92c5167747764829901a492f5cdb3cf9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 860ad926ffb04a4d91d773d4d01339ef
+      - 9356e61bec45405889b692220f3ef8d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d445a467-2753-405c-b818-bb01cc2b938b/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e0b16ed8-7b95-40f6-bd62-a749a836fe1e/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 465c0745547d45c0b8e099e818081f72
+      - '0884d25e0ed949328df259e4f4ca613b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:50 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,88 +3208,88 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e6dc096f366249a1b541027550cd5c8a
+      - 2288b164240244afb56d6d01d10fbaa6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5NzhiYTkxLTg5NGQtNDBl
-        Yi1hYzQxLWM1ODAwN2Y2ODM0MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0NjY0NTNhLTJhMGMtNDY2
+        MS04NmZlLWY2MmQyODM3NWViZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:50 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDQ0NWE0NjctMjc1My00MDVjLWI4
-        MTgtYmIwMWNjMmI5MzhiL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM1NTE0ZWM2LTcxYjQt
-        NGE2Zi05ZWYxLTEzYzM4ZmQ4NmYyMy8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJl
-        ZC1hNTg0LTgxYTFkOGU0ZGFlMS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy84ZmQ2Mjg4Yi1lNjgzLTQ2ZWYtOWI5NC1kMGU5MDRi
-        OWY2OGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OTBhNmM2YTEtMzg2NS00MmRhLWFmYTktNTE1NjUxZTk0YzdmLyIsIi9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wYjQ2ZTQ5MC1iMzU3LTRi
-        NGYtYjFhZC05ODcwM2I1ZTdkMTIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2ZmFlYmU4
-        MWZiNS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMWE1
-        NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0LyIsIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgt
-        OTYyMy0zYmRkYzNiMTBlYjEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4MTE4OGM5
-        NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNm
-        ODQtNGM1NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2My03YjIyLTRhYjktYWVl
-        Ni05NjQxZmIzZjVjNTEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzZhNzY0MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8i
-        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzAxYmEwMzct
-        NWY4Zi00N2JkLWE5MGEtNDU4MTFmZTNmZDgwLyIsIi9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MGJkMTJiMS00MDcxLTRjNTktODMxYS03
-        YTdhMjg1YjBkM2IvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzc3MDJiYWQ2LTVkNzYtNDRhZC05OWFmLWIzMjAzNTA0NmViZS8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvN2VlMTJmOWMtMTc1
-        Zi00NDY3LWJkMjItMzU5YjA2MWI1OGE2LyIsIi9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3
-        ZjZhYzFmOWMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2E4M2RhYzg3LTc1YjUtNGU3Yi04YjBiLWJmMTk4ZGNiNjIxNC8iLCIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYThjMzk2MzItZWNlOC00
-        MzZiLWJkMDctYjg0MDdhM2VmODcwLyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRkMjgw
-        ZjVlZDMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I2
-        NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00OGIx
-        LWEwZDYtY2Y3YTk4YWZkYzU1LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9iOGU2NGQ0ZC0yMGUwLTQ3YzItOTU5Ni0zM2E0M2YxNGJi
-        YjUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2JhZjI0
-        YzFhLTBlMDctNDE2ZS04NGE3LWVlNDU3MjMyYjA1ZC8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvYzFkNjkzMGItMjYxYy00ZGY0LTk2
-        OWItZTE1NjA1YWYzZjEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9jMzY0ZTkyZS0xNjQxLTRjZWItODBiMC05NDk5OWQyMTljNDQv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NlNmYxNjll
-        LWQ5ZmQtNGMyNC04NmNiLWMyNTNhNmZlNTUwOS8iLCIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmIt
-        YTI0NmM4MDBlOWI4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9lNGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U1NzYwOTBmLWVm
-        MGUtNGFlZi1iM2I3LTJhMzgyNmQwMWQ2Yy8iLCIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvZTU5MjQ0YjYtMTY3YS00MDg0LTg3NWEtNzhm
-        NTAyYzM0MDEyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDExNjIvIiwiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2VjMjdkMzU5LTkzODgt
-        NDg3Yy1iMmNhLWRlZDNlMjdmZTZkYS8iXX1dLCJkZXBlbmRlbmN5X3NvbHZp
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBiMTZlZDgtN2I5NS00MGY2LWJk
+        NjItYTc0OWE4MzZmZTFlL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQ5ZTViZmNhLTlhYzIt
+        NDA2Mi04NzI3LTdiNDY0MDgxOTczNi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzIyNTBmMTdhLWJjMTgtNGNl
+        MS04YzZhLTA3YzRmMDY4MjU0Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy82NmYzNGYxYS0zNzA0LTQ4M2MtOGM1Ny0yM2IzOWVk
+        YTU1ZGIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsIi9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wOGM5ZTgxZS0wMjhkLTQ3
+        ZjQtYmM5ZC1hYThmOTUyMTU4YmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzBkNGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBi
+        NjdkZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGUy
+        Njg3M2EtZWIzNy00MGQyLWFmNDMtMzgwMzEzNmQxMjJhLyIsIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZjc1N2QyNC02NzgyLTQ1MTAt
+        OWJkNy0xZjRkODlmMTk4Y2IvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgxOGZjNmYx
+        NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMzJkYTk1
+        M2QtMTliYS00NmM3LTgzNGQtNTdlYzRlZDlkNzlhLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy8zMzE5Y2ZhMC1kZGZjLTQzYzAtOGE2
+        ZS1kMWQ5OWQ0MWI2ZDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5MmEwZC8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjIt
+        ZDczOS00MDkyLTg5NmYtODM2MzBmZjNjNGZiLyIsIi9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4My0wNjI2LTRlMTgtOGJlYy02
+        M2Q2YmNlZDdiYjMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzZkYzhjMDc2LWQ1MWQtNDFkZC1iNDU1LTgzNGMyZjhkNTg4Yy8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNmViNWRlODEtZDYw
+        NS00OTMxLThlNjQtNDZlMDFmMTUzMDAzLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1hNzg3LTQ4Y2MtODBjYi1mY2Ez
+        OTgwMDBjNzYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNiOS8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGFlZjg5YjAtZDNiMy00
+        ZDQyLWJiZTEtZmEwZDg5MDEzMzUxLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy84YjgzYTg5Ny01ODRjLTQ2YTItODI3Zi04YjA3ZGFl
+        OTdiYWYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzky
+        YjY2YWNiLTYwYjktNGVmNC1iNTFhLTlhYjZhNzUwMGY4Mi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOTliNmFmZWYtZjIxYi00OWY5
+        LWEzNmItODUxODAzM2YwMzYwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00MjljNGY5YmZj
+        N2IvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1NjZh
+        YzljLTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvYTVjZGJkZGUtYmNhOC00NTI5LTli
+        NDEtYzdiZTgxZjc5MjQ4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9hZTM1YmFmMC01NmY4LTRmOWEtODRmMy0xYjMxMjU0Y2VkZDcv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NhZjM4MDc5
+        LWUwNTYtNDRlNy05NjNlLWUyYzIzM2M4ZmY4NC8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9ycG0vcGFja2FnZXMvY2VhMWQ4OTctMmFhMS00NDhhLWI1YTgt
+        ZTBmMzM3ZjUxN2NkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9kNTA5ODkxYS1mMjIyLTQ5MjktYWYyZC1jOTEwMGE0OGE2Y2MvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2UxMTc0ZGIxLTc2
+        MTktNGM1MC05Y2M3LTJjODJhZTc4Nzg4Yy8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvZTQ5N2UwZWUtM2JhOS00YTNlLWE3YmEtZGIy
+        NTA1OTFiMjMyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy9lNGE4MjJkNi00ZWY0LTQ2ZmUtYTI3Yy0yMTNiZjhlYTlkZjQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YyZGZmMTNlLWY4OTIt
+        NGM3Ny1iNGI0LTU4N2NhNzk4MjZkZi8iXX1dLCJkZXBlbmRlbmN5X3NvbHZp
         bmciOmZhbHNlfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2877,7 +3302,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2895,21 +3320,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 881f4cc02e204e05b77ae65b5ffd7209
+      - 06376d0b13cd4f2eba656fc6de242bc9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3OTJkNjQ5LTdjYTQtNDk0
-        My04NWE5LWZlN2Q5MzFmZmVlYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxMDQ2NWNjLWRlYzAtNGYy
+        OC1iNzVlLTFkODExNzI0YzMxYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c978ba91-894d-40eb-ac41-c58007f68340/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0466453a-2a0c-4661-86fe-f62d28375ebe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2930,51 +3355,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d6f139451c444789a2527d3f6d0512e7
+      - 9e0ec622a2b94aa6a479504d6fbc9c4e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzk3OGJhOTEtODk0
-        ZC00MGViLWFjNDEtYzU4MDA3ZjY4MzQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6NDAuNDI4NDEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQ2NjQ1M2EtMmEw
+        Yy00NjYxLTg2ZmUtZjYyZDI4Mzc1ZWJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTAuNzI2MDg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlNmRjMDk2ZjM2NjI0OWExYjU0
-        MTAyNzU1MGNkNWM4YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjQwLjQ2OTQ3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        NDAuNjAzMjc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMjg4YjE2NDI0MDI0NGFmYjU2
+        ZDZkMDFkMTBmYmFhNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjUwLjgxMzUxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        NTEuMTI0OTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzU1MTRlYzYtNzFi
-        NC00YTZmLTllZjEtMTNjMzhmZDg2ZjIzLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDllNWJmY2EtOWFj
+        Mi00MDYyLTg3MjctN2I0NjQwODE5NzM2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c978ba91-894d-40eb-ac41-c58007f68340/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0466453a-2a0c-4661-86fe-f62d28375ebe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2995,51 +3420,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c17b3008ed084d2198926ed7f47c8bd0
+      - 3b19a5e1446847bbb129a72b5ed8f37d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzk3OGJhOTEtODk0
-        ZC00MGViLWFjNDEtYzU4MDA3ZjY4MzQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6NDAuNDI4NDEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQ2NjQ1M2EtMmEw
+        Yy00NjYxLTg2ZmUtZjYyZDI4Mzc1ZWJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTAuNzI2MDg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlNmRjMDk2ZjM2NjI0OWExYjU0
-        MTAyNzU1MGNkNWM4YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjQwLjQ2OTQ3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        NDAuNjAzMjc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMjg4YjE2NDI0MDI0NGFmYjU2
+        ZDZkMDFkMTBmYmFhNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjUwLjgxMzUxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        NTEuMTI0OTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzU1MTRlYzYtNzFi
-        NC00YTZmLTllZjEtMTNjMzhmZDg2ZjIzLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDllNWJmY2EtOWFj
+        Mi00MDYyLTg3MjctN2I0NjQwODE5NzM2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c978ba91-894d-40eb-ac41-c58007f68340/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0466453a-2a0c-4661-86fe-f62d28375ebe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3060,51 +3485,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9b9519eb2a584bc6848b78a1b49808f5
+      - b4e89855770c489c8b03449b587c506c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzk3OGJhOTEtODk0
-        ZC00MGViLWFjNDEtYzU4MDA3ZjY4MzQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6NDAuNDI4NDEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQ2NjQ1M2EtMmEw
+        Yy00NjYxLTg2ZmUtZjYyZDI4Mzc1ZWJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTAuNzI2MDg3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlNmRjMDk2ZjM2NjI0OWExYjU0
-        MTAyNzU1MGNkNWM4YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjQwLjQ2OTQ3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        NDAuNjAzMjc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMjg4YjE2NDI0MDI0NGFmYjU2
+        ZDZkMDFkMTBmYmFhNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjUwLjgxMzUxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        NTEuMTI0OTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzU1MTRlYzYtNzFi
-        NC00YTZmLTllZjEtMTNjMzhmZDg2ZjIzLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDllNWJmY2EtOWFj
+        Mi00MDYyLTg3MjctN2I0NjQwODE5NzM2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a792d649-7ca4-4943-85a9-fe7d931ffeea/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/610465cc-dec0-4f28-b75e-1d811724c31c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3125,55 +3550,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:40 GMT
+      - Fri, 29 Jul 2022 11:31:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 369a6e780d0a4b5c9787ee6ee64b4934
+      - 5a7f116343d44157b6d2d01b68a0b553
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '415'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTc5MmQ2NDktN2Nh
-        NC00OTQzLTg1YTktZmU3ZDkzMWZmZWVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6NDAuNDk0ODc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjEwNDY1Y2MtZGVj
+        MC00ZjI4LWI3NWUtMWQ4MTE3MjRjMzFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6NTAuODQwMTI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiODgxZjRjYzAyZTIwNGUwNWI3N2FlNjViNWZm
-        ZDcyMDkiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNTo0MC42MzQ3
-        MTNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjQwLjgwNDY1
-        OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvMGRmMThhZmYtNjRiOC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiMDYzNzZkMGIxM2NkNGYyZWJhNjU2ZmM2ZGUy
+        NDJiYzkiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMTo1MS4xOTUx
+        MzdaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjUxLjcyNjYz
+        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzU1MTRl
-        YzYtNzFiNC00YTZmLTllZjEtMTNjMzhmZDg2ZjIzL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDllNWJm
+        Y2EtOWFjMi00MDYyLTg3MjctN2I0NjQwODE5NzM2L3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzM1NTE0ZWM2LTcxYjQtNGE2Zi05ZWYxLTEz
-        YzM4ZmQ4NmYyMy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2Q0NDVhNDY3LTI3NTMtNDA1Yy1iODE4LWJiMDFjYzJiOTM4
-        Yi8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzQ5ZTViZmNhLTlhYzItNDA2Mi04NzI3LTdi
+        NDY0MDgxOTczNi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2UwYjE2ZWQ4LTdiOTUtNDBmNi1iZDYyLWE3NDlhODM2ZmUx
+        ZS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3181,7 +3606,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3194,95 +3619,95 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2604'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2a776cc818da49edac7b429c7d9eff1a
+      - d95411ddd6f54a628e4ea3c1fb878b29
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '793'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MjksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U1NzYw
-        OTBmLWVmMGUtNGFlZi1iM2I3LTJhMzgyNmQwMWQ2Yy8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wYjQ2ZTQ5
-        MC1iMzU3LTRiNGYtYjFhZC05ODcwM2I1ZTdkMTIvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzcwMmJhZDYt
-        NWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2ZWJlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2
-        N2EtNDA4NC04NzVhLTc4ZjUwMmMzNDAxMi8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iYWYyNGMxYS0wZTA3
-        LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzM2NGU5MmUtMTY0MS00
-        Y2ViLTgwYjAtOTQ5OTlkMjE5YzQ0LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2VjMjdkMzU5LTkzODgtNDg3
-        Yy1iMmNhLWRlZDNlMjdmZTZkYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iNjZmNzBkYS01OWQ4LTQzYjct
-        OGRhMi1jMmIxMTBhMWYxYmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgz
-        MWEtN2E3YTI4NWIwZDNiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0MTJmLTRjMzQtNGE0Mi1hYWY2
-        LTYyOTc1NDliMDM4OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04
-        YjRkMjgwZjVlZDMvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2Y2ItYzI1
-        M2E2ZmU1NTA5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2I4ZTY0ZDRkLTIwZTAtNDdjMi05NTk2LTMzYTQz
-        ZjE0YmJiNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hODNkYWM4Ny03NWI1LTRlN2ItOGIwYi1iZjE5OGRj
-        YjYyMTQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2VlMTJmOWMtMTc1Zi00NDY3LWJkMjItMzU5YjA2MWI1
-        OGE2LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3
-        MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDUw
+        OTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNjLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZlYjVk
+        ZTgxLWQ2MDUtNDkzMS04ZTY0LTQ2ZTAxZjE1MzAwMy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZDRmNzdi
+        My0xNDgxLTRmNTItOWM3NS0xYmJhNzcwYjY3ZGUvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGFlZjg5YjAt
+        ZDNiMy00ZDQyLWJiZTEtZmEwZDg5MDEzMzUxLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2FlMzViYWYwLTU2
+        ZjgtNGY5YS04NGYzLTFiMzEyNTRjZWRkNy8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMmRmZjEzZS1mODky
+        LTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00
+        MWRkLWI0NTUtODM0YzJmOGQ1ODhjLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZmMWM5MGIwLWE3ODctNDhj
+        Yy04MGNiLWZjYTM5ODAwMGM3Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zMmRhOTUzZC0xOWJhLTQ2Yzct
+        ODM0ZC01N2VjNGVkOWQ3OWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMGUyNjg3M2EtZWIzNy00MGQyLWFm
+        NDMtMzgwMzEzNmQxMjJhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0YTgyMmQ2LTRlZjQtNDZmZS1hMjdj
+        LTIxM2JmOGVhOWRmNC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy83MzNhNGEwMC04ODRlLTRhMDEtYjI0MC02
+        ZTM4YzNlZTczYjkvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDRlODkwMGQtNzIyMS00NDA4LTkwMDUtMTNh
+        OTNiMzkyYTBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzL2U0OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUw
+        NTkxYjIzMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5LTRjNTAtOWNjNy0yYzgyYWU3
+        ODc4OGMvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3
+        YmFmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZk
+        OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9
+        a2FnZXMvMDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzJkNjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7
+        Z2VzLzBmNzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yZDVlNjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJw
+        cy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MTliMzk3MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4
-        ZDRlN2ExLTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MTVjOTEwNGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1
+        NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3290,7 +3715,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3303,7 +3728,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3321,21 +3746,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 694794ac1c29475f94c56d0651af8bfb
+      - aa77178f4244477ca3b492271ba07966
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3343,7 +3768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3356,37 +3781,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2976'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94a16911748e4cde92f3a09ea69a43ee
+      - 1c8765dfb28d4a23b01685250d1544b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '707'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3402,8 +3827,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3431,8 +3856,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy84ZmQ2Mjg4Yi1lNjgzLTQ2ZWYtOWI5NC1kMGU5MDRiOWY2OGIvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzI2NDJaIiwi
+        cmllcy83N2ZlMjc1YS0wZGU3LTQ5OTQtYjBlMy1lMzYxOTZlYmY3ZmYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjQ5NDJaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1OCIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDkiLCJkZXNjcmlwdGlvbiI6IkdvcmlsbGFfRXJyYXR1bSIs
         Imlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOSIsImZyb21zdHIi
@@ -3450,10 +3875,10 @@ http_interactions:
         NjIifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3461,7 +3886,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3474,7 +3899,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3492,21 +3917,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b309c3a45a1046f59c75907046aebe59
+      - 5ff5ccbf3e9842a3be5fd52a542afd20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3514,7 +3939,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3527,7 +3952,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3545,21 +3970,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e894ba658774db4b33e0b5cce4f9380
+      - af67d7c0faaa45fc9b28fed89bea9ca1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3567,7 +3992,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3580,7 +4005,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3598,21 +4023,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 22ff0fb6ef544dee8829c5850ca6a71d
+      - 5cf658455655423c94f3df18d3eb8618
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3620,7 +4045,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3633,95 +4058,95 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2604'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bc6e21f623aa474f99315eab034d8b7a
+      - 8bb8eecc5aa845ca83399ab91a879cb5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '793'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MjksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
         LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzcwMWJhMDM3LTVmOGYtNDdiZC1hOTBhLTQ1ODExZmUzZmQ4MC8i
+        Y2thZ2VzL2EwYjJmZmNiLWIzODAtNGFiOS1iYjhiLTQyOWM0ZjliZmM3Yi8i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9hM2UwM2NkMS0zYzM0LTRjYmItOWY4Ni1mOTI3ZjZhYzFmOWMvIn0s
+        YWdlcy82OTNhNGViMi1kNzM5LTQwOTItODk2Zi04MzYzMGZmM2M0ZmIvIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvNGVlYWI2NjMtN2IyMi00YWI5LWFlZTYtOTY0MWZiM2Y1YzUxLyJ9LHsi
+        ZXMvNmE1ZjY2ODMtMDYyNi00ZTE4LThiZWMtNjNkNmJjZWQ3YmIzLyJ9LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        L2U1Y2FlM2YzLWIyZDAtNDIyYy05ZTkxLThlZGQ5ZDlkMTE2Mi8ifSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9l
-        NGUzYjg2ZS1mYTQ0LTRiNjYtYWVhZC1mZjg1MGI5MjZlNWMvIn0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzFk
-        NjkzMGItMjYxYy00ZGY0LTk2OWItZTE1NjA1YWYzZjEyLyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U1NzYw
-        OTBmLWVmMGUtNGFlZi1iM2I3LTJhMzgyNmQwMWQ2Yy8ifSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wYjQ2ZTQ5
-        MC1iMzU3LTRiNGYtYjFhZC05ODcwM2I1ZTdkMTIvIn0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNzcwMmJhZDYt
-        NWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2ZWJlLyJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2
-        N2EtNDA4NC04NzVhLTc4ZjUwMmMzNDAxMi8ifSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iYWYyNGMxYS0wZTA3
-        LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIn0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzM2NGU5MmUtMTY0MS00
-        Y2ViLTgwYjAtOTQ5OTlkMjE5YzQ0LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2VjMjdkMzU5LTkzODgtNDg3
-        Yy1iMmNhLWRlZDNlMjdmZTZkYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9iNjZmNzBkYS01OWQ4LTQzYjct
-        OGRhMi1jMmIxMTBhMWYxYmUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgz
-        MWEtN2E3YTI4NWIwZDNiLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0MTJmLTRjMzQtNGE0Mi1hYWY2
-        LTYyOTc1NDliMDM4OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04
-        YjRkMjgwZjVlZDMvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2Y2ItYzI1
-        M2E2ZmU1NTA5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzL2I4ZTY0ZDRkLTIwZTAtNDdjMi05NTk2LTMzYTQz
-        ZjE0YmJiNS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hODNkYWM4Ny03NWI1LTRlN2ItOGIwYi1iZjE5OGRj
-        YjYyMTQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvN2VlMTJmOWMtMTc1Zi00NDY3LWJkMjItMzU5YjA2MWI1
-        OGE2LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
-        L3BhY2thZ2VzL2E4YzM5NjMyLWVjZTgtNDM2Yi1iZDA3LWI4NDA3YTNlZjg3
-        MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRkYzNiMTBlYjEv
+        L2NlYTFkODk3LTJhYTEtNDQ4YS1iNWE4LWUwZjMzN2Y1MTdjZC8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85
+        OWI2YWZlZi1mMjFiLTQ5ZjktYTM2Yi04NTE4MDMzZjAzNjAvIn0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZDUw
+        OTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNjLyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZlYjVk
+        ZTgxLWQ2MDUtNDkzMS04ZTY0LTQ2ZTAxZjE1MzAwMy8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZDRmNzdi
+        My0xNDgxLTRmNTItOWM3NS0xYmJhNzcwYjY3ZGUvIn0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvOGFlZjg5YjAt
+        ZDNiMy00ZDQyLWJiZTEtZmEwZDg5MDEzMzUxLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2FlMzViYWYwLTU2
+        ZjgtNGY5YS04NGYzLTFiMzEyNTRjZWRkNy8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mMmRmZjEzZS1mODky
+        LTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00
+        MWRkLWI0NTUtODM0YzJmOGQ1ODhjLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZmMWM5MGIwLWE3ODctNDhj
+        Yy04MGNiLWZjYTM5ODAwMGM3Ni8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zMmRhOTUzZC0xOWJhLTQ2Yzct
+        ODM0ZC01N2VjNGVkOWQ3OWEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvMGUyNjg3M2EtZWIzNy00MGQyLWFm
+        NDMtMzgwMzEzNmQxMjJhLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0YTgyMmQ2LTRlZjQtNDZmZS1hMjdj
+        LTIxM2JmOGVhOWRmNC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy83MzNhNGEwMC04ODRlLTRhMDEtYjI0MC02
+        ZTM4YzNlZTczYjkvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vcGFja2FnZXMvNDRlODkwMGQtNzIyMS00NDA4LTkwMDUtMTNh
+        OTNiMzkyYTBkLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzL2U0OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUw
+        NTkxYjIzMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5LTRjNTAtOWNjNy0yYzgyYWU3
+        ODc4OGMvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3
+        YmFmLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzMzMTljZmEwLWRkZmMtNDNjMC04YTZlLWQxZDk5ZDQxYjZk
+        OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9jYWYzODA3OS1lMDU2LTQ0ZTctOTYzZS1lMmMyMzNjOGZmODQv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZDA2Yjc5OTYtNDI1YS00YTg1LTgxYmItYTI0NmM4MDBlOWI4LyJ9
+        a2FnZXMvMDhjOWU4MWUtMDI4ZC00N2Y0LWJjOWQtYWE4Zjk1MjE1OGJiLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzJkNjJjZjg0LTRjNTUtNDg5NC05NDRmLTg2MjczNzk3NTZkMi8ifSx7
+        Z2VzLzBmNzU3ZDI0LTY3ODItNDUxMC05YmQ3LTFmNGQ4OWYxOThjYi8ifSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8yZDVlNjYxOC0wYjBkLTRiOWYtOWQ4ZC0xNWM0ODExODhjOTUvIn0seyJw
+        cy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIn0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
-        MTliMzk3MjMtMGI3NS00ZGZlLWFjM2YtNzZmYWViZTgxZmI1LyJ9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2I4
-        ZDRlN2ExLTAzODctNDhiMS1hMGQ2LWNmN2E5OGFmZGM1NS8ifV19
+        MTVjOTEwNGYtMTIzMy00NmM0LWJmNzMtNzUxODE4ZmM2ZjE1LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E1
+        NjZhYzljLTUwMDAtNDIxMC1iZDJiLTkwMzM2ZGQzMGM0Yy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3729,7 +4154,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3742,7 +4167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3760,21 +4185,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 17f0d3bdf63f4a0880f1e32823ead471
+      - d3d222c122d840e1b90cb2ebfbaea70e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3782,7 +4207,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3795,37 +4220,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '2976'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7f8e9d5eac7646ffa4584957b23b91a3
+      - 23abf594099543f982455bc4aa7c05b2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '707'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -3841,8 +4266,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -3870,8 +4295,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy84ZmQ2Mjg4Yi1lNjgzLTQ2ZWYtOWI5NC1kMGU5MDRiOWY2OGIvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzI2NDJaIiwi
+        cmllcy83N2ZlMjc1YS0wZGU3LTQ5OTQtYjBlMy1lMzYxOTZlYmY3ZmYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjQ5NDJaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1OCIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDkiLCJkZXNjcmlwdGlvbiI6IkdvcmlsbGFfRXJyYXR1bSIs
         Imlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOSIsImZyb21zdHIi
@@ -3889,10 +4314,10 @@ http_interactions:
         NjIifV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZh
         bHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3900,7 +4325,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3913,7 +4338,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3931,21 +4356,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1ad370c744a4327958602613a7b253a
+      - c9f160265cf5469c908f8aa716a74679
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3953,7 +4378,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3966,7 +4391,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3984,21 +4409,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4c80b3adfd264e13b9b5aa5738c52d9a
+      - 9f32792a66c64b1c937fca0de52b9206
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/35514ec6-71b4-4a6f-9ef1-13c38fd86f23/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/49e5bfca-9ac2-4062-8727-7b4640819736/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4006,7 +4431,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -4019,7 +4444,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:41 GMT
+      - Fri, 29 Jul 2022 11:31:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4037,16 +4462,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a6a5eb390da24c368c1995e2571d72b1
+      - 0fc2505741fe4a76bf2d5300a65b0ed9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:53 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_errata_inclusion_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_errata_inclusion_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fdb253681c1546569b18d7e4ed2b35a2
+      - 3da9fa4f2bff4634bdfdb8403d61d8a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMjRmMjc1ZC04OWFiLTQxMWMtYWE2MS1iMzlkMWU1NjQ3NTEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo1Ny42MTYyMTda
+        cnBtL3JwbS9lNTlkZTMxYi05NjQ0LTQ0NDAtYjUwOS0zOTQzNjU4NTNhYzMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTo1Ni40Nzc1MjVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMjRmMjc1ZC04OWFiLTQxMWMtYWE2MS1iMzlkMWU1NjQ3NTEv
+        cnBtL3JwbS9lNTlkZTMxYi05NjQ0LTQ0NDAtYjUwOS0zOTQzNjU4NTNhYzMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UyNGYy
-        NzVkLTg5YWItNDExYy1hYTYxLWIzOWQxZTU2NDc1MS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2U1OWRl
+        MzFiLTk2NDQtNDQ0MC1iNTA5LTM5NDM2NTg1M2FjMy92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:09 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/e24f275d-89ab-411c-aa61-b39d1e564751/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e59de31b-9644-4440-b509-394365853ac3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c11d518e82214ed89689bfdb247a9d2d
+      - 075a138421f94d17b8f5c80f81493578
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0NDQ2Y2M4LTk2NjUtNDhi
-        Mi1hYjJjLWNiMDk4NTU5MGNhYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzNDg1OGZhLWJiNzQtNDU0
+        OS05M2M1LTJlY2FjYTNjN2I0OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8c49474b4bb547679ca3388f8c249617
+      - d49dba7de6fd4f2e9d592aad6c1b42f8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/34446cc8-9665-48b2-ab2c-cb0985590cab/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/834858fa-bb74-4549-93c5-2ecaca3c7b48/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '0799faaaecef44bfbc0fc162364183ba'
+      - 6c1997e82e704d56aefc3ed81740ae6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzQ0NDZjYzgtOTY2
-        NS00OGIyLWFiMmMtY2IwOTg1NTkwY2FiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDMuNDE4MDc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODM0ODU4ZmEtYmI3
+        NC00NTQ5LTkzYzUtMmVjYWNhM2M3YjQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MTAuMDIwNzk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMTFkNTE4ZTgyMjE0ZWQ4OTY4OWJmZGIy
-        NDdhOWQyZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjAzLjQ0
-        ODkwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MDMuNTcx
-        OTMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNzVhMTM4NDIxZjk0ZDE3YjhmNWM4MGY4
+        MTQ5MzU3OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjEwLjEx
+        NjE2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MTAuNDM2
+        MTczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTI0ZjI3NWQtODlhYi00MTFj
-        LWFhNjEtYjM5ZDFlNTY0NzUxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTU5ZGUzMWItOTY0NC00NDQw
+        LWI1MDktMzk0MzY1ODUzYWMzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 63679f1c9dcb4c428ddb07162765722b
+      - 7f38f4e6223a4d8384e3aaf6273b98a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4d20914ea15344ae8bc9243c89740e79
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMmJiNzIxNzItYzg1Yi00YTlhLWI5MzQtYWIzMWNkZjYwNjli
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MDQuNDY5ODQ4
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:10 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/2bb72172-c85b-4a9a-b934-ab31cdf6069b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 21be152fab1b4a80ba5a9b5a0664149f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY0NGQyNzU1LTAwZDEtNGYw
+        YS1hM2VjLTgwNzFjNDczMWIyZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:10 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/644d2755-00d1-4f0a-a3ec-8071c4731b2e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0c88175b05b9425fb1a5eb7ef60f53e2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjQ0ZDI3NTUtMDBk
+        MS00ZjBhLWEzZWMtODA3MWM0NzMxYjJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MTAuNzk1MjAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMWJlMTUyZmFiMWI0YTgwYmE1YTliNWEw
+        NjY0MTQ5ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjEwLjg0
+        NDAzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MTEuMDI3
+        MjI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4eaef0a47595495dbfac66ed21a168f6
+      - fac9ce377088435f90c7b03a0cce1792
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 35f7dde24ff9493b8980e5e355dd6db1
+      - b19994f62dc648bda2b0958be2dd57c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8ce6d7ded33407e84e078472b3c2589
+      - c54a5a7c539541edbaa875015389cc0f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 65f29fdb38bd430881e5c318aa89dbdc
+      - 3c57865da3a341999bcf1e53ea1f5c03
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 16b53b62869b43d687495cdc4da224dc
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:03 GMT
+      - Fri, 29 Jul 2022 11:32:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/ded847e6-a690-421f-b828-4abbd3d6492e/"
+      - "/pulp/api/v3/remotes/rpm/rpm/948cafed-43a8-4b9f-bdbc-e6b489aeb9c9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a9e9b81f8096403ba82af2ad83a5e182
+      - c351a21a38ff4c68bd2212658a813fc3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Rl
-        ZDg0N2U2LWE2OTAtNDIxZi1iODI4LTRhYmJkM2Q2NDkyZS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjAzLjk3MjE0NFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk0
+        OGNhZmVkLTQzYTgtNGI5Zi1iZGJjLWU2YjQ4OWFlYjljOS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjExLjQ1MjE0MFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI1OjAzLjk3MjE2NFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjExLjQ1MjE2NVoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:03 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/"
+      - "/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f1ee166fd5a1454982f231d620029239
+      - bf054cddb1d84e3280d04cdf6292e38a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2M0MGM1NzQtODg1NS00YjM0LWE3OTYtZWIxMzY2ZWNkYmM1LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MDQuMDgzNTcyWiIsInZl
+        cG0vODUxYTVmNTQtYjY2My00MTE3LWE0ZGUtM2U4OWUzNmE2ZDkxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MTEuNjQ4OTAyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2M0MGM1NzQtODg1NS00YjM0LWE3OTYtZWIxMzY2ZWNkYmM1L3ZlcnNp
+        cG0vODUxYTVmNTQtYjY2My00MTE3LWE0ZGUtM2U4OWUzNmE2ZDkxL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83YzQwYzU3NC04
-        ODU1LTRiMzQtYTc5Ni1lYjEzNjZlY2RiYzUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84NTFhNWY1NC1i
+        NjYzLTQxMTctYTRkZS0zZTg5ZTM2YTZkOTEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56ec21381b0248498f182c2a3cff832d
+      - a9d389ca8842447db98ddb9bc54faa4d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80NzgyNzRmNy05YTViLTRhMzktYjZlZS04NTUxYjk3OGVkZTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo1OC4zNTAzMzda
+        cnBtL3JwbS8yMTNjMGU1NC0yYmYyLTQ3MDYtODRhOC1lZjBmZWM2OGJhOGEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTo1Ny44MDk3MTNa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80NzgyNzRmNy05YTViLTRhMzktYjZlZS04NTUxYjk3OGVkZTMv
+        cnBtL3JwbS8yMTNjMGU1NC0yYmYyLTQ3MDYtODRhOC1lZjBmZWM2OGJhOGEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQ3ODI3
-        NGY3LTlhNWItNGEzOS1iNmVlLTg1NTFiOTc4ZWRlMy92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzIxM2Mw
+        ZTU0LTJiZjItNDcwNi04NGE4LWVmMGZlYzY4YmE4YS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/478274f7-9a5b-4a39-b6ee-8551b978ede3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/213c0e54-2bf2-4706-84a8-ef0fec68ba8a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 140d225969984d5e811e6d904767ace4
+      - b669696d6c764eafb6c45992a4c9afb9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3ZDRkYTU0LWUyOTItNDUy
-        Yi05ZGNjLTljNzcxYmVkYTdmMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlZjM4M2YxLWUxNDYtNDI4
+        ZS1hOTk4LTUxY2RjOGY5NWM3MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:11 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - aa3e3e652b7046e8ae8b1827f8286582
+      - d50d2ca2258d442183c50ccb8c52bed8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vOTk2M2RjYzQtOTYyYS00NTQxLWE2NWEtMzhmZWJiYWYwZDM1LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NTcuNTAyMzA4WiIsIm5h
+        cG0vYzlmOTk3OGYtOWI1ZS00M2Y1LTg3MTUtNDZjMTE3NTY0N2ZiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6NTYuMjk0NDk5WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDo1OC43MzM0ODFaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTo1OC4zNTkxODFaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/9963dcc4-962a-4541-a65a-38febbaf0d35/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c9f9978f-9b5e-43f5-8715-46c1175647fb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d50a5896828f40c7b65c1179e80b720c
+      - 631ad01886b34f6d92b56092537eb438
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4MWM5OWFjLTk5OTUtNGNk
-        ZC1iYjJiLTM2MTY1Nzc4ZjMwZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjMTc1YTBmLTE1OTYtNDQ1
+        OS05Y2U4LTU2OWE4N2JhNTgyOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d7d4da54-e292-452b-9dcc-9c771beda7f3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/def383f1-e146-428e-a998-51cdc8f95c70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6b8f243932c043dd9c3aa2b8255dd98c
+      - d87d45de8e6f4efa863c8fb117553d20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDdkNGRhNTQtZTI5
-        Mi00NTJiLTlkY2MtOWM3NzFiZWRhN2YzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDQuMjY0Mjc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGVmMzgzZjEtZTE0
+        Ni00MjhlLWE5OTgtNTFjZGM4Zjk1YzcwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MTEuOTM4ODAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxNDBkMjI1OTY5OTg0ZDVlODExZTZkOTA0
-        NzY3YWNlNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjA0LjI5
-        NjM3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MDQuMzQ5
-        Njc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiNjY5Njk2ZDZjNzY0ZWFmYjZjNDU5OTJh
+        NGM5YWZiOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjExLjk5
+        NDM4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MTIuMTEz
+        MTg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDc4Mjc0ZjctOWE1Yi00YTM5
-        LWI2ZWUtODU1MWI5NzhlZGUzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjEzYzBlNTQtMmJmMi00NzA2
+        LTg0YTgtZWYwZmVjNjhiYThhLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/381c99ac-9995-4cdd-bb2b-36165778f30e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/dc175a0f-1596-4459-9ce8-569a87ba5829/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b0c1885f8b3c4f3caebaadecb064748b
+      - 7562e496dd62444eb7e6179030b4e235
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzgxYzk5YWMtOTk5
-        NS00Y2RkLWJiMmItMzYxNjU3NzhmMzBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDQuMzUyMTY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGMxNzVhMGYtMTU5
+        Ni00NDU5LTljZTgtNTY5YTg3YmE1ODI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MTIuMDkxMjMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkNTBhNTg5NjgyOGY0MGM3YjY1YzExNzll
-        ODBiNzIwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjA0LjM4
-        NDU0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MDQuNDI2
-        OTE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2MzFhZDAxODg2YjM0ZjZkOTJiNTYwOTI1
+        MzdlYjQzOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjEyLjE1
+        MzQ5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MTIuMzYy
+        NzM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk5NjNkY2M0LTk2MmEtNDU0MS1hNjVh
-        LTM4ZmViYmFmMGQzNS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M5Zjk5NzhmLTliNWUtNDNmNS04NzE1
+        LTQ2YzExNzU2NDdmYi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1928517b759e4e239e158b223207e69c
+      - cda43933478043289ef7e130fe49a42d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 246c4f57e7874f1980709d5a0e4a1514
+      - 50fafd69583d40eeb1ee41be37684c58
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd91a938f8bb49689dd74b66a4b95a05
+      - 7037f381b87141d89eaa918e11155838
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1144381a272641b3b48b766b6587fe78
+      - b5cd8b9b31f1479a837ea5077f9f214c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 430da93a0b8a4942a2b50f63c2a37eb4
+      - fc5ec858b2a44fcfa004a8a7bdb35dd7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 778f601304f94fd78ec3ca502b798e13
+      - a5df51f1aa0847f5ba5dbf93a37a7121
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:12 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:04 GMT
+      - Fri, 29 Jul 2022 11:32:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/"
+      - "/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e394eda41b1242228130c7a0f7c76732
+      - 4741cd7c3d0c4854b0a8b7dc90c546bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzdhOTA1ZjItOWI3ZC00YjJhLTk5M2YtNWZiNWUwMWVmM2NmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjU6MDQuODAwNzEwWiIsInZl
+        cG0vYjYxNWU1YWItN2Q2My00YWUzLTgxNzYtYzEyZjc1ZmU4ZGFmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MTMuMDE5ODYxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNzdhOTA1ZjItOWI3ZC00YjJhLTk5M2YtNWZiNWUwMWVmM2NmL3ZlcnNp
+        cG0vYjYxNWU1YWItN2Q2My00YWUzLTgxNzYtYzEyZjc1ZmU4ZGFmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83N2E5MDVmMi05
-        YjdkLTRiMmEtOTkzZi01ZmI1ZTAxZWYzY2YvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iNjE1ZTVhYi03
+        ZDYzLTRhZTMtODE3Ni1jMTJmNzVmZThkYWYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:04 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:13 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/ded847e6-a690-421f-b828-4abbd3d6492e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/948cafed-43a8-4b9f-bdbc-e6b489aeb9c9/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:05 GMT
+      - Fri, 29 Jul 2022 11:32:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f6c8c12847fd40d499190f9b78c44cb7
+      - 96dec21cd6cf4874807dcf57ed6cf95c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlYWQ5MjE2LTliNWQtNGY5
-        Ny05YjM5LTEzOTE5ZTVhNTZiYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0MzdjOWRhLWUyZDQtNDZk
+        NC1hMDMwLWE0OTljNDNmMTAyOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/eead9216-9b5d-4f97-9b39-13919e5a56bc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/e437c9da-e2d4-46d4-a030-a499c43f1029/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:05 GMT
+      - Fri, 29 Jul 2022 11:32:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56feed8d030a4259a974e993a9a8cca5
+      - c25415e38bc544dd8db919c6ed7c196d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWVhZDkyMTYtOWI1
-        ZC00Zjk3LTliMzktMTM5MTllNWE1NmJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDUuMDY3MzAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTQzN2M5ZGEtZTJk
+        NC00NmQ0LWEwMzAtYTQ5OWM0M2YxMDI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MTMuNDczNDc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmNmM4YzEyODQ3ZmQ0MGQ0OTkxOTBmOWI3
-        OGM0NGNiNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjA1LjA5
-        OTE4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MDUuMTIx
-        NjAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5NmRlYzIxY2Q2Y2Y0ODc0ODA3ZGNmNTdl
+        ZDZjZjk1YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjEzLjU0
+        OTY4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MTMuNTgz
+        NzYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2RlZDg0N2U2LWE2OTAtNDIxZi1iODI4
-        LTRhYmJkM2Q2NDkyZS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk0OGNhZmVkLTQzYTgtNGI5Zi1iZGJj
+        LWU2YjQ4OWFlYjljOS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:13 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2RlZDg0
-        N2U2LWE2OTAtNDIxZi1iODI4LTRhYmJkM2Q2NDkyZS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk0OGNh
+        ZmVkLTQzYTgtNGI5Zi1iZGJjLWU2YjQ4OWFlYjljOS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:05 GMT
+      - Fri, 29 Jul 2022 11:32:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 132c2c4219d34a1e8bdf751e45667bd8
+      - ff86e588b5ca4bd5af1770d075a59811
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlNWMzYzUxLTY1YTctNGI3
-        Ny04OWFiLWI1YjFjZGY3NjYyMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2NDVhMWJiLWZmNWMtNDZi
+        ZS1iMThjLWVjODdkYzE0ODRlZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:05 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:13 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/be5c3c51-65a7-4b77-89ab-b5b1cdf76622/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/1645a1bb-ff5c-46be-b18c-ec87dc1484ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:07 GMT
+      - Fri, 29 Jul 2022 11:32:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c47753bd80204e4d96a809cfc8464268
+      - e96be9bd979c4858beb701eef724cad8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '600'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmU1YzNjNTEtNjVh
-        Ny00Yjc3LTg5YWItYjViMWNkZjc2NjIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDUuMjQyNDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTY0NWExYmItZmY1
+        Yy00NmJlLWIxOGMtZWM4N2RjMTQ4NGVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MTMuNzk0MDEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxMzJjMmM0MjE5ZDM0YTFlOGJk
-        Zjc1MWU0NTY2N2JkOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjA1LjI3MTUzMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MDYuODgwMzg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmZjg2ZTU4OGI1Y2E0YmQ1YWYx
+        NzcwZDA3NWE1OTgxMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjEzLjg1NjI3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MTcuODc4NDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vN2M0MGM1NzQtODg1NS00YjM0LWE3OTYt
-        ZWIxMzY2ZWNkYmM1L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzdjNDBjNTc0LTg4NTUtNGIzNC1hNzk2LWViMTM2NmVjZGJjNS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9kZWQ4NDdlNi1hNjkw
-        LTQyMWYtYjgyOC00YWJiZDNkNjQ5MmUvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzg1MWE1ZjU0LWI2NjMtNDExNy1hNGRlLTNl
+        ODllMzZhNmQ5MS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84
+        NTFhNWY1NC1iNjYzLTQxMTctYTRkZS0zZTg5ZTM2YTZkOTEvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vOTQ4Y2FmZWQtNDNhOC00
+        YjlmLWJkYmMtZTZiNDg5YWViOWM5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:17 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vN2M0MGM1NzQtODg1NS00YjM0LWE3OTYtZWIxMzY2ZWNk
-        YmM1L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vODUxYTVmNTQtYjY2My00MTE3LWE0ZGUtM2U4OWUzNmE2
+        ZDkxL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:07 GMT
+      - Fri, 29 Jul 2022 11:32:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af6fedd8360543eab88c97a93cd21d80
+      - 79610b1f8e734b4aa6e10ebc2921102f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzODEwYzBmLWJmMzgtNDZh
-        OC1iZDkwLTY4YjNhMTI4YmQ1MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4YjE4ZDU4LWIxMjMtNDY5
+        NC05NWEyLTdmZGMzN2NhMGEyNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:18 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/13810c0f-bf38-46a8-bd90-68b3a128bd50/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/38b18d58-b123-4694-95a2-7fdc37ca0a25/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:07 GMT
+      - Fri, 29 Jul 2022 11:32:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - df330e7fba194f1cafb61a2ded017147
+      - 3e1199c19bf540ebac0d40754de47b62
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTM4MTBjMGYtYmYz
-        OC00NmE4LWJkOTAtNjhiM2ExMjhiZDUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDcuMTYwMTQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzhiMThkNTgtYjEy
+        My00Njk0LTk1YTItN2ZkYzM3Y2EwYTI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MTguMjMwMTEyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImFmNmZlZGQ4MzYwNTQzZWFiODhjOTdhOTNj
-        ZDIxZDgwIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6MDcuMjA0
-        NjE0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNTowNy4zOTUz
-        OTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6Ijc5NjEwYjFmOGU3MzRiNGFhNmUxMGViYzI5
+        MjExMDJmIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MTguNDc2
+        MzIxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMjoxOC45ODgy
+        MzFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzU5ZGU1NTc1LTNkZDctNDllZS05ZjY2LTA1OTgzYTRiZjIwOC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZGI2MWJi
-        ZDQtZGZiNC00MTRmLThkMzktYzQwNDE3YTVlYzYyLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMGUwZmJj
+        MTItYzY3ZS00ZGFmLWJhYmQtZDU2MGIyYjdhNGNlLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vN2M0MGM1NzQtODg1NS00YjM0LWE3OTYtZWIxMzY2
-        ZWNkYmM1LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vODUxYTVmNTQtYjY2My00MTE3LWE0ZGUtM2U4OWUz
+        NmE2ZDkxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:07 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 27ea41c2adc341aaba7e23eb0bfb8440
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:25:07 GMT
+      - Fri, 29 Jul 2022 11:32:19 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c988c2813c5495a9c039d9ee58a051c
+      - e79c61e2769b45a298f24334b7604054
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/0e0fbc12-c67e-4daf-babd-d560b2b7a4ce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:07 GMT
+      - Fri, 29 Jul 2022 11:32:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 15b7882ef1cb4cc2873d1be58966d2fc
+      - 15290b91e9fc4699891febd71b4411c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMGUwZmJjMTItYzY3ZS00ZGFmLWJhYmQtZDU2MGIyYjdhNGNlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzI6MTguNTA3ODIyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84NTFhNWY1NC1iNjYzLTQxMTctYTRkZS0zZTg5ZTM2YTZkOTEv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzg1MWE1ZjU0LWI2NjMtNDExNy1hNGRlLTNlODll
+        MzZhNmQ5MS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:19 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8wZTBmYmMxMi1jNjdlLTRkYWYtYmFiZC1kNTYwYjJiN2E0Y2Uv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a1ebc5f9fc8b4f7fae63d1a3c90ff4d6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwNDFhZjFkLTVmNDgtNDg1
+        YS04YmUxLWFkNTkyNjBmZGYxZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9041af1d-5f48-485a-8be1-ad59260fdf1f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - daf7d53f561f4da392c17df127a7191b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTA0MWFmMWQtNWY0
+        OC00ODVhLThiZTEtYWQ1OTI2MGZkZjFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MTkuMzQyNjAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhMWViYzVmOWZjOGI0ZjdmYWU2M2QxYTNj
+        OTBmZjRkNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjE5LjM5
+        ODQyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6MTkuNjk3
+        NTIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vY2Vi
+        M2VmZDEtOTQyZC00OTdkLTlmZjQtYzNmZDRlOTZlMTM5LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/ceb3efd1-942d-497d-9ff4-c3fd4e96e139/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:19 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 629f577d639d4a4b8d8e3e723ea12dec
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2NlYjNlZmQxLTk0MmQtNDk3ZC05ZmY0LWMzZmQ0ZTk2ZTEzOS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMyOjE5LjY3MzA2OFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMGUwZmJjMTItYzY3ZS00ZGFmLWJhYmQt
+        ZDU2MGIyYjdhNGNlLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:19 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4911803ec22b4378b04828ab1ddad4fb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:20 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bb38606b3332417ca1f74220878f3864
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:32:20 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:32:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3eb59e4972b44f56aaebf68346fb88b3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:07 GMT
+      - Fri, 29 Jul 2022 11:32:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b34ab563b01d477cae1d21be0a282fc6
+      - 5c3e0efdb6c242c58efc4f3b5aaeedf3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:07 GMT
+      - Fri, 29 Jul 2022 11:32:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9df3705713c943b38b58b00b43586b2b
+      - 94411ce203c74551b8f7c3aeac00ea6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:07 GMT
+      - Fri, 29 Jul 2022 11:32:20 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6c594feb9a904ae183ef6ea4b77bbf04
+      - 01b7c5d67525440591bf05c24ad8ed95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:07 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:20 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25d819a5dadf4082aa256ae199a3fba5
+      - 9d7beb582e994f2ba0f95f4a3ce0aedd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af95d5445c6b4b23b7aac374857279f0
+      - 837db9317f5540b888e0e4906d8c1727
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 99dc5278355c4f149efd8b21c6cf0608
+      - 7edfac4f640149b6afcb32e9175fbbfc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7c40c574-8855-4b34-a796-eb1366ecdbc5/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/851a5f54-b663-4117-a4de-3e89e36a6d91/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 34f15c28bc164d2ea1a68fd43f127f4c
+      - b4e0cb6e0e9448a9828f519807fd734f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:21 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,42 +3208,42 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 98950b7213114eef8baac119d9a665d8
+      - a4b4a4ab134a41bb9fbb4660a25af312
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhZmI2NWFhLTBjYjUtNDU2
-        NC1iNWNiLTAxNTAwMzA2MTlmOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2NmFiZGQ2LTZhNTktNDE4
+        OC1iNzU5LTRhYmE2MTJkNWIyMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:21 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2M0MGM1NzQtODg1NS00YjM0LWE3
-        OTYtZWIxMzY2ZWNkYmM1L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzc3YTkwNWYyLTliN2Qt
-        NGIyYS05OTNmLTVmYjVlMDFlZjNjZi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzYwMTVkZGM5LTVmZTktNGU4
-        MC04NTkyLTM3Y2Q4N2RlYTE0OC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNDRjOGQwZWYtMGYyNi00MTUyLWJhMzctY2U4N2FjNzVh
-        YWYxLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84M2Fl
-        Mzc4Ni02ZmZlLTQ2OWUtYjM4Zi1hNTQ4ZWFlZjVmYTIvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2NkZTc1MDU0LTQyZDktNDBlZS04
-        ZWU1LTA5NTFkZjMxNzVmYS8iXX1dLCJkZXBlbmRlbmN5X3NvbHZpbmciOmZh
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODUxYTVmNTQtYjY2My00MTE3LWE0
+        ZGUtM2U4OWUzNmE2ZDkxL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I2MTVlNWFiLTdkNjMt
+        NGFlMy04MTc2LWMxMmY3NWZlOGRhZi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2E3YWZjYTk1LWIzYjYtNGVj
+        ZC05YzQ2LTc3MWE0NGNkZGViOS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMTIzMmMwNTgtZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRh
+        NjhhLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy83NjI5
+        ZjMwYS0xNGY3LTQ0NTUtYTNjYS0yNGJkOGM2YjQ4MzkvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2QwMWMxYmUwLWJmMmEtNDIwOS1i
+        MTgxLThkNTk5ZmQwNzkzMy8iXX1dLCJkZXBlbmRlbmN5X3NvbHZpbmciOmZh
         bHNlfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2831,7 +3256,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2849,21 +3274,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '084c34e433474a1e8fbda3da0d5fbac0'
+      - a96b4ecf4e4b46cab4134d83e17d33dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3MmQ3YmZjLWI4NDUtNDcy
-        Yi05NWJlLTcxZGNlMDJmZjI4ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAwMGYyZGNkLTg5YzUtNDg5
+        Yi1hOTAyLWI3YjExZGU4MjJkZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2afb65aa-0cb5-4564-b5cb-0150030619f8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a66abdd6-6a59-4188-b759-4aba612d5b22/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2884,51 +3309,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ff3fe83f5104277bc61d374eb6f6c04
+      - 447f89756927436cb5861f3c930420dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmFmYjY1YWEtMGNi
-        NS00NTY0LWI1Y2ItMDE1MDAzMDYxOWY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDguMzM1ODE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY2YWJkZDYtNmE1
+        OS00MTg4LWI3NTktNGFiYTYxMmQ1YjIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjEuNjQ2MzcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ODk1MGI3MjEzMTE0ZWVmOGJh
-        YWMxMTlkOWE2NjVkOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjA4LjM2ODM0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MDguNTA1NDc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNGI0YTRhYjEzNGE0MWJiOWZi
+        YjQ2NjBhMjVhZjMxMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjIxLjg4NzI4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MjIuMTkyMzM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzdhOTA1ZjItOWI3
-        ZC00YjJhLTk5M2YtNWZiNWUwMWVmM2NmLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjYxNWU1YWItN2Q2
+        My00YWUzLTgxNzYtYzEyZjc1ZmU4ZGFmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2afb65aa-0cb5-4564-b5cb-0150030619f8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a66abdd6-6a59-4188-b759-4aba612d5b22/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2949,51 +3374,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 389c2a2a40944f67b2cd5b089aa2c963
+      - a018df5db7b84985915be8353f64986a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmFmYjY1YWEtMGNi
-        NS00NTY0LWI1Y2ItMDE1MDAzMDYxOWY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDguMzM1ODE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY2YWJkZDYtNmE1
+        OS00MTg4LWI3NTktNGFiYTYxMmQ1YjIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjEuNjQ2MzcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ODk1MGI3MjEzMTE0ZWVmOGJh
-        YWMxMTlkOWE2NjVkOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjA4LjM2ODM0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MDguNTA1NDc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNGI0YTRhYjEzNGE0MWJiOWZi
+        YjQ2NjBhMjVhZjMxMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjIxLjg4NzI4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MjIuMTkyMzM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzdhOTA1ZjItOWI3
-        ZC00YjJhLTk5M2YtNWZiNWUwMWVmM2NmLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjYxNWU1YWItN2Q2
+        My00YWUzLTgxNzYtYzEyZjc1ZmU4ZGFmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2afb65aa-0cb5-4564-b5cb-0150030619f8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a66abdd6-6a59-4188-b759-4aba612d5b22/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3014,51 +3439,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74b7bc690b9b498aa3a71ea52f1c08da
+      - c28c6c8f921442d1be8193e91a2965ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmFmYjY1YWEtMGNi
-        NS00NTY0LWI1Y2ItMDE1MDAzMDYxOWY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDguMzM1ODE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY2YWJkZDYtNmE1
+        OS00MTg4LWI3NTktNGFiYTYxMmQ1YjIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjEuNjQ2MzcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ODk1MGI3MjEzMTE0ZWVmOGJh
-        YWMxMTlkOWE2NjVkOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1
-        OjA4LjM2ODM0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjU6
-        MDguNTA1NDc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNGI0YTRhYjEzNGE0MWJiOWZi
+        YjQ2NjBhMjVhZjMxMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMy
+        OjIxLjg4NzI4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzI6
+        MjIuMTkyMzM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzdhOTA1ZjItOWI3
-        ZC00YjJhLTk5M2YtNWZiNWUwMWVmM2NmLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjYxNWU1YWItN2Q2
+        My00YWUzLTgxNzYtYzEyZjc1ZmU4ZGFmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a72d7bfc-b845-472b-95be-71dce02ff28d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/000f2dcd-89c5-489b-a902-b7b11de822df/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3079,55 +3504,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d2bba736fd2d41baac93bd9c7093a2c3
+      - 215ff46171734e4d88c8bfb3bc8c79a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '416'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTcyZDdiZmMtYjg0
-        NS00NzJiLTk1YmUtNzFkY2UwMmZmMjhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjU6MDguMzg2MTU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDAwZjJkY2QtODlj
+        NS00ODliLWE5MDItYjdiMTFkZTgyMmRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzI6MjEuNzUwNzk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiMDg0YzM0ZTQzMzQ3NGExZThmYmRhM2RhMGQ1
-        ZmJhYzAiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNTowOC41Mzc1
-        MzNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI1OjA4LjY5MTE4
-        MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiYTk2YjRlY2Y0ZTRiNDZjYWI0MTM0ZDgzZTE3
+        ZDMzZGMiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMjoyMi4yNjM1
+        MTJaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMyOjIyLjY4MTAx
+        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzdhOTA1
-        ZjItOWI3ZC00YjJhLTk5M2YtNWZiNWUwMWVmM2NmL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjYxNWU1
+        YWItN2Q2My00YWUzLTgxNzYtYzEyZjc1ZmU4ZGFmL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzc3YTkwNWYyLTliN2QtNGIyYS05OTNmLTVm
-        YjVlMDFlZjNjZi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzdjNDBjNTc0LTg4NTUtNGIzNC1hNzk2LWViMTM2NmVjZGJj
-        NS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2I2MTVlNWFiLTdkNjMtNGFlMy04MTc2LWMx
+        MmY3NWZlOGRhZi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzg1MWE1ZjU0LWI2NjMtNDExNy1hNGRlLTNlODllMzZhNmQ5
+        MS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3135,7 +3560,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3148,44 +3573,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d9230f77fd574378a7bdb91978c621b6
+      - 034bdb7fe85147b19f25193ae0a41e07
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '193'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy84M2FlMzc4Ni02ZmZlLTQ2OWUtYjM4Zi1hNTQ4ZWFlZjVmYTIv
+        YWNrYWdlcy83NjI5ZjMwYS0xNGY3LTQ0NTUtYTNjYS0yNGJkOGM2YjQ4Mzkv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3NWZhLyJ9
+        a2FnZXMvMTIzMmMwNTgtZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8ifV19
+        Z2VzL2QwMWMxYmUwLWJmMmEtNDIwOS1iMTgxLThkNTk5ZmQwNzkzMy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3193,7 +3618,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3206,7 +3631,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:08 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3224,21 +3649,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 35bfd27cb9394d3295dcb33c88f4fa4d
+      - 372e09337d13419a8ede80c5378b7458
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:08 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3246,7 +3671,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3259,37 +3684,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1351'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e076980831bd4bd1b5d3cc11abc8b17a
+      - a2677839848740ca8282069643b37045
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '527'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzYwMTVkZGM5LTVmZTktNGU4MC04NTkyLTM3Y2Q4N2RlYTE0
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3Njg4
-        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU2IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzL2E3YWZjYTk1LWIzYjYtNGVjZC05YzQ2LTc3MWE0NGNkZGVi
+        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQyNjgy
+        NFoiLCJpZCI6IlJIRUEtMjAxMjowMDU2IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowOCIsImRlc2NyaXB0aW9uIjoiUGFydGhhQmlyZF9F
         cnJhdHVtIiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA4Iiwi
         ZnJvbXN0ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxl
@@ -3317,10 +3742,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3328,7 +3753,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3341,7 +3766,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3359,21 +3784,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e03234a42c0146a5891c9422e885c16d
+      - cb319c20d4a143f08afda495bc28562a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3381,7 +3806,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3394,7 +3819,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3412,21 +3837,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 568f68a58f034b9eb59237a906c20ae2
+      - 966caba1c6604d07b6b63dca67446cae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3434,7 +3859,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3447,7 +3872,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3465,21 +3890,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 05a78e8232e24d1187b3d57ef57f191f
+      - 28252e0457084c098903650c3aa6d20e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3487,7 +3912,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3500,44 +3925,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 72f9c82a282e4f5ab932b31615b0d9a5
+      - 0a16f3fdb72943ca8c9b4ec3a196c5d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '193'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy84M2FlMzc4Ni02ZmZlLTQ2OWUtYjM4Zi1hNTQ4ZWFlZjVmYTIv
+        YWNrYWdlcy83NjI5ZjMwYS0xNGY3LTQ0NTUtYTNjYS0yNGJkOGM2YjQ4Mzkv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvY2RlNzUwNTQtNDJkOS00MGVlLThlZTUtMDk1MWRmMzE3NWZhLyJ9
+        a2FnZXMvMTIzMmMwNTgtZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8ifV19
+        Z2VzL2QwMWMxYmUwLWJmMmEtNDIwOS1iMTgxLThkNTk5ZmQwNzkzMy8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3545,7 +3970,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3558,7 +3983,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3576,21 +4001,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da4cb27b214c44ffb71aad53fa3ef55f
+      - bb6a77e6f776488a9e811c49a7be43c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3598,7 +4023,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3611,37 +4036,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1351'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5b014f3ac464e02b5d2e882b266cf82
+      - 217e2502b730403db31af9996da88563
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '527'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzYwMTVkZGM5LTVmZTktNGU4MC04NTkyLTM3Y2Q4N2RlYTE0
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3Njg4
-        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU2IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzL2E3YWZjYTk1LWIzYjYtNGVjZC05YzQ2LTc3MWE0NGNkZGVi
+        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQyNjgy
+        NFoiLCJpZCI6IlJIRUEtMjAxMjowMDU2IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowOCIsImRlc2NyaXB0aW9uIjoiUGFydGhhQmlyZF9F
         cnJhdHVtIiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA4Iiwi
         ZnJvbXN0ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxl
@@ -3669,10 +4094,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3680,7 +4105,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3693,7 +4118,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3711,21 +4136,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f46ab853fbb4090af0127341e75085d
+      - 6f7b35957cc74cb58b021dda6abdd998
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3733,7 +4158,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3746,7 +4171,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3764,21 +4189,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 293ff9b1d4054cc482769e82745af699
+      - 719360fe22e34aa99c0e771552b91b3f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/77a905f2-9b7d-4b2a-993f-5fb5e01ef3cf/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b615e5ab-7d63-4ae3-8176-c12f75fe8daf/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3786,7 +4211,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3799,7 +4224,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:25:09 GMT
+      - Fri, 29 Jul 2022 11:32:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3817,16 +4242,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e65421f0547e451290263d0f9c343aaf
+      - e9d36079f0da455ca8b328582a56788b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:25:09 GMT
+  recorded_at: Fri, 29 Jul 2022 11:32:24 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_whitelist_max_version_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_whitelist_max_version_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b23fae50468145018912dccc21705d64
+      - 20f94c1ba4604969822749d7b5dac845
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '317'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNzRkZTA5NC04NTJmLTQ5M2QtODk0MS03NjQxMGMyMjFkMGYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDoyOS4wNzUzNjVa
+        cnBtL3JwbS8wNjQyNDA5Yi03YjU3LTQyOWItYTUxMS0yNDNjOTRhYjNjNDAv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyOTo0Mi41MjA2ODJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNzRkZTA5NC04NTJmLTQ5M2QtODk0MS03NjQxMGMyMjFkMGYv
+        cnBtL3JwbS8wNjQyNDA5Yi03YjU3LTQyOWItYTUxMS0yNDNjOTRhYjNjNDAv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM3NGRl
-        MDk0LTg1MmYtNDkzZC04OTQxLTc2NDEwYzIyMWQwZi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzA2NDI0
+        MDliLTdiNTctNDI5Yi1hNTExLTI0M2M5NGFiM2M0MC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:56 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/0642409b-7b57-429b-a511-243c94ab3c40/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1bc560ecdd7b4aa99f29f43304d7f82e
+      - e096a0ad3a6c456d9ce2533450d76189
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyMGE3MTdjLTUyM2MtNGUw
-        Yi04NDY1LTQ1MmVjNWQ0MzEyYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4ZTY1MzJmLTU4ZmMtNDFj
+        MS04ZTNmLWRkMjE0YjQ5YzBmNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 844f2544d227461daf09f7d86faa30ba
+      - 8f6c0ce8ecb945a2b56be03118602723
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/420a717c-523c-4e0b-8465-452ec5d4312b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/18e6532f-58fc-41c1-8e3f-dd214b49c0f4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af0ecc44371b4b0aa093d7033020a5a1
+      - 698149a5ef374aa38ece0668e2ad534f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDIwYTcxN2MtNTIz
-        Yy00ZTBiLTg0NjUtNDUyZWM1ZDQzMTJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzUuNDY4MDg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMThlNjUzMmYtNThm
+        Yy00MWMxLThlM2YtZGQyMTRiNDljMGY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NTYuMDkyNjg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxYmM1NjBlY2RkN2I0YWE5OWYyOWY0MzMw
-        NGQ3ZjgyZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjM1LjQ5
-        OTEwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MzUuNjE2
-        MzE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlMDk2YTBhZDNhNmM0NTZkOWNlMjUzMzQ1
+        MGQ3NjE4OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjU2LjE2
+        ODg5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NTYuNTQ3
+        ODMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzc0ZGUwOTQtODUyZi00OTNk
-        LTg5NDEtNzY0MTBjMjIxZDBmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDY0MjQwOWItN2I1Ny00Mjli
+        LWE1MTEtMjQzYzk0YWIzYzQwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7ed34fab9e864da1aea87da4c01778ff
+      - 46e13a8a774f410ab6ad0c0f8c9c826f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:56 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3fc7b08f9eb8438d9bcb06b6f8c4fbb7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMjBkMjdhODctYjgxOC00NzAyLWEzMDgtMWEzMDg0NTA4OTAw
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6NTAuNTMzNTQ0
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:56 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/20d27a87-b818-4702-a308-1a3084508900/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 18736cd7e017481589e55626cfc96fe8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwNDdjMmIwLTY0ZTAtNGY0
+        NS1hM2FmLTkyNGQ0MThhOWMxNi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/5047c2b0-64e0-4f45-a3af-924d418a9c16/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e169c19e35ca43628b90abbdbdfb415c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTA0N2MyYjAtNjRl
+        MC00ZjQ1LWEzYWYtOTI0ZDQxOGE5YzE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NTYuNzY1MzE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxODczNmNkN2UwMTc0ODE1ODllNTU2MjZj
+        ZmM5NmZlOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjU2Ljgx
+        OTk5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NTYuODY2
+        MzUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 452177ce24db4d9d8d5c0d3990f78321
+      - 138471a6ad354943a9636f3114f70d4f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 300ba4ebe50448ce8f2305a357109eb3
+      - 87ad9e1162864b1c877c08bf3f0c68e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dbe7a936fcfb48e0856f31831c461e6c
+      - e50c5f19a32f4cd1ae999725d29a45fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:35 GMT
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4952d7971b8b4ab48cb7e700273e40f0
+      - fb74d70f4ba643efa26633918cedc56b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 572d5a472deb4fd39d480af5791e0ddb
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:35 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/d72be091-b975-471b-aa8f-f079bdc1a83d/"
+      - "/pulp/api/v3/remotes/rpm/rpm/4f710fc0-aff3-41e2-bd3b-d74f75608692/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 106b2972d0e945ad887b4d40b6a00c41
+      - 49c785f9cf4a46b2abf06ffbeb4628ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q3
-        MmJlMDkxLWI5NzUtNDcxYi1hYThmLWYwNzliZGMxYTgzZC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjM2LjA2MDI1NFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRm
+        NzEwZmMwLWFmZjMtNDFlMi1iZDNiLWQ3NGY3NTYwODY5Mi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjU3LjM4NDU2NVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjM2LjA2MDI3M1oiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjU3LjM4NDU5MFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/"
+      - "/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 490131b424794d88b17df85795e370ab
+      - f44d0351d2834b47a36619672f8447cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzY3NzBmZDMtNzMwNy00MTJmLWI1MTMtODU4ZmUyYjAzN2Q4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MzYuMTcyMzAxWiIsInZl
+        cG0vZmM5NDEwY2MtOWMzMi00MWI3LWIxNTYtNzY2ODEyMzMzN2FjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6NTcuNTc1MzA5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzY3NzBmZDMtNzMwNy00MTJmLWI1MTMtODU4ZmUyYjAzN2Q4L3ZlcnNp
+        cG0vZmM5NDEwY2MtOWMzMi00MWI3LWIxNTYtNzY2ODEyMzMzN2FjL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNjc3MGZkMy03
-        MzA3LTQxMmYtYjUxMy04NThmZTJiMDM3ZDgvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYzk0MTBjYy05
+        YzMyLTQxYjctYjE1Ni03NjY4MTIzMzM3YWMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1dbd3450e37843f3ba5055016755a23c
+      - f1ed51535f624275b11053a044c5e01d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wYWEwNWU0OS03NThjLTQ3MjItOWJmOC01MDZkMWFlN2NiNmEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDoyOS44MjA5MzVa
+        cnBtL3JwbS81ODRiNjY3NS0yYzAwLTRkYWYtODdlYy03YzlkYWU3NDgwNmUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyOTo0My43MTY3OTda
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wYWEwNWU0OS03NThjLTQ3MjItOWJmOC01MDZkMWFlN2NiNmEv
+        cnBtL3JwbS81ODRiNjY3NS0yYzAwLTRkYWYtODdlYy03YzlkYWU3NDgwNmUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBhYTA1
-        ZTQ5LTc1OGMtNDcyMi05YmY4LTUwNmQxYWU3Y2I2YS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU4NGI2
+        Njc1LTJjMDAtNGRhZi04N2VjLTdjOWRhZTc0ODA2ZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/584b6675-2c00-4daf-87ec-7c9dae74806e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 00e0b49742d34bb892623c9ffc059037
+      - 83e9c78552b445d7b477e483b930de3c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkY2VmZTQwLTk2OTMtNDQx
-        Ny05YmQ1LWNkMjdmNDA4MTQ2YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBmNTUyNWY0LTEzZWItNDA4
+        Mi04MTA2LTdkNTFlOTAwZTkyYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3788aa95f4ee49a59bac1ae8232299de
+      - 0fe8159710f146699d71bf4a3d04856e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '379'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vYmY0OTQxZGMtNTI4YS00YWE5LWI1ZTUtOTcwYjM3ZWNhMjdhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MjguODczODM5WiIsIm5h
+        cG0vYzVhY2Q1ZTMtMjIyOC00ZmQxLThiZDItZTk3NDNjZTE3NjZiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6NDIuMzM4MjE4WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDozMC4zMDcyODVaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMToyOTo0NC4yNjYxMTRaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/bf4941dc-528a-4aa9-b5e5-970b37eca27a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c5acd5e3-2228-4fd1-8bd2-e9743ce1766b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66fe4a3486af4529be0d078c86cfc279
+      - 48c2ab5805cf432fa9dd48faba91552c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3YWQyMzM4LTFiYjUtNGU3
-        MS04MjgxLTAyNDM2NmZlNWUxMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmNmY2ZjhjLTVlOWUtNDc1
+        OC1hZTFhLWExNTExMzIxYTAzZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/cdcefe40-9693-4417-9bd5-cd27f408146a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0f5525f4-13eb-4082-8106-7d51e900e92c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66b95d2f053c45aeb7152d7d56c8e2d6
+      - 9e30b4343b914de4bccf9ccaedefa603
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2RjZWZlNDAtOTY5
-        My00NDE3LTliZDUtY2QyN2Y0MDgxNDZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzYuMzI4NzUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGY1NTI1ZjQtMTNl
+        Yi00MDgyLTgxMDYtN2Q1MWU5MDBlOTJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NTcuODg2NTU1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMGUwYjQ5NzQyZDM0YmI4OTI2MjNjOWZm
-        YzA1OTAzNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjM2LjM2
-        MzQ4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MzYuNDE5
-        NjMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4M2U5Yzc4NTUyYjQ0NWQ3YjQ3N2U0ODNi
+        OTMwZGUzYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjU3Ljk1
+        MTMxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NTguMDkz
+        MzA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGFhMDVlNDktNzU4Yy00NzIy
-        LTliZjgtNTA2ZDFhZTdjYjZhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTg0YjY2NzUtMmMwMC00ZGFm
+        LTg3ZWMtN2M5ZGFlNzQ4MDZlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/37ad2338-1bb5-4e71-8281-024366fe5e11/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/8f6f6f8c-5e9e-4758-ae1a-a1511321a03d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0bbdd21dcb2d4588aa134b7f7a6d7ce2
+      - 1d4cc3b7e289452381f53d79b9847071
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzdhZDIzMzgtMWJi
-        NS00ZTcxLTgyODEtMDI0MzY2ZmU1ZTExLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzYuNDE1ODY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGY2ZjZmOGMtNWU5
+        ZS00NzU4LWFlMWEtYTE1MTEzMjFhMDNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NTguMDY1NjcyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NmZlNGEzNDg2YWY0NTI5YmUwZDA3OGM4
-        NmNmYzI3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjM2LjQ0
-        NzMxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MzYuNDkx
-        MjUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0OGMyYWI1ODA1Y2Y0MzJmYTlkZDQ4ZmFi
+        YTkxNTUyYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjU4LjE1
+        NTY0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NTguMjQ3
+        Mzg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JmNDk0MWRjLTUyOGEtNGFhOS1iNWU1
-        LTk3MGIzN2VjYTI3YS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M1YWNkNWUzLTIyMjgtNGZkMS04YmQy
+        LWU5NzQzY2UxNzY2Yi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f0083b05c2ae4e838e77cd2a4e05f768
+      - 55cb3f70ae234051a0fd2105f40b8549
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0eb53bbd8cec47e5a5581ed57d3c9bce
+      - 3a1084c8d23e405593b468de512ad944
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10ebe876ec0246a28308ac4602289c81
+      - 260a5612471a43c89673d92e1795050f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d6e3a253c974a3380effefdb757d151
+      - 501afc11ff09494291b01a08119919a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9f9f4e31e02e4ba187148be80ca22eee
+      - 57de65ee795f4d9bae8f26419e4fcf03
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '050817fc31df4a5ba87dae043c3258e1'
+      - 9598c66899d54122923f564f34b74114
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:36 GMT
+      - Fri, 29 Jul 2022 11:29:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/"
+      - "/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9ebe35f9c634603883123cc420e92d0
+      - abe95f59a5a24c8c97e692bed1961d79
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vM2FkNDcyMDktZGEyNi00OWIzLTlkYjgtOGEwNjcxYjQ4ZDRmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MzYuODYxODYzWiIsInZl
+        cG0vODAyMDRmMTAtYmJiZS00NjY0LThjZjItYzVhZTQ1NmVmYWZlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6NTguNzkwOTcyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vM2FkNDcyMDktZGEyNi00OWIzLTlkYjgtOGEwNjcxYjQ4ZDRmL3ZlcnNp
+        cG0vODAyMDRmMTAtYmJiZS00NjY0LThjZjItYzVhZTQ1NmVmYWZlL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zYWQ0NzIwOS1k
-        YTI2LTQ5YjMtOWRiOC04YTA2NzFiNDhkNGYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84MDIwNGYxMC1i
+        YmJlLTQ2NjQtOGNmMi1jNWFlNDU2ZWZhZmUvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:36 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:58 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/d72be091-b975-471b-aa8f-f079bdc1a83d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/4f710fc0-aff3-41e2-bd3b-d74f75608692/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:37 GMT
+      - Fri, 29 Jul 2022 11:29:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f802ed6ed375491a95d9b8a7466b0dbc
+      - aa9c44c41d2e43da98ba0b4af998b5ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyYjlkNmZmLTY2ZGQtNDMz
-        OS04NTYwLTg4Zjg5NDlmYjFhYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2ODIwOWRkLTIwNjAtNDdm
+        Zi04YTg1LTVmY2QwMGI5MjU2YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f2b9d6ff-66dd-4339-8560-88f8949fb1ab/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/268209dd-2060-47ff-8a85-5fcd00b9256a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:37 GMT
+      - Fri, 29 Jul 2022 11:29:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8825be62efdc4d069d98e692b76790cd
+      - 0f1de844abf54b2caa117aa18a912995
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjJiOWQ2ZmYtNjZk
-        ZC00MzM5LTg1NjAtODhmODk0OWZiMWFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzcuMTUxMTgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjY4MjA5ZGQtMjA2
+        MC00N2ZmLThhODUtNWZjZDAwYjkyNTZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NTkuMjQ1NTkxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmODAyZWQ2ZWQzNzU0OTFhOTVkOWI4YTc0
-        NjZiMGRiYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjM3LjE4
-        Mjc0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MzcuMjA1
-        MzgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhYTljNDRjNDFkMmU0M2RhOThiYTBiNGFm
+        OTk4YjVjZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjU5LjMy
+        MDk5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6NTkuMzcz
+        MDg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q3MmJlMDkxLWI5NzUtNDcxYi1hYThm
-        LWYwNzliZGMxYTgzZC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmNzEwZmMwLWFmZjMtNDFlMi1iZDNi
+        LWQ3NGY3NTYwODY5Mi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:59 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q3MmJl
-        MDkxLWI5NzUtNDcxYi1hYThmLWYwNzliZGMxYTgzZC8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRmNzEw
+        ZmMwLWFmZjMtNDFlMi1iZDNiLWQ3NGY3NTYwODY5Mi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:37 GMT
+      - Fri, 29 Jul 2022 11:29:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fb293fb078a34ebda2b06fcdeb039074
+      - 73a0178c742f4dd3bd523dc33d8dee61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY4ZGU4MjZhLTBkNDYtNGFm
-        ZS04NWUxLWQ5YTI2OTJjOWM5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhMTE4MzkxLTYyY2MtNGNl
+        Ni04ZDM5LTA4ZTEwYjlkNTgwMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:37 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/68de826a-0d46-4afe-85e1-d9a2692c9c99/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2a118391-62cc-4ce6-8d39-08e10b9d5802/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:39 GMT
+      - Fri, 29 Jul 2022 11:30:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a50f99afd4ed42978368dda2a35608f6
+      - 2bd05d10054f49c2b8704cf7caebd92a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '600'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjhkZTgyNmEtMGQ0
-        Ni00YWZlLTg1ZTEtZDlhMjY5MmM5Yzk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzcuMzQ0ODU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmExMTgzOTEtNjJj
+        Yy00Y2U2LThkMzktMDhlMTBiOWQ1ODAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6NTkuNTU4NjkwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmYjI5M2ZiMDc4YTM0ZWJkYTJi
-        MDZmY2RlYjAzOTA3NCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjM3LjM3NTMwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        MzkuMjU4MDcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgw
-        M2EvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI3M2EwMTc4Yzc0MmY0ZGQzYmQ1
+        MjNkYzMzZDhkZWU2MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjU5LjYxMjEyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MDMuODQzMDQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMzY3NzBmZDMtNzMwNy00MTJmLWI1MTMt
-        ODU4ZmUyYjAzN2Q4L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzM2NzcwZmQzLTczMDctNDEyZi1iNTEzLTg1OGZlMmIwMzdkOC8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9kNzJiZTA5MS1iOTc1
-        LTQ3MWItYWE4Zi1mMDc5YmRjMWE4M2QvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2ZjOTQxMGNjLTljMzItNDFiNy1iMTU2LTc2
+        NjgxMjMzMzdhYy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9m
+        Yzk0MTBjYy05YzMyLTQxYjctYjE1Ni03NjY4MTIzMzM3YWMvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNGY3MTBmYzAtYWZmMy00
+        MWUyLWJkM2ItZDc0Zjc1NjA4NjkyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMzY3NzBmZDMtNzMwNy00MTJmLWI1MTMtODU4ZmUyYjAz
-        N2Q4L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZmM5NDEwY2MtOWMzMi00MWI3LWIxNTYtNzY2ODEyMzMz
+        N2FjL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:39 GMT
+      - Fri, 29 Jul 2022 11:30:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a628c61395c94a6f8fdb5b7a6adc121a
+      - 22c6fe1185064e70b2b9eedf16ea26f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkNzU2ODZlLTViNjEtNGRm
-        OS05ZWY3LTU0MTQ2MjU1YjU1YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlMTVkZGZlLTQwOGQtNDAx
+        My1hYzE3LWY1NmQzZjJiOTA1NC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ed75686e-5b61-4df9-9ef7-54146255b55a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ce15ddfe-408d-4013-ac17-f56d3f2b9054/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:39 GMT
+      - Fri, 29 Jul 2022 11:30:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 627c260203c44f7c8c37c1da9e93132e
+      - 74faf54db8a54215a3a03f6e322910b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '478'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWQ3NTY4NmUtNWI2
-        MS00ZGY5LTllZjctNTQxNDYyNTViNTVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzkuNTAzOTczWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2UxNWRkZmUtNDA4
+        ZC00MDEzLWFjMTctZjU2ZDNmMmI5MDU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MDQuMjA0ODExWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImE2MjhjNjEzOTVjOTRhNmY4ZmRiNWI3YTZh
-        ZGMxMjFhIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MzkuNTM1
-        MTY0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDozOS43MDk2
-        ODdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjIyYzZmZTExODUwNjRlNzBiMmI5ZWVkZjE2
+        ZWEyNmYwIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MDQuMjc5
+        MDkzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMDowNC44MTgy
+        MTNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZDYwNzE2
-        ZDUtOTUyYi00NjNjLThjMTItMDYwYjM0YWRjMjY3LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTdmYzk5
+        ZGUtMjdkMi00NWU0LThjMjYtZDRlMjUyNGZjZGU4LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMzY3NzBmZDMtNzMwNy00MTJmLWI1MTMtODU4ZmUy
-        YjAzN2Q4LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZmM5NDEwY2MtOWMzMi00MWI3LWIxNTYtNzY2ODEy
+        MzMzN2FjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:39 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:39 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f007ef86e3d84131ad8e382e32036a01
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:39 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e9f2bd500cc348c4972ff03f73544cbd
+      - 7163166fb17b4718a6fa08e2f5994d83
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/17fc99de-27d2-45e4-8c26-d4e2524fcde8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b5c9ef89660642c7ae2d122591b4c190
+      - 91d745421e6f4099b4ae5dab0d752397
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMTdmYzk5ZGUtMjdkMi00NWU0LThjMjYtZDRlMjUyNGZjZGU4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzA6MDQuMzE2MzgyWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9mYzk0MTBjYy05YzMyLTQxYjctYjE1Ni03NjY4MTIzMzM3YWMv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2ZjOTQxMGNjLTljMzItNDFiNy1iMTU2LTc2Njgx
+        MjMzMzdhYy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:05 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8xN2ZjOTlkZS0yN2QyLTQ1ZTQtOGMyNi1kNGUyNTI0ZmNkZTgv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 390d3d1f2e1a4ba6839fd35b03f07cf9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3YTZkYjc1LWU2NjUtNGUz
+        Zi04ZDU5LTc2NWNjMzhkZmY3Yy8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/97a6db75-e665-4e3f-8d59-765cc38dff7c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - af2de3ce3bcf47b88c8b58187097d7ac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTdhNmRiNzUtZTY2
+        NS00ZTNmLThkNTktNzY1Y2MzOGRmZjdjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MDUuMjU3NDc3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzOTBkM2QxZjJlMWE0YmE2ODM5ZmQzNWIw
+        M2YwN2NmOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjA1LjMz
+        NTUxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6MDUuODM4
+        NDkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNWEx
+        ZjdlNDMtN2RiMi00YWM5LWE2YTgtMmM2MTMzMDY2YWQzLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/5a1f7e43-7db2-4ac9-a6a8-2c6133066ad3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 50bd1a801f794454973771b8f65577ef
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzVhMWY3ZTQzLTdkYjItNGFjOS1hNmE4LTJjNjEzMzA2NmFkMy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMwOjA1LjgxMDA1N1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMTdmYzk5ZGUtMjdkMi00NWU0LThjMjYt
+        ZDRlMjUyNGZjZGU4LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b02e85ba9c94495a5c179e89c3d4dfb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:06 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a93c2e2955a14064b2c0afe7e02106ce
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:06 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7bdc8dd3d152425881ac8111b38775bc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2293d53f18048a88297275d6973358f
+      - 449aed36875b4379af7288a9ee5853fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f8dc4236c74140bf84453fe63bc48f88
+      - f39d3d9131b74299a4729bdced6fc1ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 32c4cf7099f643f69c1d8083e27b0aec
+      - 36bffe2396aa466590342b533c7ae88b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4b4eb03388c84874af0370eb045461e7
+      - 2071f82f6a814384b05a93db9b6465d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e3f20edaced3489cba80966314849375
+      - 623157bbd08345a0b800c1afa2cdd79f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9dfc64f470a147f4936822447e6d34cc
+      - 7dc2538629b9464aa8c61b8a5caaa347
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/fc9410cc-9c32-41b7-b156-7668123337ac/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 502127f7d34e428ea97422162a0db2cc
+      - 605033069db0498f849b1747ab3bf568
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:07 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,37 +3208,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c8792dbb8e444ac972aa7075dcd58e3
+      - ecdd752280354adea14319f17fb94d2c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiNTM3NjM2LTA0NjQtNDAz
-        MS04Y2Y4LWIzMzA3ZTM4ZmQwZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhZWFmZTI1LWMyOTgtNGMw
+        OS1iM2NkLTBjYjAyN2QyODNhZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:07 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzY3NzBmZDMtNzMwNy00MTJmLWI1
-        MTMtODU4ZmUyYjAzN2Q4L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNhZDQ3MjA5LWRhMjYt
-        NDliMy05ZGI4LThhMDY3MWI0OGQ0Zi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMt
-        OWU5MS04ZWRkOWQ5ZDExNjIvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmM5NDEwY2MtOWMzMi00MWI3LWIx
+        NTYtNzY2ODEyMzMzN2FjL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzgwMjA0ZjEwLWJiYmUt
+        NDY2NC04Y2YyLWM1YWU0NTZlZmFmZS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEt
+        YjVhOC1lMGYzMzdmNTE3Y2QvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
         YWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2826,7 +3251,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2844,21 +3269,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b723c0c4ec0e4c4d99fe39e81ce044c9
+      - 04d99b8f39f34d029189d9fb18caae75
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0NzY1YzI4LWY5YWItNDll
-        OS1hY2YyLTZmODhlNzgxMWMwZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhM2IwMzExLWU5OGUtNDUy
+        Zi04MDEwLWViNzFkOGMzMjM5Ni8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fb537636-0464-4031-8cf8-b3307e38fd0f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/baeafe25-c298-4c09-b3cd-0cb027d283ae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2879,51 +3304,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 34e7c014eb4c4dd09c4dfa927b0f608f
+      - 5452dfe7211a40b6a70c7c4c06abd338
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmI1Mzc2MzYtMDQ2
-        NC00MDMxLThjZjgtYjMzMDdlMzhmZDBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDAuNTk4MTE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmFlYWZlMjUtYzI5
+        OC00YzA5LWIzY2QtMGNiMDI3ZDI4M2FlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MDcuNTc5NzA0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyYzg3OTJkYmI4ZTQ0NGFjOTcy
-        YWE3MDc1ZGNkNThlMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjQwLjYzNzI1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NDAuNzY3NTk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlY2RkNzUyMjgwMzU0YWRlYTE0
+        MzE5ZjE3ZmI5NGQyYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjA3LjY2MDU2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MDguMTUxMDQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2FkNDcyMDktZGEy
-        Ni00OWIzLTlkYjgtOGEwNjcxYjQ4ZDRmLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODAyMDRmMTAtYmJi
+        ZS00NjY0LThjZjItYzVhZTQ1NmVmYWZlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/fb537636-0464-4031-8cf8-b3307e38fd0f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/baeafe25-c298-4c09-b3cd-0cb027d283ae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2944,51 +3369,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3f2180ac0fa84ec983d9f64a901857f7
+      - a8baac9a2aa1488b9511cb1735d6372c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmI1Mzc2MzYtMDQ2
-        NC00MDMxLThjZjgtYjMzMDdlMzhmZDBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDAuNTk4MTE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmFlYWZlMjUtYzI5
+        OC00YzA5LWIzY2QtMGNiMDI3ZDI4M2FlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MDcuNTc5NzA0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyYzg3OTJkYmI4ZTQ0NGFjOTcy
-        YWE3MDc1ZGNkNThlMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjQwLjYzNzI1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NDAuNzY3NTk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlY2RkNzUyMjgwMzU0YWRlYTE0
+        MzE5ZjE3ZmI5NGQyYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjA3LjY2MDU2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MDguMTUxMDQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2FkNDcyMDktZGEy
-        Ni00OWIzLTlkYjgtOGEwNjcxYjQ4ZDRmLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODAyMDRmMTAtYmJi
+        ZS00NjY0LThjZjItYzVhZTQ1NmVmYWZlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/74765c28-f9ab-49e9-acf2-6f88e7811c0e/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/baeafe25-c298-4c09-b3cd-0cb027d283ae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3009,55 +3434,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:40 GMT
+      - Fri, 29 Jul 2022 11:30:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3ae4e59f3334b969ccdf8c9794658dc
+      - 9d99a945bf2f4466832c80cad8219555
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '415'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzQ3NjVjMjgtZjlh
-        Yi00OWU5LWFjZjItNmY4OGU3ODExYzBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDAuNjU1MTI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmFlYWZlMjUtYzI5
+        OC00YzA5LWIzY2QtMGNiMDI3ZDI4M2FlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MDcuNTc5NzA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlY2RkNzUyMjgwMzU0YWRlYTE0
+        MzE5ZjE3ZmI5NGQyYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjA3LjY2MDU2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MDguMTUxMDQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODAyMDRmMTAtYmJi
+        ZS00NjY0LThjZjItYzVhZTQ1NmVmYWZlLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/baeafe25-c298-4c09-b3cd-0cb027d283ae/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '613'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 688710edc4b542148cf475b97632392e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmFlYWZlMjUtYzI5
+        OC00YzA5LWIzY2QtMGNiMDI3ZDI4M2FlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MDcuNTc5NzA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlY2RkNzUyMjgwMzU0YWRlYTE0
+        MzE5ZjE3ZmI5NGQyYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMw
+        OjA3LjY2MDU2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzA6
+        MDguMTUxMDQ5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODAyMDRmMTAtYmJi
+        ZS00NjY0LThjZjItYzVhZTQ1NmVmYWZlLyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:30:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/0a3b0311-e98e-452f-8010-eb71d8c32396/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:30:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ad7b540efbb2408da30d31aac864f034
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGEzYjAzMTEtZTk4
+        ZS00NTJmLTgwMTAtZWI3MWQ4YzMyMzk2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzA6MDcuNjgyMzc5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiYjcyM2MwYzRlYzBlNGM0ZDk5ZmUzOWU4MWNl
-        MDQ0YzkiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDo0MC43OTk5
-        OTdaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjQwLjk1MTM0
-        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvMGRmMThhZmYtNjRiOC00YzZhLTk0MWItNGI0OTgwY2Y4MDNhLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiMDRkOTliOGYzOWYzNGQwMjkxODlkOWZiMThj
+        YWFlNzUiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMDowOC4yMTUx
+        MjJaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMwOjA4LjcxMTI2
+        MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2FkNDcy
-        MDktZGEyNi00OWIzLTlkYjgtOGEwNjcxYjQ4ZDRmL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODAyMDRm
+        MTAtYmJiZS00NjY0LThjZjItYzVhZTQ1NmVmYWZlL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzNhZDQ3MjA5LWRhMjYtNDliMy05ZGI4LThh
-        MDY3MWI0OGQ0Zi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzM2NzcwZmQzLTczMDctNDEyZi1iNTEzLTg1OGZlMmIwMzdk
-        OC8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzgwMjA0ZjEwLWJiYmUtNDY2NC04Y2YyLWM1
+        YWU0NTZlZmFmZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2ZjOTQxMGNjLTljMzItNDFiNy1iMTU2LTc2NjgxMjMzMzdh
+        Yy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:40 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3065,7 +3620,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3078,41 +3633,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f520ac597ea5429db47b954571e4b878
+      - 2091b577c0b14efb97e093cab3fe0171
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDExNjIv
+        YWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3Y2Qv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3120,7 +3675,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3133,7 +3688,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3151,21 +3706,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d9d0e36328a4a87aca134020b51445d
+      - 129d98f8f6c8448ba19b9ced172beb3b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3173,7 +3728,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3186,7 +3741,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3204,21 +3759,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 52698e40b3e447f78af10be6bb087e1a
+      - 6223dbbb9cd94dbfbb8a4129e456f7ed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3226,7 +3781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3239,7 +3794,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3257,21 +3812,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ae65bdbe98741d395d16c848a64a84c
+      - 7dc9c266493049ad98ef0b93ccfafcb3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3279,7 +3834,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3292,7 +3847,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3310,21 +3865,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2a6553c5699c487c9694d030500809e3
+      - 14e0f885eca1448ba4dc0bbde0653995
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3332,7 +3887,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3345,7 +3900,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3363,21 +3918,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5ac9e7ff31e4c55a35ecedfec4d98a3
+      - 0ae960fa59a74c348a7ef17a4a80345b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3385,7 +3940,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3398,41 +3953,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6ef7133ed60e442cabf8e0b2ee144a33
+      - 8ef9c9a7724b426c8aed4b45dac5608f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDExNjIv
+        YWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3Y2Qv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3440,7 +3995,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3453,7 +4008,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3471,21 +4026,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 003c6fd9da2f40a4aa12c7775b57778f
+      - b20a3a41ea794e158b6354de663098c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3493,7 +4048,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3506,7 +4061,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3524,21 +4079,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2215c1c663f1412cb7dccd513d141bf8
+      - c49e96b6e7904d48ab429852dbb6cf32
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3546,7 +4101,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3559,7 +4114,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3577,21 +4132,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4de8f1ef8b754ce8878d8c022228d139
+      - d76296c912d54dae86c36e9142e58bb5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3599,7 +4154,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3612,7 +4167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3630,21 +4185,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 957caa38bcd4427394da322d41b1ee57
+      - 177b7ae8366f4d44b2741136b9663a6d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:10 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/80204f10-bbbe-4664-8cf2-c5ae456efafe/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3652,7 +4207,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3665,7 +4220,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:41 GMT
+      - Fri, 29 Jul 2022 11:30:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3683,16 +4238,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - daf52cde5c2444ef9a73c4d9fbb2e16b
+      - a82c62fbb7ab42b49cca6742855e6748
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:41 GMT
+  recorded_at: Fri, 29 Jul 2022 11:30:10 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_whitelist_min_version_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_whitelist_min_version_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f694cb1d6a64091849a89e7f0324e63
+      - 1a6415bfd4c14335b2c08096fc510d59
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85NTYwYWI0My0zYjE3LTRkYWUtYWY5NS1hNzcyNTVkZjY0NzEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDoyMi4xMjM4NTFa
+        cnBtL3JwbS8zYjZiYjhhNi04N2I1LTQ4YzgtYTUwNy0xY2Y4M2FiMWEzZjQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyOTowOS4xODYwNTda
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85NTYwYWI0My0zYjE3LTRkYWUtYWY5NS1hNzcyNTVkZjY0NzEv
+        cnBtL3JwbS8zYjZiYjhhNi04N2I1LTQ4YzgtYTUwNy0xY2Y4M2FiMWEzZjQv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzk1NjBh
-        YjQzLTNiMTctNGRhZS1hZjk1LWE3NzI1NWRmNjQ3MS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNiNmJi
+        OGE2LTg3YjUtNDhjOC1hNTA3LTFjZjgzYWIxYTNmNC92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:25 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/9560ab43-3b17-4dae-af95-a77255df6471/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/3b6bb8a6-87b5-48c8-a507-1cf83ab1a3f4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 80f1d096e2914c89b86848ad055e6a40
+      - 48b9a8c140814d2c8ee2d221c2ce38e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5ZmU3NmQ5LTY0YjMtNDQ2
-        OS1iNmJlLWZmZDBjZmMzYTZjZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxNjY4MTk4LWM0M2EtNDk0
+        ZC1hMzUxLWIxZTVlYzMxYjU0Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f9d0597f8ca44973a5cc2e20112d9e07
+      - ac8feb5b14c24c379660b992c3ba4268
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/d9fe76d9-64b3-4469-b6be-ffd0cfc3a6ce/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/61668198-c43a-494d-a351-b1e5ec31b542/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3fc74eb30784c35bcbd1e9b7cca4583
+      - e98b33ba988545ceaf13655a18b99a2c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDlmZTc2ZDktNjRi
-        My00NDY5LWI2YmUtZmZkMGNmYzNhNmNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjguMjI1MTA4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjE2NjgxOTgtYzQz
+        YS00OTRkLWEzNTEtYjFlNWVjMzFiNTQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjUuNTI5MzI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4MGYxZDA5NmUyOTE0Yzg5Yjg2ODQ4YWQw
-        NTVlNmE0MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjI4LjI1
-        NzA0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MjguMzgw
-        ODcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0OGI5YThjMTQwODE0ZDJjOGVlMmQyMjFj
+        MmNlMzhlNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjI1LjU4
+        NjkzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MjUuOTg4
+        NTczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTU2MGFiNDMtM2IxNy00ZGFl
-        LWFmOTUtYTc3MjU1ZGY2NDcxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2I2YmI4YTYtODdiNS00OGM4
+        LWE1MDctMWNmODNhYjFhM2Y0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '0645359afc1641678849f1235e3b0b8b'
+      - d0b650e48b84457f8e708020c5530c9b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a49938e672cc40a5920410833d3d5ffa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vMDhhZTE0ZWUtMjZlZi00ZWE4LWI5MTgtZGZmZmMwZmVhMDM3
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MTcuMDM0MDY1
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/08ae14ee-26ef-4ea8-b918-dfffc0fea037/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5689190a9b914823bf7fdf9c215db215
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0M2JiNTJiLThlZGEtNDll
+        OC05ZWQ3LTU2YTg2NmI4ZjRiYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/243bb52b-8eda-49e8-9ed7-56a866b8f4ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bdda0c8ce3454a22bebbffeb3ede5fa4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQzYmI1MmItOGVk
+        YS00OWU4LTllZDctNTZhODY2YjhmNGJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjYuMjMxMzY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1Njg5MTkwYTliOTE0ODIzYmY3ZmRmOWMy
+        MTVkYjIxNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjI2LjI4
+        MjU4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MjYuMzMw
+        NjQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 160a08a8f7294770afc5b309722ceaad
+      - bc2427068944428499578d1fb269d9de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66bc15dfac8e441cbe7a4d36ebb4b329
+      - fed7ab714ba14f9aa77c5db6c8e170e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a60c345b317549aaaf0a7ae6375224df
+      - f878f3b9f0bc4ec083ccb25495e29b99
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 706bacb3d23d4182874a79f17d8cd982
+      - a83bc41b8edf4bb8bfee4c13c10ab044
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:28 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - c6a9cdf095db423dbb42b9288148d6a7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:28 GMT
+      - Fri, 29 Jul 2022 11:29:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/bf4941dc-528a-4aa9-b5e5-970b37eca27a/"
+      - "/pulp/api/v3/remotes/rpm/rpm/b9f868fb-0209-4d8c-bcde-a25587f8838b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46336aa97b164f32b72ea5175af90799
+      - d5179088885f434a80719ba11bbe1e53
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Jm
-        NDk0MWRjLTUyOGEtNGFhOS1iNWU1LTk3MGIzN2VjYTI3YS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjI4Ljg3MzgzOVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I5
+        Zjg2OGZiLTAyMDktNGQ4Yy1iY2RlLWEyNTU4N2Y4ODM4Yi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjI2Ljg0ODI3MloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjI4Ljg3Mzg2MFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjI2Ljg0ODMwNFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:28 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:26 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/"
+      - "/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1f9ba12c2b50472c82c5edca05ef0459
+      - eac8a725569a4765b8325fb452c992b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzc0ZGUwOTQtODUyZi00OTNkLTg5NDEtNzY0MTBjMjIxZDBmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MjkuMDc1MzY1WiIsInZl
+        cG0vYjkwOTNiNTItNjI4Yy00YTJhLWI5ZTEtZDg3YTVhNWYzZDc0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MjcuMDM1NTk1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMzc0ZGUwOTQtODUyZi00OTNkLTg5NDEtNzY0MTBjMjIxZDBmL3ZlcnNp
+        cG0vYjkwOTNiNTItNjI4Yy00YTJhLWI5ZTEtZDg3YTVhNWYzZDc0L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNzRkZTA5NC04
-        NTJmLTQ5M2QtODk0MS03NjQxMGMyMjFkMGYvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iOTA5M2I1Mi02
+        MjhjLTRhMmEtYjllMS1kODdhNWE1ZjNkNzQvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2feabd57df474db894bde08212019095
+      - 5a433c4fc1724d72a17432d8ac4cf66c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '311'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84OTU3ZWE5NC02YTA3LTQ2YWYtODY3ZC1kMzM2YmI0NjhkMGEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDoyMy4wMDQyOTFa
+        cnBtL3JwbS8yYjNhNzhlOS1kZTY3LTQxMzMtOTYzOC05YTdiODcxZDllNmMv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyOToxMC4zOTU3MTRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84OTU3ZWE5NC02YTA3LTQ2YWYtODY3ZC1kMzM2YmI0NjhkMGEv
+        cnBtL3JwbS8yYjNhNzhlOS1kZTY3LTQxMzMtOTYzOC05YTdiODcxZDllNmMv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzg5NTdl
-        YTk0LTZhMDctNDZhZi04NjdkLWQzMzZiYjQ2OGQwYS92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJiM2E3
+        OGU5LWRlNjctNDEzMy05NjM4LTlhN2I4NzFkOWU2Yy92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/8957ea94-6a07-46af-867d-d336bb468d0a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/2b3a78e9-de67-4133-9638-9a7b871d9e6c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff40e0a590784c82849805e68b29960d
+      - 2114efb01dd9441b952ad84c0e1122b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzMjUxYzRlLTEzNTQtNGY4
-        My04NzZjLTljZGM5NjhhYWQwZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y5ZWQ1MWI3LWRmNGQtNDdi
+        Ny05MWVhLTUzMThjNTczYjlkNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - debddd4ab7514619a5d59bebede90d3b
+      - e0718606913d4942a5143f959fd348d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZmQ3YTNmNDktYWYxNi00YjA3LTlkZWMtYjVhZTllMzYzZWNjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MjIuMDA4MzQyWiIsIm5h
+        cG0vNzY0NGQ5NTYtOTY0Zi00NDg2LThkMjYtNjg3MzFkNmNlY2M3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MDguOTc4OTg0WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDoyMy4zNjc1NzdaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMToyOToxMC45MzA4MTNaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/fd7a3f49-af16-4b07-9dec-b5ae9e363ecc/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/7644d956-964f-4486-8d26-68731d6cecc7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9467ddd0a45e431eba8fea24bb9b537b
+      - 5f30950e27df4015978883ffddc777e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMxOTEyMzkzLWZlMWQtNDY4
-        NC1hNjRkLTllYjhjMTMzODdjOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NhNWI4ZWNlLWMwNzgtNDQ5
+        MC05OGFkLTI1ZWUxMzE1NWM0Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/53251c4e-1354-4f83-876c-9cdc968aad0f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/f9ed51b7-df4d-47b7-91ea-5318c573b9d7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a6fe754ebee949c881dfd8ed67eb4041
+      - b91d896b596d47c7a9fa113d886f8322
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTMyNTFjNGUtMTM1
-        NC00ZjgzLTg3NmMtOWNkYzk2OGFhZDBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjkuMjc3OTQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjllZDUxYjctZGY0
+        ZC00N2I3LTkxZWEtNTMxOGM1NzNiOWQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjcuMzExMzM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmZjQwZTBhNTkwNzg0YzgyODQ5ODA1ZTY4
-        YjI5OTYwZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjI5LjMw
-        NzQ0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MjkuMzY3
-        NDc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMTE0ZWZiMDFkZDk0NDFiOTUyYWQ4NGMw
+        ZTExMjJiNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjI3LjM2
+        MjYwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MjcuNDc4
+        ODk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODk1N2VhOTQtNmEwNy00NmFm
-        LTg2N2QtZDMzNmJiNDY4ZDBhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmIzYTc4ZTktZGU2Ny00MTMz
+        LTk2MzgtOWE3Yjg3MWQ5ZTZjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/31912393-fe1d-4684-a64d-9eb8c13387c8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ca5b8ece-c078-4490-98ad-25ee13155c42/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef531437f0e8443db0c2a53d5c099597
+      - 7710c7864bbf4a9a9f312f28a2d9bf11
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzE5MTIzOTMtZmUx
-        ZC00Njg0LWE2NGQtOWViOGMxMzM4N2M4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MjkuMzYzNzA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2E1YjhlY2UtYzA3
+        OC00NDkwLTk4YWQtMjVlZTEzMTU1YzQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjcuNDY4NjUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NDY3ZGRkMGE0NWU0MzFlYmE4ZmVhMjRi
-        YjliNTM3YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjI5LjM5
-        NzQzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MjkuNDM5
-        MTEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1ZjMwOTUwZTI3ZGY0MDE1OTc4ODgzZmZk
+        ZGM3NzdlOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjI3LjUz
+        MDE4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MjcuNjA3
+        MjQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2ZkN2EzZjQ5LWFmMTYtNGIwNy05ZGVj
-        LWI1YWU5ZTM2M2VjYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc2NDRkOTU2LTk2NGYtNDQ4Ni04ZDI2
+        LTY4NzMxZDZjZWNjNy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b6e79f7a5182487092cb735448f63e1d
+      - d7df3394bd364744bc8da76d36294db4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ca7b957062474f3ab488f0978ae8e51c
+      - bac6b583eef444948529295236ec00d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 171118788d66476ab94663538ea397db
+      - f721029b1e594812b16ae55672563990
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a1878a1a60bd4d15a2935c5f338177bf
+      - 308735f59921456abbfb7bdc0a87becd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83ce000a3be0464a97efbb5e7edf787b
+      - 7c1944db0b44440dbe57ca969d3571c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2020e73841ee4157971f259ea186c7f6
+      - 32454079720c4163a9a9e6031774b1cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:27 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:29 GMT
+      - Fri, 29 Jul 2022 11:29:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 462b3bedcc644325bc11d000ffb17254
+      - 6a36720618d5460aacd2e9ae80e399c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMGFhMDVlNDktNzU4Yy00NzIyLTliZjgtNTA2ZDFhZTdjYjZhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MjkuODIwOTM1WiIsInZl
+        cG0vOWViN2YwMjUtNzJkYi00NTA2LWE4N2ItOTZjNGI3YmJmNWY2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MjguMTc4MTQ2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMGFhMDVlNDktNzU4Yy00NzIyLTliZjgtNTA2ZDFhZTdjYjZhL3ZlcnNp
+        cG0vOWViN2YwMjUtNzJkYi00NTA2LWE4N2ItOTZjNGI3YmJmNWY2L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wYWEwNWU0OS03
-        NThjLTQ3MjItOWJmOC01MDZkMWFlN2NiNmEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85ZWI3ZjAyNS03
+        MmRiLTQ1MDYtYTg3Yi05NmM0YjdiYmY1ZjYvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:29 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:28 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/bf4941dc-528a-4aa9-b5e5-970b37eca27a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b9f868fb-0209-4d8c-bcde-a25587f8838b/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:30 GMT
+      - Fri, 29 Jul 2022 11:29:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5fab4e617c7f4d449fe95aa32dc0fef7
+      - 1706df808d98428d99fa4262f8a4b586
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmZmE1Nzg3LTAzNzgtNGNi
-        NS1iMDQ2LTliYWY4MDQzMGYyMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlMTNkOTZmLWEzODItNGE3
+        NC1iZjJmLWFjODBiZmJlZDNjYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/effa5787-0378-4cb5-b046-9baf80430f22/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fe13d96f-a382-4a74-bf2f-ac80bfbed3cc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:30 GMT
+      - Fri, 29 Jul 2022 11:29:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c4e1991cf54f4c98b43ff3240cedf804
+      - a16d981d923f4301920967fd55dd8d67
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWZmYTU3ODctMDM3
-        OC00Y2I1LWIwNDYtOWJhZjgwNDMwZjIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzAuMjUwNjY5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmUxM2Q5NmYtYTM4
+        Mi00YTc0LWJmMmYtYWM4MGJmYmVkM2NjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjguNjIyNjI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI1ZmFiNGU2MTdjN2Y0ZDQ0OWZlOTVhYTMy
-        ZGMwZmVmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjMwLjI4
-        ODcxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MzAuMzEz
-        MjI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIxNzA2ZGY4MDhkOTg0MjhkOTlmYTQyNjJm
+        OGE0YjU4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjI4LjY5
+        NDY3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MjguNzI4
+        OTM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JmNDk0MWRjLTUyOGEtNGFhOS1iNWU1
-        LTk3MGIzN2VjYTI3YS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I5Zjg2OGZiLTAyMDktNGQ4Yy1iY2Rl
+        LWEyNTU4N2Y4ODM4Yi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:28 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2JmNDk0
-        MWRjLTUyOGEtNGFhOS1iNWU1LTk3MGIzN2VjYTI3YS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I5Zjg2
+        OGZiLTAyMDktNGQ4Yy1iY2RlLWEyNTU4N2Y4ODM4Yi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:30 GMT
+      - Fri, 29 Jul 2022 11:29:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d0844b1161fc4bcca0fbd2c45cb7cb76
+      - 5308bf39dbb74820b5e1cffd24aa8a01
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2OTllZmNjLTBmNDktNGJi
-        MC1iNzY0LWY4MDZkZjAwZGYyNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjOTUzMWY1LWNhOGUtNDIz
+        NC05NzQ1LWEwNWFmNDJlYTNjZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:30 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:28 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e699efcc-0f49-4bb0-b764-f806df00df25/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/fc9531f5-ca8e-4234-9745-a05af42ea3cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:32 GMT
+      - Fri, 29 Jul 2022 11:29:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ffe92e5c24564e7a8058787413e97df1
+      - f2a6b096784d48999f1f51ddac8740c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '597'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTY5OWVmY2MtMGY0
-        OS00YmIwLWI3NjQtZjgwNmRmMDBkZjI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzAuNDM0MTk0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmM5NTMxZjUtY2E4
+        ZS00MjM0LTk3NDUtYTA1YWY0MmVhM2NmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MjguOTE2NTc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkMDg0NGIxMTYxZmM0YmNjYTBm
-        YmQyYzQ1Y2I3Y2I3NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjMwLjQ2NDgzOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        MzIuMDc3MDEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI1MzA4YmYzOWRiYjc0ODIwYjVl
+        MWNmZmQyNGFhOGEwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjI4Ljk4NDgwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MzMuMTYzNDI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMzc0ZGUwOTQtODUyZi00OTNkLTg5NDEt
-        NzY0MTBjMjIxZDBmL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzM3NGRlMDk0LTg1MmYtNDkzZC04OTQxLTc2NDEwYzIyMWQwZi8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9iZjQ5NDFkYy01Mjhh
-        LTRhYTktYjVlNS05NzBiMzdlY2EyN2EvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2I5MDkzYjUyLTYyOGMtNGEyYS1iOWUxLWQ4
+        N2E1YTVmM2Q3NC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9i
+        OTA5M2I1Mi02MjhjLTRhMmEtYjllMS1kODdhNWE1ZjNkNzQvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYjlmODY4ZmItMDIwOS00
+        ZDhjLWJjZGUtYTI1NTg3Zjg4MzhiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:33 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMzc0ZGUwOTQtODUyZi00OTNkLTg5NDEtNzY0MTBjMjIx
-        ZDBmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYjkwOTNiNTItNjI4Yy00YTJhLWI5ZTEtZDg3YTVhNWYz
+        ZDc0L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:32 GMT
+      - Fri, 29 Jul 2022 11:29:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8f2da8adf5146d8a4f85eb62bc48116
+      - b85c30805d63487092f41f6cbdc500fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyN2NhNjY4LWZmZWItNDFi
-        OC04NDE5LWRhMWY3OWE4NTI4Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxZTgwYzQ2LWQwNTEtNDMx
+        Mi1iYWZmLTRkOTFhYzE0NDJlZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/927ca668-ffeb-41b8-8419-da1f79a85286/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/91e80c46-d051-4312-baff-4d91ac1442ed/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:32 GMT
+      - Fri, 29 Jul 2022 11:29:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7955f780008d4569bf692f5c11733829
+      - 8ebacc609d9547c5ad7ea24a2c45df34
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTI3Y2E2NjgtZmZl
-        Yi00MWI4LTg0MTktZGExZjc5YTg1Mjg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzIuMjczNjgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTFlODBjNDYtZDA1
+        MS00MzEyLWJhZmYtNGQ5MWFjMTQ0MmVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MzMuNTg0NDMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImM4ZjJkYThhZGY1MTQ2ZDhhNGY4NWViNjJi
-        YzQ4MTE2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6MzIuMzAz
-        NTE3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDozMi40ODc3
-        NDVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImI4NWMzMDgwNWQ2MzQ4NzA5MmY0MWY2Y2Jk
+        YzUwMGZlIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MzMuNjM2
+        NTYyWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOTozNC4xMjYz
+        OTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZmZlMWU1
-        NDEtZDg5MC00YzFmLTg1OTQtZWU3NjZkODlkYjEzLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYmRhNTdk
+        YzctZWM0Yy00MDY4LWEzMTMtZjc4ZDlhZTgxNWY4LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMzc0ZGUwOTQtODUyZi00OTNkLTg5NDEtNzY0MTBj
-        MjIxZDBmLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYjkwOTNiNTItNjI4Yy00YTJhLWI5ZTEtZDg3YTVh
+        NWYzZDc0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:32 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0c7ad3c654664409b050361f8488c342
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:32 GMT
+      - Fri, 29 Jul 2022 11:29:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 071ee0e1dc8040a392e2229ad324aed8
+      - 7d9379ef4c3646b4a849a7fe64b8b605
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/bda57dc7-ec4c-4068-a313-f78d9ae815f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:32 GMT
+      - Fri, 29 Jul 2022 11:29:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7a2fe1ff0c304e69b42ae9a1dde1a198
+      - 51cd35e4aa7e48638be8fc87d86aeba7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vYmRhNTdkYzctZWM0Yy00MDY4LWEzMTMtZjc4ZDlhZTgxNWY4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MzMuNjY3MjkxWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9iOTA5M2I1Mi02MjhjLTRhMmEtYjllMS1kODdhNWE1ZjNkNzQv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2I5MDkzYjUyLTYyOGMtNGEyYS1iOWUxLWQ4N2E1
+        YTVmM2Q3NC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:34 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS9iZGE1N2RjNy1lYzRjLTQwNjgtYTMxMy1mNzhkOWFlODE1Zjgv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f8fcdab4e30e41e99b4751926c2ddbb3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1YzY3ZTY5LTE4NzItNDJj
+        ZC04MTU1LWJhM2I4MWYzNTcyYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d5c67e69-1872-42cd-8155-ba3b81f3572a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7b56fb7bc0634162b52dc71534c1d3c7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDVjNjdlNjktMTg3
+        Mi00MmNkLTgxNTUtYmEzYjgxZjM1NzJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MzQuNDg3NzYzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmOGZjZGFiNGUzMGU0MWU5OWI0NzUxOTI2
+        YzJkZGJiMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjM0LjU0
+        NjMwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MzQuOTcw
+        ODMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZTJj
+        YmJkYWYtZGQ2Ni00YTgzLWE4YWQtM2E2YzY5ZDk0YzU0LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/e2cbbdaf-dd66-4a83-a8ad-3a6c69d94c54/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b5fe53106eb43c78c03096cc2adbfc2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2UyY2JiZGFmLWRkNjYtNGE4My1hOGFkLTNhNmM2OWQ5NGM1NC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjM0Ljk0Mjc1MVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vYmRhNTdkYzctZWM0Yy00MDY4LWEzMTMt
+        Zjc4ZDlhZTgxNWY4LyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 03056c55e744410f82880f0a1becb813
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bc61f51241cb4df78c26fbead7306081
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - be659243ac4748ca8e35c124aa2c1341
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:32 GMT
+      - Fri, 29 Jul 2022 11:29:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96b50326fc394aa8b427413d99b2d071
+      - f2d20db224b14c54a1755b94b2c078a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:32 GMT
+      - Fri, 29 Jul 2022 11:29:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ff920a0782e14dd197f765ab22dae61a
+      - 24e5c01e952748599a9a3af89ab0b9f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:32 GMT
+      - Fri, 29 Jul 2022 11:29:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c68e9ebb48454d1798da48f2c4f4d70e
+      - dfaf4f3aa95f49a78a045ac9a44572b2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:32 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 488b31edd0084f40aacac7d0843b7df8
+      - 6d3cd69b6ad04eddb5834fbaa36cff8a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 628ce959781a4ea58fc026441aaef2a3
+      - 6666c938baa84b59b113ba31d85365b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 46070d00e7744d9b86a4989a6d2966fa
+      - 0f2dd053409d42a790c3adddce0ca06b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/374de094-852f-493d-8941-76410c221d0f/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b9093b52-628c-4a2a-b9e1-d87a5a5f3d74/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c4f11166a274c14954744348e91694c
+      - 4ae6b3e0607a4784bc0d1d91407ac886
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,37 +3208,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 63856d1272ca42c29dcd4993ce85e597
+      - c3e027c3d36545159310b313a6bcf686
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhODM4MTg5LWRkNGEtNDg0
-        MS05ZTgyLWM3MjUyYTJkZWNlYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwMjgwMWM3LWY5MmUtNDAz
+        OS04OWRkLTMzNjVmMWJmOTBkMy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzc0ZGUwOTQtODUyZi00OTNkLTg5
-        NDEtNzY0MTBjMjIxZDBmL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBhYTA1ZTQ5LTc1OGMt
-        NDcyMi05YmY4LTUwNmQxYWU3Y2I2YS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2My03YjIyLTRhYjkt
-        YWVlNi05NjQxZmIzZjVjNTEvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjkwOTNiNTItNjI4Yy00YTJhLWI5
+        ZTEtZDg3YTVhNWYzZDc0L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzllYjdmMDI1LTcyZGIt
+        NDUwNi1hODdiLTk2YzRiN2JiZjVmNi8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4My0wNjI2LTRlMTgt
+        OGJlYy02M2Q2YmNlZDdiYjMvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
         YWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2826,7 +3251,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2844,21 +3269,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c4c6fce2cd90419da7a5e204e1eb23b7
+      - eedc3ced75504a2590261056fff5a8be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1ODdjMGE1LWYwNzYtNDJh
-        Zi1hMjM5LTBmMDUxNzYwOTAyMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1NDYwMWYxLWE0MzItNDA0
+        Yy1iOTY4LTNmYTE4MmJlOTVmNC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2a838189-dd4a-4841-9e82-c7252a2decec/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/902801c7-f92e-4039-89dd-3365f1bf90d3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2879,51 +3304,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e6bcea1c0f64da5b2b4ca390e1b75d7
+      - 782bbb645d764f15a44662e86d63b2cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmE4MzgxODktZGQ0
-        YS00ODQxLTllODItYzcyNTJhMmRlY2VjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzMuMzgzOTU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTAyODAxYzctZjky
+        ZS00MDM5LTg5ZGQtMzM2NWYxYmY5MGQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MzYuNzk2MzI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2Mzg1NmQxMjcyY2E0MmMyOWRj
-        ZDQ5OTNjZTg1ZTU5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjMzLjQ0MDg5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        MzMuNTg1MzkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjM2UwMjdjM2QzNjU0NTE1OTMx
+        MGIzMTNhNmJjZjY4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjM2Ljg0ODMyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MzcuMzYzNDYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGFhMDVlNDktNzU4
-        Yy00NzIyLTliZjgtNTA2ZDFhZTdjYjZhLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWViN2YwMjUtNzJk
+        Yi00NTA2LWE4N2ItOTZjNGI3YmJmNWY2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2a838189-dd4a-4841-9e82-c7252a2decec/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/902801c7-f92e-4039-89dd-3365f1bf90d3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2944,51 +3369,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e2adc7373544f6c90b0b4af9a655857
+      - 46a16c8eabf44ddd8f535f8a340d81f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmE4MzgxODktZGQ0
-        YS00ODQxLTllODItYzcyNTJhMmRlY2VjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzMuMzgzOTU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTAyODAxYzctZjky
+        ZS00MDM5LTg5ZGQtMzM2NWYxYmY5MGQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MzYuNzk2MzI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2Mzg1NmQxMjcyY2E0MmMyOWRj
-        ZDQ5OTNjZTg1ZTU5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjMzLjQ0MDg5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        MzMuNTg1MzkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjM2UwMjdjM2QzNjU0NTE1OTMx
+        MGIzMTNhNmJjZjY4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjM2Ljg0ODMyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MzcuMzYzNDYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGFhMDVlNDktNzU4
-        Yy00NzIyLTliZjgtNTA2ZDFhZTdjYjZhLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWViN2YwMjUtNzJk
+        Yi00NTA2LWE4N2ItOTZjNGI3YmJmNWY2LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a587c0a5-f076-42af-a239-0f0517609021/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/902801c7-f92e-4039-89dd-3365f1bf90d3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3009,55 +3434,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e68229dca52480db633319880d4a4ff
+      - d12830c28787481ab32690d4b4b8a253
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '416'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTU4N2MwYTUtZjA3
-        Ni00MmFmLWEyMzktMGYwNTE3NjA5MDIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6MzMuNDYzODc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTAyODAxYzctZjky
+        ZS00MDM5LTg5ZGQtMzM2NWYxYmY5MGQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MzYuNzk2MzI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjM2UwMjdjM2QzNjU0NTE1OTMx
+        MGIzMTNhNmJjZjY4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjM2Ljg0ODMyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MzcuMzYzNDYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWViN2YwMjUtNzJk
+        Yi00NTA2LWE4N2ItOTZjNGI3YmJmNWY2LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/902801c7-f92e-4039-89dd-3365f1bf90d3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '613'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e4e342a128f44123ba326720b39b65cf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTAyODAxYzctZjky
+        ZS00MDM5LTg5ZGQtMzM2NWYxYmY5MGQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MzYuNzk2MzI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjM2UwMjdjM2QzNjU0NTE1OTMx
+        MGIzMTNhNmJjZjY4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjM2Ljg0ODMyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MzcuMzYzNDYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5
+        ZDAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWViN2YwMjUtNzJk
+        Yi00NTA2LWE4N2ItOTZjNGI3YmJmNWY2LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/454601f1-a432-404c-b968-3fa182be95f4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5bc5eecaef3c4926b436b32929621af1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDU0NjAxZjEtYTQz
+        Mi00MDRjLWI5NjgtM2ZhMTgyYmU5NWY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MzYuODg3MDY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiYzRjNmZjZTJjZDkwNDE5ZGE3YTVlMjA0ZTFl
-        YjIzYjciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDozMy42MTc0
-        NTBaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjMzLjc2MDUx
-        OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvZTg0NzU3YWItODI0Yy00YmE0LWE1YWYtZWY4NzgwZDI5MDUxLyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiZWVkYzNjZWQ3NTUwNGEyNTkwMjYxMDU2ZmZm
+        NWE4YmUiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOTozNy40MzYz
+        NDZaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjM3Ljg5NTk2
+        NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvNTlkZTU1NzUtM2RkNy00OWVlLTlmNjYtMDU5ODNhNGJmMjA4LyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGFhMDVl
-        NDktNzU4Yy00NzIyLTliZjgtNTA2ZDFhZTdjYjZhL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWViN2Yw
+        MjUtNzJkYi00NTA2LWE4N2ItOTZjNGI3YmJmNWY2L3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzBhYTA1ZTQ5LTc1OGMtNDcyMi05YmY4LTUw
-        NmQxYWU3Y2I2YS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzM3NGRlMDk0LTg1MmYtNDkzZC04OTQxLTc2NDEwYzIyMWQw
-        Zi8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzllYjdmMDI1LTcyZGItNDUwNi1hODdiLTk2
+        YzRiN2JiZjVmNi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2I5MDkzYjUyLTYyOGMtNGEyYS1iOWUxLWQ4N2E1YTVmM2Q3
+        NC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3065,7 +3620,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3078,41 +3633,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - df08f7dc2a71420b9c4db2472d358c81
+      - cf5d5d6b1d434899abd6ba5485490509
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80ZWVhYjY2My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEv
+        YWNrYWdlcy82YTVmNjY4My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3120,7 +3675,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3133,7 +3688,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3151,21 +3706,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 89c6830546e3419db545f2a6e458ae92
+      - 888ea4e57b7044cba8232934124d3bad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3173,7 +3728,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3186,7 +3741,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:33 GMT
+      - Fri, 29 Jul 2022 11:29:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3204,21 +3759,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d172c28da9445e4b10e3607e7126384
+      - 1f3b239e41f4449099c98fbf72121829
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:33 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3226,7 +3781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3239,7 +3794,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3257,21 +3812,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b0db7bc42870418691553cf4157f7897
+      - 7c46fc008c6147159ec7324529d7c1a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3279,7 +3834,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3292,7 +3847,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3310,21 +3865,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d46c6bb564c4457284671aa1eb0dd8d4
+      - 81506be874e443ef9b3efde79b489482
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3332,7 +3887,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3345,7 +3900,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3363,21 +3918,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7b7d148472454a9cb72c79059b5f76af
+      - b65f76aacac94279bb5ac387688ff388
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3385,7 +3940,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3398,41 +3953,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6744c8fbec3e49cf8a400d69943aea5a
+      - 14a7cb9107fe4fc7a0350a78ae3fd5fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy80ZWVhYjY2My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEv
+        YWNrYWdlcy82YTVmNjY4My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3440,7 +3995,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3453,7 +4008,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3471,21 +4026,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e8568d09d8c4606955bd27d35eeb226
+      - 52150eae2afd487991ced5ec3347d2b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3493,7 +4048,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3506,7 +4061,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3524,21 +4079,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8d4f9379c6c4dbb8830b06262304d97
+      - 4aab3f2916ab4f1f811a5512dffc4203
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3546,7 +4101,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3559,7 +4114,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3577,21 +4132,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b99214014fda47d4b1bc8b2477c34858
+      - 5c901048850c4f6c93995579e49a05ab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3599,7 +4154,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3612,7 +4167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3630,21 +4185,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39b8f778252e43e7a0902982f827b19c
+      - 9d76a26646c74f0ca938b44370bab3b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/0aa05e49-758c-4722-9bf8-506d1ae7cb6a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/9eb7f025-72db-4506-a87b-96c4b7bbf5f6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3652,7 +4207,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3665,7 +4220,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:34 GMT
+      - Fri, 29 Jul 2022 11:29:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3683,16 +4238,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56dec455d72f4c448525ad6bb0013374
+      - f52b0f2b2ea44bfebb075d82699dd1c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:34 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:39 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_whitelist_name_filter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_repository/yum_copy_with_whitelist_name_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,41 +23,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:42 GMT
+      - Fri, 29 Jul 2022 11:31:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 65e1da64eafc412da6e17c5497547bf6
+      - 19e66633e1c6409ca2b45dbd60f4cba6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '316'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNjc3MGZkMy03MzA3LTQxMmYtYjUxMy04NThmZTJiMDM3ZDgv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDozNi4xNzIzMDFa
+        cnBtL3JwbS9hYzRiYzA2NC04MDJkLTQ1NjgtYTUzMi02NTU1ZTFkZDA1NjEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTowNi42MDMwNDJa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zNjc3MGZkMy03MzA3LTQxMmYtYjUxMy04NThmZTJiMDM3ZDgv
+        cnBtL3JwbS9hYzRiYzA2NC04MDJkLTQ1NjgtYTUzMi02NTU1ZTFkZDA1NjEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzM2Nzcw
-        ZmQzLTczMDctNDEyZi1iNTEzLTg1OGZlMmIwMzdkOC92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2FjNGJj
+        MDY0LTgwMmQtNDU2OC1hNTMyLTY1NTVlMWRkMDU2MS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -66,10 +66,10 @@ http_interactions:
         Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
         ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:42 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:21 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/36770fd3-7307-412f-b513-858fe2b037d8/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/ac4bc064-802d-4568-a532-6555e1dd0561/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -90,7 +90,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:42 GMT
+      - Fri, 29 Jul 2022 11:31:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -108,21 +108,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7c4070a2cd374a20a23365ab118438f6
+      - 632f35d4f7ad43919024758d97c1dcf3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4MTEyZDdhLTc1ZTgtNGZl
-        Mi05NGVhLTdiMmQyMWJlMGZiNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5YzRlNmI4LTlhMzYtNDFj
+        OC05MTYzLTU4ZWIwMDJmZDJlMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:42 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:42 GMT
+      - Fri, 29 Jul 2022 11:31:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c819946e5bdf48619be7c63b4e91188e
+      - 864e989009e14a7e9e0d55a72fdb1bfc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:42 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:21 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/08112d7a-75e8-4fe2-94ea-7b2d21be0fb4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/19c4e6b8-9a36-41c8-9163-58eb002fd2e0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,51 +196,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:42 GMT
+      - Fri, 29 Jul 2022 11:31:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e87ef9ee107d47699d10017c2b061191
+      - 777b71caacbb4bb2b43cefdd60d2bb3b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDgxMTJkN2EtNzVl
-        OC00ZmUyLTk0ZWEtN2IyZDIxYmUwZmI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDIuNjIzMjcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTljNGU2YjgtOWEz
+        Ni00MWM4LTkxNjMtNThlYjAwMmZkMmUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MjEuNjM0NTkwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3YzQwNzBhMmNkMzc0YTIwYTIzMzY1YWIx
-        MTg0MzhmNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjQyLjY1
-        NTAwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NDIuNzgw
-        NDg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2MzJmMzVkNGY3YWQ0MzkxOTAyNDc1OGQ5
+        N2MxZGNmMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjIxLjcw
+        NzY3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MjIuMTM5
+        ODE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzY3NzBmZDMtNzMwNy00MTJm
-        LWI1MTMtODU4ZmUyYjAzN2Q4LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYWM0YmMwNjQtODAyZC00NTY4
+        LWE1MzItNjU1NWUxZGQwNTYxLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:42 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -248,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -261,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:42 GMT
+      - Fri, 29 Jul 2022 11:31:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dd0f21212aae4615ad55f71973d3bd78
+      - 76031690b5ec41b1822d00eefedf61cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:42 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +314,185 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:42 GMT
+      - Fri, 29 Jul 2022 11:31:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '448'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9db866dcb00b4361a41e6c5f07df86fc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZDZkYTg0NmQtNWJmYy00YmQ3LWFjM2ItZGVhODg3ZWM1NzBj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MTUuNTQzMjQ3
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/d6da846d-5bfc-4bd7-ac3b-dea887ec570c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 823208f8a23b46be8cb89f8550dfdfdd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4Yzk2YTU5LWUzNGEtNDJm
+        Yy1hNWNjLWQ0YjZjOTVhOTgwZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/18c96a59-e34a-42fc-a5cc-d4b6c95a980e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '558'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 03366c2bccb542f0a9d5c2f120d35568
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMThjOTZhNTktZTM0
+        YS00MmZjLWE1Y2MtZDRiNmM5NWE5ODBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MjIuMzkxODA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4MjMyMDhmOGEyM2I0NmJlOGNiODlmODU1
+        MGRmZGZkZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjIyLjQ2
+        OTI2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MjIuNjM5
+        NDc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56438b9161954e76bfe60ef287850129
+      - fa1ba67c6f4348f6a9cf9a9ee9822336
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:42 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -354,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -385,21 +563,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 88f2c91a7a8740f39cf86f55ca775945
+      - 14163cebd1d8464e8dc7c2cc5af829ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -407,7 +585,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -420,7 +598,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -438,21 +616,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - faab5d55979541938836b480b27da50b
+      - 5c8265e0043a47f29b5236a5ea34df8d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -473,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -491,74 +669,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8ad1d64862fe42f9ad4082ea78bcb889
+      - b6ece2ab687a4ba3bca285592a9433f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:43 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2254ec4c9f9e4494857858afab52e044
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:22 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -575,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -588,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/8a90a589-68ea-4512-bc21-3fd8036eb9e3/"
+      - "/pulp/api/v3/remotes/rpm/rpm/2f6bb831-3196-4d75-a67e-17d40cb7d1ef/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -608,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 582c192188c04bf9875d8e818dc4b0b4
+      - fe5d9735a7944dea9f70a79c3f29ef5c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhh
-        OTBhNTg5LTY4ZWEtNDUxMi1iYzIxLTNmZDgwMzZlYjllMy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjQzLjIzODUwNloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzJm
+        NmJiODMxLTMxOTYtNGQ3NS1hNjdlLTE3ZDQwY2I3ZDFlZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjIzLjAzNjQ1NVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI0OjQzLjIzODUyNVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjIzLjAzNjg0MFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:23 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -643,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -656,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -676,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 61511d194b274bdbb4a4a90eda148524
+      - c589e13c3c9047a4af19db768cbaa95b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjVlN2E2ZGYtNDEzOS00Zjc4LTk5YTQtNzkwN2RkMzMwNDg5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NDMuMzcyMDgzWiIsInZl
+        cG0vZTJlMDZjZDAtZDQ5OC00ZmQwLThjMWEtNTFlYzM1NjNlZjEzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MjMuMjIwNDcxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMjVlN2E2ZGYtNDEzOS00Zjc4LTk5YTQtNzkwN2RkMzMwNDg5L3ZlcnNp
+        cG0vZTJlMDZjZDAtZDQ5OC00ZmQwLThjMWEtNTFlYzM1NjNlZjEzL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yNWU3YTZkZi00
-        MTM5LTRmNzgtOTlhNC03OTA3ZGQzMzA0ODkvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMmUwNmNkMC1k
+        NDk4LTRmZDAtOGMxYS01MWVjMzU2M2VmMTMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -700,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1f4bc374e26c4ef78201b063abe99df8
+      - c1d10c9b0fe74fdf97119b7857021ef8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '311'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zYWQ0NzIwOS1kYTI2LTQ5YjMtOWRiOC04YTA2NzFiNDhkNGYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDozNi44NjE4NjNa
+        cnBtL3JwbS84MjE0MmMxMi02N2Y1LTRhOTMtODQyMi0yZmFkYWQxN2E4ZWUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTowOC41NTQzMTVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zYWQ0NzIwOS1kYTI2LTQ5YjMtOWRiOC04YTA2NzFiNDhkNGYv
+        cnBtL3JwbS84MjE0MmMxMi02N2Y1LTRhOTMtODQyMi0yZmFkYWQxN2E4ZWUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNhZDQ3
-        MjA5LWRhMjYtNDliMy05ZGI4LThhMDY3MWI0OGQ0Zi92ZXJzaW9ucy8xLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzgyMTQy
+        YzEyLTY3ZjUtNGE5My04NDIyLTJmYWRhZDE3YThlZS92ZXJzaW9ucy8xLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -766,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:23 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/3ad47209-da26-49b3-9db8-8a0671b48d4f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/82142c12-67f5-4a93-8422-2fadad17a8ee/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -790,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -808,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3dad05ac6c074d8ea4d33bd3ca4922d3
+      - 6dab529d83a4474890438934e5cb916c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1MGY5ZmNiLTQ0YjQtNGI2
-        ZS04YzUxLWJiZDYxYjA5OGE2Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhMzI2NTJkLTM5MmEtNGI1
+        ZS1hYWM1LTU4ZGY1YjkzNzJmMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -843,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96a750d279ea4f968cb83907889a678a
+      - 3efb24d78c3b4ccebf83a824bd433ec7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vZDcyYmUwOTEtYjk3NS00NzFiLWFhOGYtZjA3OWJkYzFhODNkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6MzYuMDYwMjU0WiIsIm5h
+        cG0vOTAwMDQxYjMtODNiYi00ZDIyLWE1ODEtODliM2UyMDk5ZTRhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MDYuMzcxNDc3WiIsIm5h
         bWUiOiIyIiwidXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3Bs
         ZS5vcmcvZmFrZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsImNhX2NlcnQiOm51
         bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
         cHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMi0wNS0yM1QyMzoyNDozNy4yMDA5MzdaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMi0wNy0yOVQxMTozMTowOS4yMzA2MTNaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5l
         Y3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAs
         InNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:23 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/d72be091-b975-471b-aa8f-f079bdc1a83d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/900041b3-83bb-4d22-a581-89b3e2099e4a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -908,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a0508cc3ec084ae6bfdf8237156b767b
+      - 22cd5d1a120344ef9e89726ad0342ab4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhNTcxNDhjLWMxNjEtNGZh
-        MC1iMmY5LTFmMDU0ZTk2NmRhZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JkMDA4YWEyLWYzMTktNDU0
+        NC1iYmI3LWM1MGRkMmVhYmQzMS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/950f9fcb-44b4-4b6e-8c51-bbd61b098a6c/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ba32652d-392a-4b5e-aac5-58df5b9372f1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f3c24fa157a4cf3829a17aae11922e4
+      - 75bfa89fb80741ab901a0cc7d7cbe0b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTUwZjlmY2ItNDRi
-        NC00YjZlLThjNTEtYmJkNjFiMDk4YTZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDMuNTI4MzUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmEzMjY1MmQtMzky
+        YS00YjVlLWFhYzUtNThkZjViOTM3MmYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MjMuNDkwNzYxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzZGFkMDVhYzZjMDc0ZDhlYTRkMzNiZDNj
-        YTQ5MjJkMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjQzLjU2
-        MDc3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NDMuNjE3
-        MzAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZGFiNTI5ZDgzYTQ0NzQ4OTA0Mzg5MzRl
+        NWNiOTE2YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjIzLjU2
+        MDQxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MjMuODU0
+        MjMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2FkNDcyMDktZGEyNi00OWIz
-        LTlkYjgtOGEwNjcxYjQ4ZDRmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODIxNDJjMTItNjdmNS00YTkz
+        LTg0MjItMmZhZGFkMTdhOGVlLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:23 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2a57148c-c161-4fa0-b2f9-1f054e966dad/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/bd008aa2-f319-4544-bbb7-c50dd2eabd31/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e3ed29947161459eb987425409392c93
+      - 075ea166bdea45f3b0efdb275b547171
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmE1NzE0OGMtYzE2
-        MS00ZmEwLWIyZjktMWYwNTRlOTY2ZGFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDMuNjEzNjU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmQwMDhhYTItZjMx
+        OS00NTQ0LWJiYjctYzUwZGQyZWFiZDMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MjMuNjU3MjEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhMDUwOGNjM2VjMDg0YWU2YmZkZjgyMzcx
-        NTZiNzY3YiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjQzLjY0
-        NjQ0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NDMuNjg4
-        ODk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMmNkNWQxYTEyMDM0NGVmOWU4OTcyNmFk
+        MDM0MmFiNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjIzLjc4
+        NzE1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MjQuMDE4
+        MjQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q3MmJlMDkxLWI5NzUtNDcxYi1hYThm
-        LWYwNzliZGMxYTgzZC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkwMDA0MWIzLTgzYmItNGQyMi1hNTgx
+        LTg5YjNlMjA5OWU0YS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1078,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1091,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d5adde4a5cd14ff79f07307686a6004c
+      - 9ee3712c8fc64e3c82d801db33cee014
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1144,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1162,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a3479d9f94f455cb6af19e45e838459
+      - a1276659a3d94f92a75a9be54b7232d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1215,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 941fd947fc9446fc8aded2d513652fcf
+      - 5ee28a332f1e4bf1ba9269c09bd4428d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1268,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95d6078c3300486eafab6562fc6a02d0
+      - 8856c7aa7dec47db906f69fe02975ac3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1290,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1303,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1321,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bab39d98984541869bea19cc1239096a
+      - e78deeb905554b81b49805b7dad2c27d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:24 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1343,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1356,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:43 GMT
+      - Fri, 29 Jul 2022 11:31:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c540096e8f504dc39d5f9b966d577a6c
+      - c69d5dc8a4864181959a30286a46ed64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:43 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:24 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1398,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1411,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:44 GMT
+      - Fri, 29 Jul 2022 11:31:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1431,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f736809e667740bfbd4cdfd2d18e09e8
+      - 58094980a3234c049585255455c1e36e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2E1MzkwMmEtN2M1YS00OWQxLWE2ZGEtYmQwYTAyMTZkMzIwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjQ6NDQuMDY4Mzk2WiIsInZl
+        cG0vZDk5NWFmMGUtMzNlYy00OTQ5LTk4YmMtMzQyMzk1NGZkM2FhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MjQuNjQyODQ4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2E1MzkwMmEtN2M1YS00OWQxLWE2ZGEtYmQwYTAyMTZkMzIwL3ZlcnNp
+        cG0vZDk5NWFmMGUtMzNlYy00OTQ5LTk4YmMtMzQyMzk1NGZkM2FhL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83YTUzOTAyYS03
-        YzVhLTQ5ZDEtYTZkYS1iZDBhMDIxNmQzMjAvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kOTk1YWYwZS0z
+        M2VjLTQ5NDktOThiYy0zNDIzOTU0ZmQzYWEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1454,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:44 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:24 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/8a90a589-68ea-4512-bc21-3fd8036eb9e3/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/2f6bb831-3196-4d75-a67e-17d40cb7d1ef/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1474,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1487,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:44 GMT
+      - Fri, 29 Jul 2022 11:31:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1505,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cfc76998ddb14f1e89752d0bf691f7b4
+      - da50e456560c4be58a159b0ba50a2d81
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5NWU5YmJiLWRmYWUtNDlj
-        ZC04MjYzLThjYWZhYzhiOGQxZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkNTFhOGU4LWQ4MTMtNDFk
+        NS1iOGViLWIyZGU1NGY4YTkxMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:44 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/495e9bbb-dfae-49cd-8263-8cafac8b8d1d/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/2d51a8e8-d813-41d5-b8eb-b2de54f8a912/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1540,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:44 GMT
+      - Fri, 29 Jul 2022 11:31:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c66dc19ae7147ab8bda319f923b4c02
+      - e932bfda19bd45398acd4aaea30090c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDk1ZTliYmItZGZh
-        ZS00OWNkLTgyNjMtOGNhZmFjOGI4ZDFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDQuMzM3NTQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ1MWE4ZTgtZDgx
+        My00MWQ1LWI4ZWItYjJkZTU0ZjhhOTEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MjUuMTQ3MjEwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiJjZmM3Njk5OGRkYjE0ZjFlODk3NTJkMGJm
-        NjkxZjdiNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjQ0LjM2
-        OTQ5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NDQuMzkx
-        MDMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkYTUwZTQ1NjU2MGM0YmU1OGExNTliMGJh
+        NTBhMmQ4MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjI1LjIy
+        NjI3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MjUuNDA3
+        ODIzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhhOTBhNTg5LTY4ZWEtNDUxMi1iYzIx
-        LTNmZDgwMzZlYjllMy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzJmNmJiODMxLTMxOTYtNGQ3NS1hNjdl
+        LTE3ZDQwY2I3ZDFlZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:44 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:25 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzhhOTBh
-        NTg5LTY4ZWEtNDUxMi1iYzIxLTNmZDgwMzZlYjllMy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzJmNmJi
+        ODMxLTMxOTYtNGQ3NS1hNjdlLTE3ZDQwY2I3ZDFlZi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1609,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:44 GMT
+      - Fri, 29 Jul 2022 11:31:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1627,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 16b2a85a745645ce9e47114373d46e46
+      - d771eb8e178b4995ab12b2c11a25a8f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlMGZjYjdiLTQ4NzYtNGVi
-        MS04NTg5LTcyZDhiNTk3YjllNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzljYTU1NzkzLTUwZmYtNGU3
+        MC05NjY0LWMzZjEwMTk3MWE2Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:44 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:25 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/be0fcb7b-4876-4eb1-8589-72d8b597b9e4/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/9ca55793-50ff-4e70-9664-c3f101971a6f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:46 GMT
+      - Fri, 29 Jul 2022 11:31:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c7e05f1f022f4183aa864e5812cc8fac
+      - ea9ed3dd76034bd389d3581b61444846
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '600'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmUwZmNiN2ItNDg3
-        Ni00ZWIxLTg1ODktNzJkOGI1OTdiOWU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDQuNTEyODUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWNhNTU3OTMtNTBm
+        Zi00ZTcwLTk2NjQtYzNmMTAxOTcxYTZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MjUuNTkwNTMyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxNmIyYTg1YTc0NTY0NWNlOWU0
-        NzExNDM3M2Q0NmU0NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjQ0LjU0MzM4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NDYuMTQ5MDA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJkNzcxZWI4ZTE3OGI0OTk1YWIx
+        MmIyYzExYTI1YThmMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjI1LjY1ODM3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        MzAuNzA2NTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1709,35 +1834,35 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
         InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMjVlN2E2ZGYtNDEzOS00Zjc4LTk5YTQt
-        NzkwN2RkMzMwNDg5L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzI1ZTdhNmRmLTQxMzktNGY3OC05OWE0LTc5MDdkZDMzMDQ4OS8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS84YTkwYTU4OS02OGVh
-        LTQ1MTItYmMyMS0zZmQ4MDM2ZWI5ZTMvIl19
+        dG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcuYWR2
+        aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUi
+        OjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2UyZTA2Y2QwLWQ0OTgtNGZkMC04YzFhLTUx
+        ZWMzNTYzZWYxMy92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9l
+        MmUwNmNkMC1kNDk4LTRmZDAtOGMxYS01MWVjMzU2M2VmMTMvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMmY2YmI4MzEtMzE5Ni00
+        ZDc1LWE2N2UtMTdkNDBjYjdkMWVmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:46 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:30 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMjVlN2E2ZGYtNDEzOS00Zjc4LTk5YTQtNzkwN2RkMzMw
-        NDg5L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZTJlMDZjZDAtZDQ5OC00ZmQwLThjMWEtNTFlYzM1NjNl
+        ZjEzL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1750,7 +1875,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:46 GMT
+      - Fri, 29 Jul 2022 11:31:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,21 +1893,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb98ee947daa4eba92307c4254336872
+      - 9da06d14f670479fa4a7dfe2896742ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmY2YzZDZkLTlkMGEtNGNi
-        My05MWNlLTkyMDQxNWRmYzA2OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiZWRiMGRhLTNjZjYtNGQ2
+        YS05MGRmLTk5NTU1MzFlZTdjZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:46 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/afcf3d6d-9d0a-4cb3-91ce-920415dfc068/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/cbedb0da-3cf6-4d6a-90df-9955531ee7cd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1803,56 +1928,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:46 GMT
+      - Fri, 29 Jul 2022 11:31:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 67443e2ebcaa43f5b99e150bce5fcfb6
+      - a504ab3817a9440681f23eb83c55008e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWZjZjNkNmQtOWQw
-        YS00Y2IzLTkxY2UtOTIwNDE1ZGZjMDY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDYuMzM1NTUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2JlZGIwZGEtM2Nm
+        Ni00ZDZhLTkwZGYtOTk1NTUzMWVlN2NkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MzEuMDM1NTQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImJiOThlZTk0N2RhYTRlYmE5MjMwN2M0MjU0
-        MzM2ODcyIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6NDYuMzg1
-        MzA1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDo0Ni41ODM0
-        MDVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjlkYTA2ZDE0ZjY3MDQ3OWZhNGE3ZGZlMjg5
+        Njc0MmNhIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MzEuMDg4
+        MDM1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMTozMS41NzU1
+        ODFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMmY4ZjY0
-        NzYtNTc1Ny00MDVkLTlhZjUtY2NmODA4NWIzM2E0LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTM4YzYw
+        YWItMjE3Mi00Mjg2LWFkMjgtYWFhNDNkZTljZmYzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMjVlN2E2ZGYtNDEzOS00Zjc4LTk5YTQtNzkwN2Rk
-        MzMwNDg5LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZTJlMDZjZDAtZDQ5OC00ZmQwLThjMWEtNTFlYzM1
+        NjNlZjEzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:46 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1860,7 +1985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1873,326 +1998,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 687267b7420c447fa8ce960d342ad5c6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '3154'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvMWE1NzY1ZWUtNzA3OC00MzM4LWEwMzYtZmQ5MjczMDQ1MTk0
-        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
-        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
-        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
-        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
-        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
-        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy83MDFiYTAzNy01ZjhmLTQ3YmQtYTkwYS00
-        NTgxMWZlM2ZkODAvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
-        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
-        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYTNlMDNjZDEtM2MzNC00Y2Ji
-        LTlmODYtZjkyN2Y2YWMxZjljLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
-        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
-        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
-        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
-        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
-        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
-        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy80ZWVhYjY2
-        My03YjIyLTRhYjktYWVlNi05NjQxZmIzZjVjNTEvIiwibmFtZSI6IndhbHJ1
-        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
-        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
-        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
-        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
-        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
-        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lNWNhZTNmMy1iMmQwLTQyMmMtOWU5MS04ZWRkOWQ5ZDEx
-        NjIvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
-        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
-        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
-        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
-        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNGUzYjg2ZS1mYTQ0LTRi
-        NjYtYWVhZC1mZjg1MGI5MjZlNWMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRl
-        N2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6
-        InRyb3V0LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRy
-        b3V0LTAuMTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Mx
-        ZDY5MzBiLTI2MWMtNGRmNC05NjliLWUxNTYwNWFmM2YxMi8iLCJuYW1lIjoi
-        dGlnZXIiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6
-        IjQiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyNDAzNDNjMTI5Y2JlNWI2
-        MmUyOTIzNWJkMWMzOGFhODlhZWI2MjY3MWViNzY3OGZlMWNhZGU3NjI1NTM0
-        NTE3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB0aWdlciIsImxv
-        Y2F0aW9uX2hyZWYiOiJ0aWdlci0xLjAtNC5ub2FyY2gucnBtIiwicnBtX3Nv
-        dXJjZXJwbSI6InRpZ2VyLTEuMC00LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
-        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvODNhZTM3ODYtNmZmZS00NjllLWIzOGYtYTU0OGVhZWY1ZmEy
-        LyIsIm5hbWUiOiJzdG9yayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEy
-        IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzAx
-        NDVkZTc0NTUwODE1ODY1MDE0YzNjOGQ0N2JjNjU1NjBmYzY4YzE5Y2UwODVj
-        ZTE1MjNjOTRhMjMxMDY0Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
-        ZiBzdG9yayIsImxvY2F0aW9uX2hyZWYiOiJzdG9yay0wLjEyLTIubm9hcmNo
-        LnJwbSIsInJwbV9zb3VyY2VycG0iOiJzdG9yay0wLjEyLTIuc3JjLnJwbSIs
-        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlcy9lNTc2MDkwZi1lZjBlLTRhZWYtYjNi
-        Ny0yYTM4MjZkMDFkNmMvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIw
-        IiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJj
-        aCIsInBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNh
-        MDY3ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsInN1bW1hcnkiOiJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCJsb2NhdGlvbl9ocmVmIjoi
-        c3F1aXJyZWwtMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
-        cXVpcnJlbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzBiNDZlNDkwLWIzNTctNGI0Zi1iMWFkLTk4NzAzYjVlN2QxMi8iLCJuYW1l
-        Ijoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFz
-        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5NTFlMGVhY2YzZTZl
-        NjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcyMGU3ODM3NDlkYmQzMmY0
-        YTY5YWIzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIs
-        ImxvY2F0aW9uX2hyZWYiOiJzaGFyay0wLjEtMS5ub2FyY2gucnBtIiwicnBt
-        X3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvNzcwMmJhZDYtNWQ3Ni00NGFkLTk5YWYtYjMyMDM1MDQ2
-        ZWJlLyIsIm5hbWUiOiJwaWtlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjIu
-        MiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZDE4
-        YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0NTYy
-        NDNjNGZhZjlhOGI5MTI0YSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
-        b2YgcGlrZSIsImxvY2F0aW9uX2hyZWYiOiJwaWtlLTIuMi0xLm5vYXJjaC5y
-        cG0iLCJycG1fc291cmNlcnBtIjoicGlrZS0yLjItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2U1OTI0NGI2LTE2N2EtNDA4NC04NzVhLTc4
-        ZjUwMmMzNDAxMi8iLCJuYW1lIjoicGVuZ3VpbiIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIwLjkuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
-        InBrZ0lkIjoiNTdkMzE0Y2M2ZjUzMjI0ODRjZGNkMzNmNDE3MzM3NGRlOTVj
-        NTMwMzRkZTViMTE2OGI5MjkxY2EwYWQwNmRlYyIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsImxvY2F0aW9uX2hyZWYiOiJwZW5n
-        dWluLTAuOS4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJwZW5n
-        dWluLTAuOS4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9i
-        YWYyNGMxYS0wZTA3LTQxNmUtODRhNy1lZTQ1NzIzMmIwNWQvIiwibmFtZSI6
-        Im1vdXNlIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMS4xMiIsInJlbGVh
-        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiZjQyMDA2NDNiMDg0
-        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
-        ZGUyMjZjZSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91c2Ui
-        LCJsb2NhdGlvbl9ocmVmIjoibW91c2UtMC4xLjEyLTEubm9hcmNoLnJwbSIs
-        InJwbV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzL2MzNjRlOTJlLTE2NDEtNGNlYi04MGIwLTk0
-        OTk5ZDIxOWM0NC8iLCJuYW1lIjoibGlvbiIsImVwb2NoIjoiMCIsInZlcnNp
-        b24iOiIwLjQiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
-        ZCI6IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNi
-        OWFiZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
-        YWNrYWdlIG9mIGxpb24iLCJsb2NhdGlvbl9ocmVmIjoibGlvbi0wLjQtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6Imxpb24tMC40LTEuc3JjLnJw
-        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIiwibmFtZSI6Imthbmdhcm9vIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiOTQxNmNiZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZk
-        NDcxZDUyOWE0Y2Y2NzkzMGNlYThiZDcwNTZkZjVjYTkxYyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJsb2NhdGlvbl9ocmVm
-        Ijoia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
-        OiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzL2I2NmY3MGRhLTU5ZDgtNDNiNy04ZGEyLWMyYjExMGExZjFiZS8iLCJu
-        YW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMiIsInJl
-        bGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNjJlNDNhNzYz
-        MTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5
-        YmNmOGYyOWQ2OCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9y
-        c2UiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0yLm5vYXJjaC5ycG0i
-        LCJycG1fc291cmNlcnBtIjoiaG9yc2UtMC4yMi0yLnNyYy5ycG0iLCJpc19t
-        b2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvNzBiZDEyYjEtNDA3MS00YzU5LTgzMWEtN2E3
-        YTI4NWIwZDNiLyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
-        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
-        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGdvcmlsbGEiLCJsb2NhdGlvbl9ocmVmIjoiZ29yaWxs
-        YS0wLjYyLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJnb3JpbGxh
-        LTAuNjItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZhNzY0
-        MTJmLTRjMzQtNGE0Mi1hYWY2LTYyOTc1NDliMDM4OC8iLCJuYW1lIjoiZ2ly
-        YWZmZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjY3IiwicmVsZWFzZSI6
-        IjIiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIzZWVjZTVkOGM2Y2UwM2Jk
-        MzEyZDcwMzRkYTA1YjY3YjFmMWFjN2JkNWUwMGFlNzdiNGU1ZmRmMGM0Yzdm
-        MzYzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwi
-        bG9jYXRpb25faHJlZiI6ImdpcmFmZmUtMC42Ny0yLm5vYXJjaC5ycG0iLCJy
-        cG1fc291cmNlcnBtIjoiZ2lyYWZmZS0wLjY3LTIuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy9hYWU4MzM1ZC04NWYyLTRlZTEtODg5Yy04YjRk
-        MjgwZjVlZDMvIiwibmFtZSI6ImZyb2ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
-        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
-        OiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2ZjYwMTJlMTM4ZWYzYTNmNWM2
-        NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
-        a2FnZSBvZiBmcm9nIiwibG9jYXRpb25faHJlZiI6ImZyb2ctMC4xLTEubm9h
-        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJmcm9nLTAuMS0xLnNyYy5ycG0i
-        LCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvY2U2ZjE2OWUtZDlmZC00YzI0LTg2
-        Y2ItYzI1M2E2ZmU1NTA5LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
-        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
-        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
-        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3Iiwic3VtbWFyeSI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBmb3giLCJsb2NhdGlvbl9ocmVmIjoiZm94LTEuMS0y
-        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5y
-        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhlNjRkNGQtMjBlMC00N2My
-        LTk1OTYtMzNhNDNmMTRiYmI1LyIsIm5hbWUiOiJlbGVwaGFudCIsImVwb2No
-        IjoiMCIsInZlcnNpb24iOiI4LjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
-        b2FyY2giLCJwa2dJZCI6IjM4NzZkOGQ0ZmUwODY0YzRhMmU1M2M5ZjQ4ZGE4
-        N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFmM2UzNzYiLCJzdW1tYXJ5
-        IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwibG9jYXRpb25faHJl
-        ZiI6ImVsZXBoYW50LTguMy0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
-        IjoiZWxlcGhhbnQtOC4zLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy9jZGU3NTA1NC00MmQ5LTQwZWUtOGVlNS0wOTUxZGYzMTc1ZmEvIiwi
-        bmFtZSI6ImR1Y2siLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVs
-        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI0OGRiYWZiNTNk
-        YmNjMTU2NGJmOWMwZDRiNTUzMTAzOWFjMGExOTAyYjZjZmUyMjVhNzAyZmYw
-        OTQ1Y2FhNWJiIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkdWNr
-        IiwibG9jYXRpb25faHJlZiI6ImR1Y2stMC42LTEubm9hcmNoLnJwbSIsInJw
-        bV9zb3VyY2VycG0iOiJkdWNrLTAuNi0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
-        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZXMvYTgzZGFjODctNzViNS00ZTdiLThiMGItYmYxOThkY2I2
-        MjE0LyIsIm5hbWUiOiJkb2xwaGluIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjMuMTAuMjMyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI3MDg5NDViODlhY2E1NGM1ZWQ5YWZiOGUyYmIxNDFmZDU2NDU5YWM5
-        OGIxODQ3YmU0NjQ3ZmExODI1NDcxY2NkIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBkb2xwaGluIiwibG9jYXRpb25faHJlZiI6ImRvbHBoaW4t
-        My4xMC4yMzItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvbHBo
-        aW4tMy4xMC4yMzItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        LzdlZTEyZjljLTE3NWYtNDQ2Ny1iZDIyLTM1OWIwNjFiNThhNi8iLCJuYW1l
-        IjoiZG9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNl
-        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNj
-        YjUwNTIzZTRiYWE2OTAwNTE5ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2
-        NTcyMDEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvZyIsImxv
-        Y2F0aW9uX2hyZWYiOiJkb2ctNC4yMy0xLm5vYXJjaC5ycG0iLCJycG1fc291
-        cmNlcnBtIjoiZG9nLTQuMjMtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFs
-        c2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
-        Y2thZ2VzLzQ0YzhkMGVmLTBmMjYtNDE1Mi1iYTM3LWNlODdhYzc1YWFmMS8i
-        LCJuYW1lIjoiY3JvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjgiLCJy
-        ZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImVlOGRhMDll
-        MzA3NTk0Mzc4YzEzOTU1YTk3Y2E3ODZlNjg2N2MyYjI0MWE4NTlkZjFkOWIw
-        MmYxMzRmMDY0NTEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNy
-        b3ciLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
-        cnBtX3NvdXJjZXJwbSI6ImNyb3ctMC44LTEuc3JjLnJwbSIsImlzX21vZHVs
-        YXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlcy9hOGMzOTYzMi1lY2U4LTQzNmItYmQwNy1iODQwN2Ez
-        ZWY4NzAvIiwibmFtZSI6ImNvdyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIy
-        LjIiLCJyZWxlYXNlIjoiMyIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImIz
-        ODEwMjJjNGZhNjNjYWFhODQwNzc4YTljMzk4NjRmODVhMzcyMjUzYzk0MTU1
-        NTk1YmYwMjNhZjVlOWRhZmYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
-        IG9mIGNvdyIsImxvY2F0aW9uX2hyZWYiOiJjb3ctMi4yLTMubm9hcmNoLnJw
-        bSIsInJwbV9zb3VyY2VycG0iOiJjb3ctMi4yLTMuc3JjLnJwbSIsImlzX21v
-        ZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8xZjI0NDYyMS0wY2JiLTRiZTgtOTYyMy0zYmRk
-        YzNiMTBlYjEvIiwibmFtZSI6ImNvY2thdGVlbCIsImVwb2NoIjoiMCIsInZl
-        cnNpb24iOiIzLjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
-        a2dJZCI6IjliM2QyMmQwNTE4NzgxMGQ4NTIxZDk5Y2EyNDgzMjMyZTdkYTgw
-        MDg3NjkxZTVjMWY4ZmExMDZhMjUxMThiZGYiLCJzdW1tYXJ5IjoiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNvY2thdGVlbCIsImxvY2F0aW9uX2hyZWYiOiJjb2Nr
-        YXRlZWwtMy4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJjb2Nr
-        YXRlZWwtMy4xLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9k
-        MDZiNzk5Ni00MjVhLTRhODUtODFiYi1hMjQ2YzgwMGU5YjgvIiwibmFtZSI6
-        ImNoaW1wYW56ZWUiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yMSIsInJl
-        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNWFhOGIwZWIx
-        MGE5NzRhMDI2MzlmZmVhN2MxMGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3
-        ZTYzOGZkNGRhNiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hp
-        bXBhbnplZSIsImxvY2F0aW9uX2hyZWYiOiJjaGltcGFuemVlLTAuMjEtMS5u
-        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0x
-        LnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMmQ2MmNmODQtNGM1
-        NS00ODk0LTk0NGYtODYyNzM3OTc1NmQyLyIsIm5hbWUiOiJjaGVldGFoIiwi
-        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMjUuMyIsInJlbGVhc2UiOiI1Iiwi
-        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjE4OWFjNGJmMDU5Zjk4YThkNDgx
-        MzZlYjcyYjQ2NDE1ZjNhYTI2MzAyNjQ0M2ViZDg4NzlkNDE1ZWFjYWY0MiIs
-        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsImxvY2F0
-        aW9uX2hyZWYiOiJjaGVldGFoLTEuMjUuMy01Lm5vYXJjaC5ycG0iLCJycG1f
-        c291cmNlcnBtIjoiY2hlZXRhaC0xLjI1LjMtNS5zcmMucnBtIiwiaXNfbW9k
-        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VzLzJkNWU2NjE4LTBiMGQtNGI5Zi05ZDhkLTE1YzQ4
-        MTE4OGM5NS8iLCJuYW1lIjoiY2F0IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
-        IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
-        NDNlNzdhZGI3ZjUxYjU1NDJiODEzMDI0YThlZTNlNDc3MTc1YzE0MmYzNTk4
-        MmFiNWFlMmIyOTc4NDg2MjM5ZiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2F0IiwibG9jYXRpb25faHJlZiI6ImNhdC0xLjAtMS5ub2FyY2gu
-        cnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhdC0xLjAtMS5zcmMucnBtIiwiaXNf
-        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLzE5YjM5NzIzLTBiNzUtNGRmZS1hYzNmLTc2
-        ZmFlYmU4MWZiNS8iLCJuYW1lIjoiY2FtZWwiLCJlcG9jaCI6IjAiLCJ2ZXJz
-        aW9uIjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtn
-        SWQiOiI4MmU0OTdjYTNlN2FmZmI1NjgyMzYyYjUwNTM3YWYyOTBkMGEyMDJl
-        NGFkMDBiNmVmNjIzNTdhMmNjOTgxOWJhIiwic3VtbWFyeSI6IkEgZHVtbXkg
-        cGFja2FnZSBvZiBjYW1lbCIsImxvY2F0aW9uX2hyZWYiOiJjYW1lbC0wLjEt
-        MS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNhbWVsLTAuMS0xLnNy
-        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYjhkNGU3YTEtMDM4Ny00
-        OGIxLWEwZDYtY2Y3YTk4YWZkYzU1LyIsIm5hbWUiOiJiZWFyIiwiZXBvY2gi
-        OiIwIiwidmVyc2lvbiI6IjQuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5v
-        YXJjaCIsInBrZ0lkIjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
-        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInN1bW1hcnki
-        OiJBIGR1bW15IHBhY2thZ2Ugb2YgYmVhciIsImxvY2F0aW9uX2hyZWYiOiJi
-        ZWFyLTQuMS0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiYmVhci00
-        LjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:46 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:24:46 GMT
+      - Fri, 29 Jul 2022 11:31:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2210,21 +2016,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7aa0cc84fb2943c995836ba73173a1f3
+      - fa8a739c71a94bf88e238ead78187e6c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:46 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:31 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/538c60ab-2172-4286-ad28-aaa43de9cff3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2232,7 +2038,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2245,37 +2051,656 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:46 GMT
+      - Fri, 29 Jul 2022 11:31:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39c26d47c0c648d88d19a04958ef5c80
+      - 2ea6de4e28cd4fbaaeccb91763388107
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '816'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vNTM4YzYwYWItMjE3Mi00Mjg2LWFkMjgtYWFhNDNkZTljZmYzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6MzE6MzEuMjYyNDAwWiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMmUwNmNkMC1kNDk4LTRmZDAtOGMxYS01MWVjMzU2M2VmMTMv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtL2UyZTA2Y2QwLWQ0OTgtNGZkMC04YzFhLTUxZWMz
+        NTYzZWYxMy8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:31 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS81MzhjNjBhYi0yMTcyLTQyODYtYWQyOC1hYWE0M2RlOWNmZjMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 914c5a30b2624ea7b419004001678b93
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmZTE4ZjAwLTY1YTctNGI0
+        MS04MDQwLTg3OGU0MjU0MDJiOS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:31 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ffe18f00-65a7-4b41-8040-878e425402b9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3ffb8c0333074c7ba9fef1b80b0c3a14
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmZlMThmMDAtNjVh
+        Ny00YjQxLTgwNDAtODc4ZTQyNTQwMmI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MzEuOTAyNzU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5MTRjNWEzMGIyNjI0ZWE3YjQxOTAwNDAw
+        MTY3OGI5MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjMxLjk1
+        NTk4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6MzIuMzY3
+        MTI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMjg4
+        YmIyNjYtMmQ0NC00NTBjLWJlZDUtYjFiNzU0YmNhMmRkLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/288bb266-2d44-450c-bed5-b1b754bca2dd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4a95e804192f4f7b82f86cc4a2f6d181
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzI4OGJiMjY2LTJkNDQtNDUwYy1iZWQ1LWIxYjc1NGJjYTJkZC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjMxOjMyLjM0Mzg5M1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vNTM4YzYwYWItMjE3Mi00Mjg2LWFkMjgt
+        YWFhNDNkZTljZmYzLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '12050'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4e879cbcf85d4951a11c9204842b3c3c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MzIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvOTJiNjZhY2ItNjBiOS00ZWY0LWI1MWEtOWFiNmE3NTAwZjgy
+        LyIsIm5hbWUiOiJ6ZWJyYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjEi
+        LCJyZWxlYXNlIjoiMiIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgwMWEy
+        YTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVmN2NjZTliNGQ1Mjc3
+        MTJlNThjNDBlY2E1NWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHplYnJhIiwibG9jYXRpb25faHJlZiI6InplYnJhLTAuMS0yLm5vYXJjaC5y
+        cG0iLCJycG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsImlz
+        X21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9hMGIyZmZjYi1iMzgwLTRhYjktYmI4Yi00
+        MjljNGY5YmZjN2IvIiwibmFtZSI6IndvbGYiLCJlcG9jaCI6IjAiLCJ2ZXJz
+        aW9uIjoiOS40IiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiJkNjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4
+        YzUzOTJmNDNhYTQ3NzVjMjQ2YTVlZGYyIiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiB3b2xmIiwibG9jYXRpb25faHJlZiI6IndvbGYtOS40LTIu
+        bm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ3b2xmLTkuNC0yLnNyYy5y
+        cG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjkzYTRlYjItZDczOS00MDky
+        LTg5NmYtODM2MzBmZjNjNGZiLyIsIm5hbWUiOiJ3aGFsZSIsImVwb2NoIjoi
+        MCIsInZlcnNpb24iOiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6IjNiMzQyMzRhZmM4Yjg5MzFkNjI3Zjg0NjZmMGU0ZmQz
+        NTIxNDVhMjUxMjY4MWVjMjlkYjBhMDUxYTBjOWQ4OTMiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdoYWxlIiwibG9jYXRpb25faHJlZiI6Indo
+        YWxlLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoid2hhbGUt
+        MC4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YTVmNjY4
+        My0wNjI2LTRlMTgtOGJlYy02M2Q2YmNlZDdiYjMvIiwibmFtZSI6IndhbHJ1
+        cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFzZSI6IjEi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlmOTY3YTcw
+        ZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFmOTU3M2Yy
+        Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCJsb2Nh
+        dGlvbl9ocmVmIjoid2FscnVzLTUuMjEtMS5ub2FyY2gucnBtIiwicnBtX3Nv
+        dXJjZXJwbSI6IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsImlzX21vZHVsYXIi
+        OmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZWExZDg5Ny0yYWExLTQ0OGEtYjVhOC1lMGYzMzdmNTE3
+        Y2QvIiwibmFtZSI6IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjcxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJk
+        OTBmMGUwZDgwNTY4NmQ1OWE2N2ZkNmVmM2VkYmY4YTllNGIzY2JjOTkwOGI4
+        Nzg2NTJhMWI5OThhMWYwNGE4Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB3YWxydXMiLCJsb2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5u
+        b2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6IndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OWI2YWZlZi1mMjFiLTQ5
+        ZjktYTM2Yi04NTE4MDMzZjAzNjAvIiwibmFtZSI6InRpZ2VyIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVhc2UiOiI0IiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNiZTViNjJlMjkyMzViZDFjMzhh
+        YTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYyNTUzNDUxNyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJsb2NhdGlvbl9ocmVmIjoi
+        dGlnZXItMS4wLTQubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJ0aWdl
+        ci0xLjAtNC5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc2Mjlm
+        MzBhLTE0ZjctNDQ1NS1hM2NhLTI0YmQ4YzZiNDgzOS8iLCJuYW1lIjoic3Rv
+        cmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xMiIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMwMTQ1ZGU3NDU1MDgxNTg2
+        NTAxNGMzYzhkNDdiYzY1NTYwZmM2OGMxOWNlMDg1Y2UxNTIzYzk0YTIzMTA2
+        NCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3RvcmsiLCJsb2Nh
+        dGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5vYXJjaC5ycG0iLCJycG1fc291
+        cmNlcnBtIjoic3RvcmstMC4xMi0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvZDUwOTg5MWEtZjIyMi00OTI5LWFmMmQtYzkxMDBhNDhhNmNj
+        LyIsIm5hbWUiOiJzcXVpcnJlbCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQ2
+        YTJhOGYyNzU0NjdiMTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1
+        OWMxZGI0NjRmNWVlNDZlMGQiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHNxdWlycmVsIiwibG9jYXRpb25faHJlZiI6InNxdWlycmVsLTAuMS0x
+        Lm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoic3F1aXJyZWwtMC4xLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZWI1ZGU4MS1kNjA1
+        LTQ5MzEtOGU2NC00NmUwMWYxNTMwMDMvIiwibmFtZSI6InNoYXJrIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiOTUxZTBlYWNmM2U2ZTYxMDJiMTBhY2IyZTY4
+        OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFiMyIsInN1bW1h
+        cnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJsb2NhdGlvbl9ocmVm
+        Ijoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJz
+        aGFyay0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzBk
+        NGY3N2IzLTE0ODEtNGY1Mi05Yzc1LTFiYmE3NzBiNjdkZS8iLCJuYW1lIjoi
+        cGlrZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoi
+        MSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2Rj
+        M2VjZTcyYjdmYTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEy
+        NGEiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHBpa2UiLCJsb2Nh
+        dGlvbl9ocmVmIjoicGlrZS0yLjItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJj
+        ZXJwbSI6InBpa2UtMi4yLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy84YWVmODliMC1kM2IzLTRkNDItYmJlMS1mYTBkODkwMTMzNTEvIiwi
+        bmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC45LjEi
+        LCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjU3ZDMx
+        NGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhi
+        OTI5MWNhMGFkMDZkZWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IHBlbmd1aW4iLCJsb2NhdGlvbl9ocmVmIjoicGVuZ3Vpbi0wLjkuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0wLjkuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWUzNWJhZjAtNTZmOC00
+        ZjlhLTg0ZjMtMWIzMTI1NGNlZGQ3LyIsIm5hbWUiOiJtb3VzZSIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiIwLjEuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImY0MjAwNjQzYjA4NDVmZGM1NWVlMDAyYzky
+        YzA0MDRhOWYzYTJhNDlmNTk2Yzc4YjQwYWI1Njc0OWRlMjI2Y2UiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIG1vdXNlIiwibG9jYXRpb25faHJl
+        ZiI6Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBt
+        IjoibW91c2UtMC4xLjEyLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9mMmRmZjEzZS1mODkyLTRjNzctYjRiNC01ODdjYTc5ODI2ZGYvIiwi
+        bmFtZSI6Imxpb24iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVs
+        ZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFk
+        ZjE2N2ViMDEyNDZkY2UzMDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUw
+        NWNkZWIyMGFjIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwibG9jYXRpb25faHJlZiI6Imxpb24tMC40LTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJsaW9uLTAuNC0xLnNyYy5ycG0iLCJpc19tb2R1bGFy
+        IjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNmRjOGMwNzYtZDUxZC00MWRkLWI0NTUtODM0YzJmOGQ1
+        ODhjLyIsIm5hbWUiOiJrYW5nYXJvbyIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        Ijk0MTZjYmU5ZThjMTgzZjQ0MGVkNTkwZDY2ZDU2ZDQ3MWQ1MjlhNGNmNjc5
+        MzBjZWE4YmQ3MDU2ZGY1Y2E5MWMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGthbmdhcm9vIiwibG9jYXRpb25faHJlZiI6Imthbmdhcm9vLTAu
+        Mi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoia2FuZ2Fyb28tMC4y
+        LTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZjFjOTBiMC1h
+        Nzg3LTQ4Y2MtODBjYi1mY2EzOTgwMDBjNzYvIiwibmFtZSI6ImhvcnNlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjIiLCJyZWxlYXNlIjoiMiIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjYyZTQzYTc2MzE3N2E0OWY2YWJiMzc4
+        MzMyMWI2NjMzNTc2YmEyNTM2NGNjMzE5YjE4ZjQxOWJjZjhmMjlkNjgiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwibG9jYXRpb25f
+        aHJlZiI6ImhvcnNlLTAuMjItMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJw
+        bSI6ImhvcnNlLTAuMjItMi5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzMyZGE5NTNkLTE5YmEtNDZjNy04MzRkLTU3ZWM0ZWQ5ZDc5YS8iLCJu
+        YW1lIjoiZ29yaWxsYSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjYyIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJmZmQ1MTFi
+        ZTMyYWRiZjkxZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRj
+        ZWE0ZjRhYjVhYTM3Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBn
+        b3JpbGxhIiwibG9jYXRpb25faHJlZiI6ImdvcmlsbGEtMC42Mi0xLm5vYXJj
+        aC5ycG0iLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYyLTEuc3JjLnJw
+        bSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wZTI2ODczYS1lYjM3LTQwZDIt
+        YWY0My0zODAzMTM2ZDEyMmEvIiwibmFtZSI6ImdpcmFmZmUiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5v
+        YXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3MDM0ZGEwNWI2
+        N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIsInN1bW1hcnki
+        OiJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsImxvY2F0aW9uX2hyZWYi
+        OiJnaXJhZmZlLTAuNjctMi5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6
+        ImdpcmFmZmUtMC42Ny0yLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvZTRhODIyZDYtNGVmNC00NmZlLWEyN2MtMjEzYmY4ZWE5ZGY0LyIsIm5h
+        bWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5ZDg2MjUx
+        MjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVkZTg0NDYw
+        ZTMyZTNlMyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZnJvZyIs
+        ImxvY2F0aW9uX2hyZWYiOiJmcm9nLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1f
+        c291cmNlcnBtIjoiZnJvZy0wLjEtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6
+        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBt
+        L3BhY2thZ2VzLzczM2E0YTAwLTg4NGUtNGEwMS1iMjQwLTZlMzhjM2VlNzNi
+        OS8iLCJuYW1lIjoiZm94IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMSIs
+        InJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiOWRlNTI0
+        ODY4ZTY0YjNkYWM0YzRmOTUwMDQ1NjkwNTY4MWY4MWUxMGZhYjYxZTY2NDIw
+        ZjAyZDAwYWM1OTI2NyIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Zm94IiwibG9jYXRpb25faHJlZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwi
+        cnBtX3NvdXJjZXJwbSI6ImZveC0xLjEtMi5zcmMucnBtIiwiaXNfbW9kdWxh
+        ciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        cnBtL3BhY2thZ2VzLzQ0ZTg5MDBkLTcyMjEtNDQwOC05MDA1LTEzYTkzYjM5
+        MmEwZC8iLCJuYW1lIjoiZWxlcGhhbnQiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiOC4zIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiIzODc2ZDhkNGZlMDg2NGM0YTJlNTNjOWY0OGRhODdkMDdjODcwNzM5NmZh
+        MzkzY2UxYjVlN2QwMThhZjNlMzc2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBlbGVwaGFudCIsImxvY2F0aW9uX2hyZWYiOiJlbGVwaGFudC04
+        LjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTgu
+        My0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTIzMmMwNTgt
+        ZjZkZC00NDY3LWI4ZWItNWNjYzBkNmRhNjhhLyIsIm5hbWUiOiJkdWNrIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuNiIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiNDhkYmFmYjUzZGJjYzE1NjRiZjljMGQ0
+        YjU1MzEwMzlhYzBhMTkwMmI2Y2ZlMjI1YTcwMmZmMDk0NWNhYTViYiIsInN1
+        bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsImxvY2F0aW9uX2hy
+        ZWYiOiJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoi
+        ZHVjay0wLjYtMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2U0
+        OTdlMGVlLTNiYTktNGEzZS1hN2JhLWRiMjUwNTkxYjIzMi8iLCJuYW1lIjoi
+        ZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEwLjIzMiIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiNzA4OTQ1Yjg5
+        YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2Zh
+        MTgyNTQ3MWNjZCIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZG9s
+        cGhpbiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAuMjMyLTEubm9h
+        cmNoLnJwbSIsInJwbV9zb3VyY2VycG0iOiJkb2xwaGluLTMuMTAuMjMyLTEu
+        c3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lMTE3NGRiMS03NjE5
+        LTRjNTAtOWNjNy0yYzgyYWU3ODc4OGMvIiwibmFtZSI6ImRvZyIsImVwb2No
+        IjoiMCIsInZlcnNpb24iOiI0LjIzIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiJlZWVkNDRlODYyYzZjY2I1MDUyM2U0YmFhNjkw
+        MDUxOWZjZmQ3Y2M4OGYyOGFhMGJhMDU0YTc5NWQ4NjU3MjAxIiwic3VtbWFy
+        eSI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJsb2NhdGlvbl9ocmVmIjoi
+        ZG9nLTQuMjMtMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImRvZy00
+        LjIzLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMDFjMWJl
+        MC1iZjJhLTQyMDktYjE4MS04ZDU5OWZkMDc5MzMvIiwibmFtZSI6ImNyb3ci
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC44IiwicmVsZWFzZSI6IjEiLCJh
+        cmNoIjoibm9hcmNoIiwicGtnSWQiOiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1
+        NWE5N2NhNzg2ZTY4NjdjMmIyNDFhODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwi
+        c3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjcm93IiwibG9jYXRpb25f
+        aHJlZiI6ImNyb3ctMC44LTEubm9hcmNoLnJwbSIsInJwbV9zb3VyY2VycG0i
+        OiJjcm93LTAuOC0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        OGI4M2E4OTctNTg0Yy00NmEyLTgyN2YtOGIwN2RhZTk3YmFmLyIsIm5hbWUi
+        OiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFzZSI6
+        IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYzY2Fh
+        YTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlk
+        YWZmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjb3ciLCJsb2Nh
+        dGlvbl9ocmVmIjoiY293LTIuMi0zLm5vYXJjaC5ycG0iLCJycG1fc291cmNl
+        cnBtIjoiY293LTIuMi0zLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMzMxOWNmYTAtZGRmYy00M2MwLThhNmUtZDFkOTlkNDFiNmQ4LyIsIm5h
+        bWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMy4xIiwi
+        cmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI5YjNkMjJk
+        MDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZh
+        MTA2YTI1MTE4YmRmIiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBj
+        b2NrYXRlZWwiLCJsb2NhdGlvbl9ocmVmIjoiY29ja2F0ZWVsLTMuMS0xLm5v
+        YXJjaC5ycG0iLCJycG1fc291cmNlcnBtIjoiY29ja2F0ZWVsLTMuMS0xLnNy
+        Yy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvY2FmMzgwNzktZTA1Ni00
+        NGU3LTk2M2UtZTJjMjMzYzhmZjg0LyIsIm5hbWUiOiJjaGltcGFuemVlIiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMjEiLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjVhYThiMGViMTBhOTc0YTAyNjM5ZmZl
+        YTdjMTBkN2RhYjkzZjgyYzRkMDhjMzJiMDBiNTY3N2U2MzhmZDRkYTYiLCJz
+        dW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJsb2Nh
+        dGlvbl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJw
+        bV9zb3VyY2VycG0iOiJjaGltcGFuemVlLTAuMjEtMS5zcmMucnBtIiwiaXNf
+        bW9kdWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzA4YzllODFlLTAyOGQtNDdmNC1iYzlkLWFh
+        OGY5NTIxNThiYi8iLCJuYW1lIjoiY2hlZXRhaCIsImVwb2NoIjoiMCIsInZl
+        cnNpb24iOiIxLjI1LjMiLCJyZWxlYXNlIjoiNSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4MTM2ZWI3MmI0NjQxNWYz
+        YWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJsb2NhdGlvbl9ocmVmIjoiY2hl
+        ZXRhaC0xLjI1LjMtNS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImNo
+        ZWV0YWgtMS4yNS4zLTUuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNlfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wZjc1N2QyNC02NzgyLTQ1MTAtOWJkNy0xZjRkODlmMTk4Y2IvIiwibmFt
+        ZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNl
+        IjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGNhdCIsImxv
+        Y2F0aW9uX2hyZWYiOiJjYXQtMS4wLTEubm9hcmNoLnJwbSIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsImlzX21vZHVsYXIiOmZhbHNl
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
+        YWdlcy9hNWNkYmRkZS1iY2E4LTQ1MjktOWI0MS1jN2JlODFmNzkyNDgvIiwi
+        bmFtZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJl
+        bGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2Ez
+        ZTdhZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3
+        YTJjYzk4MTliYSIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2Ft
+        ZWwiLCJsb2NhdGlvbl9ocmVmIjoiY2FtZWwtMC4xLTEubm9hcmNoLnJwbSIs
+        InJwbV9zb3VyY2VycG0iOiJjYW1lbC0wLjEtMS5zcmMucnBtIiwiaXNfbW9k
+        dWxhciI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzLzE1YzkxMDRmLTEyMzMtNDZjNC1iZjczLTc1MTgx
+        OGZjNmYxNS8iLCJuYW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiI0LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6
+        IjdhODMxZjlmOTBiZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIw
+        MmMwMzk3NDQ1YzJlNDgxZDgxYjMiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGJlYXIiLCJsb2NhdGlvbl9ocmVmIjoiYmVhci00LjEtMS5ub2Fy
+        Y2gucnBtIiwicnBtX3NvdXJjZXJwbSI6ImJlYXItNC4xLTEuc3JjLnJwbSIs
+        ImlzX21vZHVsYXIiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L3JwbS9wYWNrYWdlcy9hNTY2YWM5Yy01MDAwLTQyMTAtYmQy
+        Yi05MDMzNmRkMzBjNGMvIiwibmFtZSI6InRyb3V0IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
+        LCJwa2dJZCI6ImFlYTkxZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2
+        MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJlMTQiLCJzdW1tYXJ5IjoiQSBk
+        dW1teSBwYWNrYWdlIG9mIHRyb3V0IiwibG9jYXRpb25faHJlZiI6InRyb3V0
+        LTAuMTItMS5ub2FyY2gucnBtIiwicnBtX3NvdXJjZXJwbSI6InRyb3V0LTAu
+        MTItMS5zcmMucnBtIiwiaXNfbW9kdWxhciI6ZmFsc2V9XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 013d9569a54246989e310a3e41aaa2c7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:31:32 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:31:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '4276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2c3c66d48826409c9032fefc9aac6aa4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzRkNjJiMDYyLTUxOTEtNDJlZC1hNTg0LTgxYTFkOGU0ZGFl
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA4MDkx
-        OFoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzLzY2ZjM0ZjFhLTM3MDQtNDgzYy04YzU3LTIzYjM5ZWRhNTVk
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNzQz
+        OVoiLCJpZCI6IlJIRUEtMjAxMjowMDU3IiwidXBkYXRlZF9kYXRlIjoiMjAx
         My0wMS0yNyAxNjowODowNSIsImRlc2NyaXB0aW9uIjoiQmVhcl9FcnJhdHVt
         IiwiaXNzdWVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2OjA4OjA1IiwiZnJvbXN0
         ciI6ImVycmF0YUByZWRoYXQuY29tIiwic3RhdHVzIjoic3RhYmxlIiwidGl0
@@ -2291,8 +2716,8 @@ http_interactions:
         cmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiI0LjEifV19
         XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLzkwYTZjNmExLTM4NjUtNDJkYS1hZmE5LTUxNTY1MWU5NGM3Zi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjIyOjI2LjA3OTE2N1oiLCJp
+        aWVzLzIyNTBmMTdhLWJjMTgtNGNlMS04YzZhLTA3YzRmMDY4MjU0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjQ5OjI3LjQzNDc1MVoiLCJp
         ZCI6IlJIRUEtMjAxMjowMDU1IiwidXBkYXRlZF9kYXRlIjoiMjAxMi0wMS0y
         NyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoiU2VhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTItMDEtMjcgMTY6MDg6MDYiLCJmcm9tc3RyIjoiZXJy
@@ -2320,8 +2745,8 @@ http_interactions:
         b3JnIiwic3VtIjoiIiwic3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1d
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNv
-        cmllcy82MDE1ZGRjOS01ZmU5LTRlODAtODU5Mi0zN2NkODdkZWExNDgvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyMjoyNi4wNzY4ODlaIiwi
+        cmllcy9hN2FmY2E5NS1iM2I2LTRlY2QtOWM0Ni03NzFhNDRjZGRlYjkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo0OToyNy40MjY4MjRaIiwi
         aWQiOiJSSEVBLTIwMTI6MDA1NiIsInVwZGF0ZWRfZGF0ZSI6IjIwMTMtMDEt
         MjcgMTY6MDg6MDgiLCJkZXNjcmlwdGlvbiI6IlBhcnRoYUJpcmRfRXJyYXR1
         bSIsImlzc3VlZF9kYXRlIjoiMjAxMy0wMS0yNyAxNjowODowOCIsImZyb21z
@@ -2349,8 +2774,8 @@ http_interactions:
         InN1bSI6IiIsInN1bV90eXBlIjoiIiwidmVyc2lvbiI6IjAuNiJ9XX1dLCJy
         ZWZlcmVuY2VzIjpbXSwicmVib290X3N1Z2dlc3RlZCI6ZmFsc2V9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMv
-        OGZkNjI4OGItZTY4My00NmVmLTliOTQtZDBlOTA0YjlmNjhiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MjI6MjYuMDcyNjQyWiIsImlkIjoi
+        NzdmZTI3NWEtMGRlNy00OTk0LWIwZTMtZTM2MTk2ZWJmN2ZmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDctMjhUMTY6NDk6MjcuNDI0OTQyWiIsImlkIjoi
         UkhFQS0yMDEyOjAwNTgiLCJ1cGRhdGVkX2RhdGUiOiIyMDEzLTAxLTI3IDE2
         OjA4OjA5IiwiZGVzY3JpcHRpb24iOiJHb3JpbGxhX0VycmF0dW0iLCJpc3N1
         ZWRfZGF0ZSI6IjIwMTMtMDEtMjcgMTY6MDg6MDkiLCJmcm9tc3RyIjoiZXJy
@@ -2368,10 +2793,10 @@ http_interactions:
         fV0sInJlZmVyZW5jZXMiOltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:46 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2379,7 +2804,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2392,7 +2817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:46 GMT
+      - Fri, 29 Jul 2022 11:31:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2410,21 +2835,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 88066a3a8e4c485da5ccb604ad7c89c1
+      - 9e41133846f4455bbe0dfcd7986a35ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:46 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2432,7 +2857,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2445,7 +2870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2463,21 +2888,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 84bc44a8717449b19c5e820165d7ba84
+      - caeef205c26a4f40acf1cd08d096306c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2485,7 +2910,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2498,7 +2923,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2516,21 +2941,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0b6e10e4f70243c5a1f28a3e71d3860c
+      - aea78213579d4580b4071e7c18c8e7e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2538,7 +2963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2551,7 +2976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2569,21 +2994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da0537fb028a41768877e041d88649c3
+      - 3cd3be147dd54f32809132fddb39501a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2591,7 +3016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2604,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2622,21 +3047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - becd683631a24bb99fc5968a7d27837a
+      - c17e297c69504346b5f46eaaa8ef1400
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2644,7 +3069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2657,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,21 +3100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 02e08584db6b48a6898d5b6fdff174cd
+      - be6b12114d6a4c2ea4a939b7f284c510
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/25e7a6df-4139-4f78-99a4-7907dd330489/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/e2e06cd0-d498-4fd0-8c1a-51ec3563ef13/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2697,7 +3122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2710,7 +3135,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2728,21 +3153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 20209ef1f4204933b4af4bd1a3844173
+      - 9506bb993d5b445192620f9a56a8f2cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2752,7 +3177,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2765,7 +3190,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2783,37 +3208,37 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6fa54bb7cee74ad2a0552bde33eba701
+      - 2f891d6b889847cb845b9b2dbc2a92c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlZDA2NzI0LTRhNjktNGRk
-        ZS05ZmVkLTRjMDg1OWJhMTk0YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyODMwNGQyLTA5YTAtNDRk
+        Yy05N2ZjLWEyZDU2Mjc4NzRkNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:33 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjVlN2E2ZGYtNDEzOS00Zjc4LTk5
-        YTQtNzkwN2RkMzMwNDg5L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdhNTM5MDJhLTdjNWEt
-        NDlkMS1hNmRhLWJkMGEwMjE2ZDMyMC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2Mt
-        YjJjYS1kZWQzZTI3ZmU2ZGEvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTJlMDZjZDAtZDQ5OC00ZmQwLThj
+        MWEtNTFlYzM1NjNlZjEzL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q5OTVhZjBlLTMzZWMt
+        NDk0OS05OGJjLTM0MjM5NTRmZDNhYS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82ZGM4YzA3Ni1kNTFkLTQxZGQt
+        YjQ1NS04MzRjMmY4ZDU4OGMvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpm
         YWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2826,7 +3251,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2844,21 +3269,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c23c255de83f4907b8ffc3fc14f53634
+      - cc86621b098a4e29b4788b4e71dbb2e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExNjI5YzIwLTc3NzItNDU5
-        ZS05MmZmLTk2M2VlZWQwOWNjNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmNjdlZmUwLWE3NzQtNGE1
+        NS05NGJiLTg0MzQ2YTM1MjM5My8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1ed06724-4a69-4dde-9fed-4c0859ba194a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/728304d2-09a0-44dc-97fc-a2d5627874d7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2879,51 +3304,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf6292bbde374f2ca1ba861b063e2493
+      - b7b6e89fd28549aa9bcc49f2758891d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWVkMDY3MjQtNGE2
-        OS00ZGRlLTlmZWQtNGMwODU5YmExOTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDcuNDcwODc4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzI4MzA0ZDItMDlh
+        MC00NGRjLTk3ZmMtYTJkNTYyNzg3NGQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MzMuOTY2ODU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmE1NGJiN2NlZTc0YWQyYTA1
-        NTJiZGUzM2ViYTcwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjQ3LjUwNzM1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NDcuNjQ0OTE4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyZjg5MWQ2Yjg4OTg0N2NiODQ1
+        YjliMmRiYzJhOTJjOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjM0LjAzNTMwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        MzQuNDY1ODM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2E1MzkwMmEtN2M1
-        YS00OWQxLWE2ZGEtYmQwYTAyMTZkMzIwLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDk5NWFmMGUtMzNl
+        Yy00OTQ5LTk4YmMtMzQyMzk1NGZkM2FhLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1ed06724-4a69-4dde-9fed-4c0859ba194a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/728304d2-09a0-44dc-97fc-a2d5627874d7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2944,51 +3369,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 542cdba69b2046bc8bd05264b3665021
+      - 23f996fd43254601a5119f3ac94a5e61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWVkMDY3MjQtNGE2
-        OS00ZGRlLTlmZWQtNGMwODU5YmExOTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDcuNDcwODc4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzI4MzA0ZDItMDlh
+        MC00NGRjLTk3ZmMtYTJkNTYyNzg3NGQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MzMuOTY2ODU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmE1NGJiN2NlZTc0YWQyYTA1
-        NTJiZGUzM2ViYTcwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjQ3LjUwNzM1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NDcuNjQ0OTE4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyZjg5MWQ2Yjg4OTg0N2NiODQ1
+        YjliMmRiYzJhOTJjOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjM0LjAzNTMwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        MzQuNDY1ODM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2E1MzkwMmEtN2M1
-        YS00OWQxLWE2ZGEtYmQwYTAyMTZkMzIwLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDk5NWFmMGUtMzNl
+        Yy00OTQ5LTk4YmMtMzQyMzk1NGZkM2FhLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1ed06724-4a69-4dde-9fed-4c0859ba194a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/728304d2-09a0-44dc-97fc-a2d5627874d7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3009,51 +3434,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 293241ed7c4042a79ab0d333a4978a78
+      - b7e6e53c73a04bab8c135e2026b56129
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWVkMDY3MjQtNGE2
-        OS00ZGRlLTlmZWQtNGMwODU5YmExOTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDcuNDcwODc4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzI4MzA0ZDItMDlh
+        MC00NGRjLTk3ZmMtYTJkNTYyNzg3NGQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MzMuOTY2ODU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2ZmE1NGJiN2NlZTc0YWQyYTA1
-        NTJiZGUzM2ViYTcwMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0
-        OjQ3LjUwNzM1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MjQ6
-        NDcuNjQ0OTE4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyZjg5MWQ2Yjg4OTg0N2NiODQ1
+        YjliMmRiYzJhOTJjOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMx
+        OjM0LjAzNTMwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6MzE6
+        MzQuNDY1ODM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2E1MzkwMmEtN2M1
-        YS00OWQxLWE2ZGEtYmQwYTAyMTZkMzIwLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDk5NWFmMGUtMzNl
+        Yy00OTQ5LTk4YmMtMzQyMzk1NGZkM2FhLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/11629c20-7772-459e-92ff-963eeed09cc6/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/7f67efe0-a774-4a55-94bb-84346a352393/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3074,55 +3499,55 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:47 GMT
+      - Fri, 29 Jul 2022 11:31:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '770'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5bd90c715595465fbb334cf042e8d453
+      - a9ab54da95704ebe89f50cb183cfa341
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '415'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTE2MjljMjAtNzc3
-        Mi00NTllLTkyZmYtOTYzZWVlZDA5Y2M2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MjQ6NDcuNTI2ODc3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2Y2N2VmZTAtYTc3
+        NC00YTU1LTk0YmItODQzNDZhMzUyMzkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6MzE6MzQuMDU4ODcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiYzIzYzI1NWRlODNmNDkwN2I4ZmZjM2ZjMTRm
-        NTM2MzQiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyNDo0Ny42NzY0
-        NjNaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI0OjQ3LjgxNjEz
-        NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvM2ZhNmQwODItOTY4My00ZWZmLWFhNmQtMWVkMzQ1MTA3MmU1LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiY2M4NjYyMWIwOThhNGUyOWI0Nzg4YjRlNzFk
+        YmIyZTgiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMTozMTozNC41NDI2
+        NThaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjMxOjM1LjAyNDcy
+        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2E1Mzkw
-        MmEtN2M1YS00OWQxLWE2ZGEtYmQwYTAyMTZkMzIwL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDk5NWFm
+        MGUtMzNlYy00OTQ5LTk4YmMtMzQyMzk1NGZkM2FhL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzdhNTM5MDJhLTdjNWEtNDlkMS1hNmRhLWJk
-        MGEwMjE2ZDMyMC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzI1ZTdhNmRmLTQxMzktNGY3OC05OWE0LTc5MDdkZDMzMDQ4
-        OS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2Q5OTVhZjBlLTMzZWMtNDk0OS05OGJjLTM0
+        MjM5NTRmZDNhYS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtL2UyZTA2Y2QwLWQ0OTgtNGZkMC04YzFhLTUxZWMzNTYzZWYx
+        My8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:47 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3130,7 +3555,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3143,41 +3568,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - facee4a475594185abfa81e2e8cc123e
+      - 7f70726d48194c54abd91909e24d093f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2MtYjJjYS1kZWQzZTI3ZmU2ZGEv
+        YWNrYWdlcy82ZGM4YzA3Ni1kNTFkLTQxZGQtYjQ1NS04MzRjMmY4ZDU4OGMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3185,7 +3610,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3198,7 +3623,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3216,21 +3641,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fccdabf0047b491d853796495d22b8e8
+      - ad827c69acdc452482200685856ad3a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3238,7 +3663,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3251,7 +3676,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3269,21 +3694,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a3502fef7d01481fb23ee610dcde65ae
+      - dfb23e0204bb416c9b7e81983877275d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3291,7 +3716,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3304,7 +3729,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3322,21 +3747,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9417373b964c4dcf9b5a75da4a31f60d
+      - feec2f7c3af44156bb2f0dcfa5fd5c3a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3344,7 +3769,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3357,7 +3782,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3375,21 +3800,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf6b8f51dca943afb3eb839f5bb7aac5
+      - 1e1bedda27bf46fe8cf0b19925c13e7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3397,7 +3822,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3410,7 +3835,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3428,21 +3853,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f3a7af0870148d281138b0f481e7b5c
+      - b15471fef462463cac5ff58e34af10d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:35 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3450,7 +3875,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3463,41 +3888,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '139'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e519dd185eb4601b0c9ea4b260d0638
+      - cf69f4ff1d884ac5872f26b73d581092
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '135'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9lYzI3ZDM1OS05Mzg4LTQ4N2MtYjJjYS1kZWQzZTI3ZmU2ZGEv
+        YWNrYWdlcy82ZGM4YzA3Ni1kNTFkLTQxZGQtYjQ1NS04MzRjMmY4ZDU4OGMv
         In1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3505,7 +3930,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3518,7 +3943,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3536,21 +3961,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c0ba498ff841426ba2b33fc4a73b6817
+      - 228f4578565d4aea8f85c22d98470916
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3558,7 +3983,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3571,7 +3996,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3589,21 +4014,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a2e30f2c60014e28827efc87c04c5153
+      - d2980936370649ffa2d5ecaf3e594c25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3611,7 +4036,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3624,7 +4049,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3642,21 +4067,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 59f1993253cb467e9b930369ea221e87
+      - f7aaf07a1a164ee481811a33a628ea72
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3664,7 +4089,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3677,7 +4102,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3695,21 +4120,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 44b003624bff4e8d8266e71cf3e86eda
+      - 51069b0eea134f54b2d5226d1671c5cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:36 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/7a53902a-7c5a-49d1-a6da-bd0a0216d320/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/d995af0e-33ec-4949-98bc-3423954fd3aa/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3717,7 +4142,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3730,7 +4155,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:24:48 GMT
+      - Fri, 29 Jul 2022 11:31:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3748,16 +4173,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8d78a9c187d641c5ba19db3cf190455b
+      - 7c8ee18f74f041e89a1f9fc8fea7c0c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:24:48 GMT
+  recorded_at: Fri, 29 Jul 2022 11:31:36 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_srpms_repository/all_srpms_copied_despite_filter_rules.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/multi_copy_all_unit_yum_srpms_repository/all_srpms_copied_despite_filter_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,27 +35,94 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '683'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c5176938e49445ec8ac15ebc2ce4736f
+      - 548fd5407c6b4467b608183f0ca4d9ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84MzIxMjk5OC1kMTlkLTQzYzItOWIwNS1kZGRmNmYzZjVhMzIv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyODozOC42Nzg3MTJa
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS84MzIxMjk5OC1kMTlkLTQzYzItOWIwNS1kZGRmNmYzZjVhMzIv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzgzMjEy
+        OTk4LWQxOWQtNDNjMi05YjA1LWRkZGY2ZjNmNWEzMi92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
+        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
+        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
+        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
+        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
+        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
+        ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:52 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/83212998-d19d-43c2-9b05-dddf6f3f5a32/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:52 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fb0c697d7615425fa8e12748b587ca21
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4N2I4YWFkLWFhMWItNDIx
+        Zi1hOWUyLThkMGNkY2JhZTNmZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +161,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 49e09a9230304fa9bd780e1b083433d0
+      - 2be9d986f7ed44a791d876e828059242
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/587b8aad-aa1b-421f-a9e2-8d0cdcbae3ff/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -137,31 +204,43 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d304e1141d0a4cfa91eabeb04455283f
+      - 5baf415614ce4b55bf0feca7cea46922
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTg3YjhhYWQtYWEx
+        Yi00MjFmLWE5ZTItOGQwY2RjYmFlM2ZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NTIuMTcyOTc4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmYjBjNjk3ZDc2MTU0MjVmYThlMTI3NDhi
+        NTg3Y2EyMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjUyLjI0
+        MDc2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6NTIuNjU2
+        MDI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODMyMTI5OTgtZDE5ZC00M2My
+        LTliMDUtZGRkZjZmM2Y1YTMyLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +248,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +279,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a1d04df9aa794d908623e9396af7d2c5
+      - '09765476b24e40eb8ec529a953ab3693'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -222,7 +301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -235,7 +314,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -247,27 +326,88 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '448'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3f25b1239494ea08066dd04f1218906
+      - 6f57857440d44a179d293997ab295089
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNmVhNDRlMjItYTZlMS00NDdhLWFjMzItYzYwMjc2MDQ5YTFj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6NDQuMDczMTQ3
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01F
+        X0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIs
+        ImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6
+        IjIiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:52 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/6ea44e22-a6e1-447a-ac32-c60276049a1c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:52 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 63cf25efece447f685034468187739e6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1NDM5ZjFjLTY2YTItNDQ5
+        Yi1hNzJhLTA2Y2FjZDljNmQ3NS8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/65439f1c-66a2-449b-a72a-06cacd9c6d75/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -275,7 +415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.18.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -288,7 +428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -296,31 +436,42 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6957fc3db6dd4dd89f67942002d8cdb1
+      - 2629e9d4877b4b93abda0a1d34bd179f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjU0MzlmMWMtNjZh
+        Mi00NDliLWE3MmEtMDZjYWNkOWM2ZDc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NTIuODY5NjMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2M2NmMjVlZmVjZTQ0N2Y2ODUwMzQ0Njgx
+        ODc3MzllNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjUyLjkx
+        OTc4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6NTIuOTg1
+        MTY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -328,7 +479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -341,7 +492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -359,21 +510,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b877bc6f4c674086b0780ccdbf68ff90
+      - 3ca5965fad2f45f8812249d232325496
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -381,7 +532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -412,21 +563,127 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0c476ba6e13c43f5acb309e45e9b14f9
+      - 4b26248f0e8d4bdeaf871057596b984b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4da6854b8562414f8f94a516a2668bc6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:28:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a8eea70d0bbb42cf94afa30793331d04
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:28:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -443,7 +700,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -456,13 +713,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/7e1ecc0e-3cc7-4be3-88ce-5ceb82865b86/"
+      - "/pulp/api/v3/remotes/rpm/rpm/b3f5c209-4560-4fc8-813c-f682e1926e95/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -476,32 +733,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6de5a8c5d883499f949da4e5759d950b
+      - 00045e60d5e54af9aa982172d074ffff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdl
-        MWVjYzBlLTNjYzctNGJlMy04OGNlLTVjZWI4Mjg2NWI4Ni8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE5OjE2Ljc2OTUwMVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Iz
+        ZjVjMjA5LTQ1NjAtNGZjOC04MTNjLWY2ODJlMTkyNmU5NS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI4OjUzLjUzODA1NloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2ZpeHR1cmVzLnB1bHBwcm9q
         ZWN0Lm9yZy9zcnBtLXVuc2lnbmVkLyIsImNhX2NlcnQiOm51bGwsImNsaWVu
         dF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJs
         IjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoi
-        MjAyMi0wNS0yM1QyMzoxOToxNi43Njk1MjVaIiwiZG93bmxvYWRfY29uY3Vy
+        MjAyMi0wNy0yOVQxMToyODo1My41MzgwODRaIiwiZG93bmxvYWRfY29uY3Vy
         cmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1l
         ZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91
         dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVh
         ZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQi
         OjAsInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -511,7 +768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -524,13 +781,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:16 GMT
+      - Fri, 29 Jul 2022 11:28:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -544,22 +801,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad08e4151af04b0485bd1584b0b301c6
+      - 26852fe552984bab8160d16265861011
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjY5ZTljYjUtMDZiMS00N2NmLTg5ZTYtMmJlNDVlYzI2ZTBhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTk6MTYuODg2Mzg1WiIsInZl
+        cG0vNjBjNDVkOGYtNzBhYy00ZTJlLWI0MWEtN2E3YTQ0MDdjM2Q5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6NTMuNzIwMjA2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjY5ZTljYjUtMDZiMS00N2NmLTg5ZTYtMmJlNDVlYzI2ZTBhL3ZlcnNp
+        cG0vNjBjNDVkOGYtNzBhYy00ZTJlLWI0MWEtN2E3YTQ0MDdjM2Q5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82NjllOWNiNS0w
-        NmIxLTQ3Y2YtODllNi0yYmU0NWVjMjZlMGEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MGM0NWQ4Zi03
+        MGFjLTRlMmUtYjQxYS03YTdhNDQwN2MzZDkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -568,10 +825,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:16 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -579,7 +836,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -592,41 +849,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '673'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c778aa5594114b47a883cb0656a9ec69
+      - bfdca3d955274f2d8a860189e838fcf5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '310'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MzBkMWE5My1iNzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxNjoxOC44NDE4NzNa
+        cnBtL3JwbS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOVQxMToyODozOS44Mjk0Njda
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MzBkMWE5My1iNzQ3LTQwY2UtOWIzOS1mMjM3YjVmNGQwNTIv
+        cnBtL3JwbS9kN2E5YTMzNS1lMmJjLTQ4ODAtOWZmNy1kNmVhODAyODJhZjAv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzczMGQx
-        YTkzLWI3NDctNDBjZS05YjM5LWYyMzdiNWY0ZDA1Mi92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q3YTlh
+        MzM1LWUyYmMtNDg4MC05ZmY3LWQ2ZWE4MDI4MmFmMC92ZXJzaW9ucy8zLyIs
         Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
@@ -634,10 +891,10 @@ http_interactions:
         bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
         cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:53 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/730d1a93-b747-40ce-9b39-f237b5f4d052/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d7a9a335-e2bc-4880-9ff7-d6ea80282af0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -645,7 +902,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -658,7 +915,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -676,21 +933,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ae42a76ab794baea3faff5465343d89
+      - 76e5c8b03ff34b9d859dedc03fc90f71
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmZTM2ZGUyLWMxYjMtNDJm
-        Ny04YTg2LWI2MzRmOWIyMTJmZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RkZjI0YjVkLTk4NDAtNDQ4
+        OC04NDBkLWJiYTk5YTY5NzhhMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -698,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -711,51 +968,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '610'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1afc8a0eb7494d43bb0035902ce3ddf2
+      - fec84800d2e445a98dcd3e1e13e97f15
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '367'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vODc0YTE3ZTctNTE5My00Yzc4LTk3MmEtZWZiMDcyNDc1YWVmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTY6MTguMDM4NTE0WiIsIm5h
+        cG0vZjYwZTIzMDAtNmNjNC00NDI0LTlhYTgtMmM1MWI1ZTg5MDFjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6MzguNTAyOTQ5WiIsIm5h
         bWUiOiIyIiwidXJsIjoiZmlsZTovLy92YXIvbGliL3B1bHAvc3luY19pbXBv
         cnRzL3Rlc3RfcmVwb3Mvem9vLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
         dWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        Mi0wNS0yM1QyMzoxNjoxOS4xNzcxMTJaIiwiZG93bmxvYWRfY29uY3VycmVu
+        Mi0wNy0yOVQxMToyODo0MC40MTExNzBaIiwiZG93bmxvYWRfY29uY3VycmVu
         Y3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlh
         dGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLjAsImNvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19jb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfcmVhZF90
         aW1lb3V0IjozNjAwLjAsImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOjAs
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/874a17e7-5193-4c78-972a-efb072475aef/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/f60e2300-6cc4-4424-9aa8-2c51b5e8901c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -763,7 +1020,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -776,7 +1033,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -794,21 +1051,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1872231679c4118b0945a2f41603aaa
+      - a9d86c77a3d845e784f25c9fff8e265c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiYTAwOTEzLTlkZGMtNGVh
-        MS05M2ZlLTNmMGE3Yjg1NzNkZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1MTkyZWFiLWMxNDQtNGQx
+        Yi1hM2MyLWJlY2UzZDE2M2QxNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/6fe36de2-c1b3-42f7-8a86-b634f9b212ff/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/ddf24b5d-9840-4488-840d-bba99a6978a0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -829,51 +1086,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5bb7c22893f74db0a0505f663f50941b
+      - b460fb765e9b47e7abacc738879d9bf2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmZlMzZkZTItYzFi
-        My00MmY3LThhODYtYjYzNGY5YjIxMmZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MTcuMDQwMzExWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGRmMjRiNWQtOTg0
+        MC00NDg4LTg0MGQtYmJhOTlhNjk3OGEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NTQuMDAyNzAwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxYWU0MmE3NmFiNzk0YmFlYTNmYWZmNTQ2
-        NTM0M2Q4OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE5OjE3LjA3
-        MjA5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTk6MTcuMTI1
-        MzM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3NmU1YzhiMDNmZjM0YjlkODU5ZGVkYzAz
+        ZmM5MGY3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjU0LjA3
+        NDg1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6NTQuMTk3
+        OTA2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzMwZDFhOTMtYjc0Ny00MGNl
-        LTliMzktZjIzN2I1ZjRkMDUyLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDdhOWEzMzUtZTJiYy00ODgw
+        LTlmZjctZDZlYTgwMjgyYWYwLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/bba00913-9ddc-4ea1-93fe-3f0a7b8573de/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d5192eab-c144-4d1b-a3c2-bece3d163d15/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -894,51 +1151,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f04ae2862cf54a5c9fb90daffe8dbc21
+      - 63ba93615bea4197bf4ae266c1cb9573
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmJhMDA5MTMtOWRk
-        Yy00ZWExLTkzZmUtM2YwYTdiODU3M2RlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MTcuMTMyODUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDUxOTJlYWItYzE0
+        NC00ZDFiLWEzYzItYmVjZTNkMTYzZDE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NTQuMTYyMzI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkMTg3MjIzMTY3OWM0MTE4YjA5NDVhMmY0
-        MTYwM2FhYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE5OjE3LjE2
-        NjkxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTk6MTcuMjE3
-        NjYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhOWQ4NmM3N2EzZDg0NWU3ODRmMjVjOWZm
+        ZjhlMjY1YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjU0LjI1
+        NDA0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6NTQuMzMx
+        MTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzg3NGExN2U3LTUxOTMtNGM3OC05NzJh
-        LWVmYjA3MjQ3NWFlZi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y2MGUyMzAwLTZjYzQtNDQyNC05YWE4
+        LTJjNTFiNWU4OTAxYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -946,7 +1203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -959,7 +1216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -977,21 +1234,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a7edbc32dce24ebcbd37864237381ef1
+      - a20838910f59400ab3a93c0b54a17fdb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -999,7 +1256,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1012,7 +1269,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1030,21 +1287,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - accf761edecf46c79617e4427deb1ea5
+      - 5c4690648afb46f3a35af3e15a17c632
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,7 +1309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1065,7 +1322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1083,21 +1340,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e31325f2c854030a9a3893af938a91b
+      - 5d8a4292442b4f56b82cc2e9d9bfe138
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1105,7 +1362,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1118,7 +1375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1136,21 +1393,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 20edf38d867f40239a9e9880adfcc13b
+      - 69c1be77a9e8458a87f46c4f91214e35
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1158,7 +1415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1171,7 +1428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1189,21 +1446,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a10e05cddfd4129a30afda108562847
+      - ee14a217c3984d2894995291966f161e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1211,7 +1468,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1224,7 +1481,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1242,21 +1499,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d8b27b971d247f8aab40101b097fcc6
+      - 1734001e4bb0450daca8c61876d1103d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMiIsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfQ==
@@ -1266,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1279,13 +1536,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1299,22 +1556,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 75cf7fc350d640aa8f677f7282d4c45f
+      - bb918ef2e62b45418f76b7e65227a2f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZWZlNjMwN2ItNmRiMy00M2E5LTgwZDEtZWI3YTEyNzQ0MjBhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6MTk6MTcuNTc2ODY3WiIsInZl
+        cG0vYjI3M2FkZjItNzg5NS00NGQ2LTk0MTUtZDQzNmRiN2JjMjQ0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjg6NTQuODc5OTc5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZWZlNjMwN2ItNmRiMy00M2E5LTgwZDEtZWI3YTEyNzQ0MjBhL3ZlcnNp
+        cG0vYjI3M2FkZjItNzg5NS00NGQ2LTk0MTUtZDQzNmRiN2JjMjQ0L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lZmU2MzA3Yi02
-        ZGIzLTQzYTktODBkMS1lYjdhMTI3NDQyMGEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMjczYWRmMi03
+        ODk1LTQ0ZDYtOTQxNS1kNDM2ZGI3YmMyNDQvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
         dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
@@ -1322,10 +1579,10 @@ http_interactions:
         Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
         Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:54 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/7e1ecc0e-3cc7-4be3-88ce-5ceb82865b86/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b3f5c209-4560-4fc8-813c-f682e1926e95/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1342,7 +1599,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1355,7 +1612,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1373,21 +1630,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d23f3b9681543e5a6e123aa885b64c2
+      - 3101c638a02a4725be67f9b1802919c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlY2JlMWYxLTY1MDgtNDcy
-        Yy04NDkwLTk1NjNkMTQwOWIxYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzNmRkYzIxLTAxYzctNDVk
+        Yy1iNjlhLTQ5MGQxMjliYWIzNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8ecbe1f1-6508-472c-8490-9563d1409b1b/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/b36ddc21-01c7-45dc-b69a-490d129bab37/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1408,63 +1665,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:17 GMT
+      - Fri, 29 Jul 2022 11:28:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4dbbb7c7de3f4920a7d4923f18b84d77
+      - 5c8152611c29452d859121ea220affd6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGVjYmUxZjEtNjUw
-        OC00NzJjLTg0OTAtOTU2M2QxNDA5YjFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MTcuODcwMjQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjM2ZGRjMjEtMDFj
+        Ny00NWRjLWI2OWEtNDkwZDEyOWJhYjM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NTUuMzMwMDE4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIyZDIzZjNiOTY4MTU0M2U1YTZlMTIzYWE4
-        ODViNjRjMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE5OjE3Ljkw
-        NzIzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTk6MTcuOTMw
-        ODc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzMTAxYzYzOGEwMmE0NzI1YmU2N2Y5YjE4
+        MDI5MTljNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4OjU1LjM4
+        NTkwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6NTUuNDI0
+        MzYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYyMDgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdlMWVjYzBlLTNjYzctNGJlMy04OGNl
-        LTVjZWI4Mjg2NWI4Ni8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IzZjVjMjA5LTQ1NjAtNGZjOC04MTNj
+        LWY2ODJlMTkyNmU5NS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:17 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:55 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/sync/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdlMWVj
-        YzBlLTNjYzctNGJlMy04OGNlLTVjZWI4Mjg2NWI4Ni8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IzZjVj
+        MjA5LTQ1NjAtNGZjOC04MTNjLWY2ODJlMTkyNmU5NS8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1477,7 +1734,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:18 GMT
+      - Fri, 29 Jul 2022 11:28:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1495,21 +1752,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 68db67a825074412ac9bc5859feb2f07
+      - f3fe5b34369e41da9e6618434fc37b97
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVjYTFhOGQ4LTNmMjQtNGEx
-        My05YjUyLTY4NmQxNWI1OTc4Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5Yjg0ZTZiLWE2ZWUtNDY0
+        Mi05MGJlLTc5YTMyMTJkNWRhZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:18 GMT
+  recorded_at: Fri, 29 Jul 2022 11:28:55 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5ca1a8d8-3f24-4a13-9b52-686d15b59786/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/49b84e6b-a6ee-4642-90be-79a3212d5daf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1530,42 +1787,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:20 GMT
+      - Fri, 29 Jul 2022 11:29:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1615'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb649b98446a44b582cd42ab0b80236d
+      - 78fcbcb65e8d4f9b9d8ce30d4d8717b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '614'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWNhMWE4ZDgtM2Yy
-        NC00YTEzLTliNTItNjg2ZDE1YjU5Nzg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MTguMDQ1MDA3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDliODRlNmItYTZl
+        ZS00NjQyLTkwYmUtNzlhMzIxMmQ1ZGFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjg6NTUuNTQ4MTQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI2OGRiNjdhODI1MDc0NDEyYWM5
-        YmM1ODU5ZmViMmYwNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE5
-        OjE4LjA3NzE3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTk6
-        MjAuMjM2NDA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmM2ZlNWIzNDM2OWU0MWRhOWU2
+        NjE4NDM0ZmMzN2I5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI4
+        OjU1LjYwNjU2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjg6
+        NTkuODg1NTQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1577,37 +1834,37 @@ http_interactions:
         dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6OSwic3VmZml4
         IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
         c3luYy5wYXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
-        OiJQYXJzZWQgQ29tcHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmNvbXBzIiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUi
-        OiJzeW5jLnBhcnNpbmcuYWR2aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVk
-        IiwidG90YWwiOjIsImRvbmUiOjIsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0
-        aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxs
-        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY2OWU5Y2I1
-        LTA2YjEtNDdjZi04OWU2LTJiZTQ1ZWMyNmUwYS92ZXJzaW9ucy8xLyJdLCJy
-        ZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS82NjllOWNiNS0wNmIxLTQ3Y2YtODllNi0yYmU0
-        NWVjMjZlMGEvIiwic2hhcmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vN2UxZWNjMGUtM2NjNy00YmUzLTg4Y2UtNWNlYjgyODY1Yjg2LyJdfQ==
+        b3RhbCI6MywiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQ
+        YXJzZWQgQ29tcHMiLCJjb2RlIjoic3luYy5wYXJzaW5nLmNvbXBzIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6Mywic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJz
+        eW5jLnBhcnNpbmcuYWR2aXNvcmllcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjIsImRvbmUiOjIsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        VW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
+        b25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzYwYzQ1ZDhmLTcw
+        YWMtNGUyZS1iNDFhLTdhN2E0NDA3YzNkOS92ZXJzaW9ucy8xLyJdLCJyZXNl
+        cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS82MGM0NWQ4Zi03MGFjLTRlMmUtYjQxYS03YTdhNDQw
+        N2MzZDkvIiwic2hhcmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0v
+        YjNmNWMyMDktNDU2MC00ZmM4LTgxM2MtZjY4MmUxOTI2ZTk1LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:00 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNjY5ZTljYjUtMDZiMS00N2NmLTg5ZTYtMmJlNDVlYzI2
-        ZTBhL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vNjBjNDVkOGYtNzBhYy00ZTJlLWI0MWEtN2E3YTQ0MDdj
+        M2Q5L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1620,7 +1877,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:20 GMT
+      - Fri, 29 Jul 2022 11:29:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1638,21 +1895,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5affdb7972d147caaa8b7235b4e65fd6
+      - 3fa3b853989549ba920a437aefa5c5d6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVkY2RlMDdmLTA2Y2UtNGZh
-        OC1iMDllLTc4Yzk0MzM0ODEzZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1NTMwZDI3LTBmMTQtNDhk
+        YS05MDQ5LWFlZmI4YTU4YzgzYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5dcde07f-06ce-4fa8-b09e-78c94334813f/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/a5530d27-0f14-48da-9049-aefb8a58c83c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1673,56 +1930,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:20 GMT
+      - Fri, 29 Jul 2022 11:29:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c320561103694437a53318a9d0fe6b7c
+      - 2f2ab16df99046feb2647d0d2c85158e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWRjZGUwN2YtMDZj
-        ZS00ZmE4LWIwOWUtNzhjOTQzMzQ4MTNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MjAuNTk0ODIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTU1MzBkMjctMGYx
+        NC00OGRhLTkwNDktYWVmYjhhNThjODNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDAuNDcyOTkxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjVhZmZkYjc5NzJkMTQ3Y2FhYThiNzIzNWI0
-        ZTY1ZmQ2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTk6MjAuNjI1
-        Njg5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxOToyMC44MDA4
-        ODlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjNmYTNiODUzOTg5NTQ5YmE5MjBhNDM3YWVm
+        YTVjNWQ2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MDAuNTI2
+        MzIwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOTowMC45Nzg2
+        NThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzFkNmMyMzE2LTQ2ZTMtNDAwNy04ZDFmLTRkNjFiYjM3YzlkMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZDEyMWU4
-        N2QtMmUxOC00MDg5LWEyNmYtZjE1MmM4YTc0OTQ5LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMWYyYTRk
+        NDMtODY0Mi00OTM5LTg3ZDktYzljODk3MTZlMTgzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNjY5ZTljYjUtMDZiMS00N2NmLTg5ZTYtMmJlNDVl
-        YzI2ZTBhLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vNjBjNDVkOGYtNzBhYy00ZTJlLWI0MWEtN2E3YTQ0
+        MDdjM2Q5LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:20 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1730,7 +1987,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1743,7 +2000,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1761,21 +2018,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d1dc5287b78041d8a1814a8e7496d9a7
+      - 1f3f1db2c6c74cf0916524bafcae315c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/publications/rpm/rpm/1f2a4d43-8642-4939-87d9-c9c89716e183/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1783,7 +2040,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1796,7 +2053,254 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '447'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fa8b7c480bb44bc99ba724fcea33b66d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
+        cG0vMWYyYTRkNDMtODY0Mi00OTM5LTg3ZDktYzljODk3MTZlMTgzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMjlUMTE6Mjk6MDAuNTUzNzg2WiIsInJl
+        cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82MGM0NWQ4Zi03MGFjLTRlMmUtYjQxYS03YTdhNDQwN2MzZDkv
+        dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzYwYzQ1ZDhmLTcwYWMtNGUyZS1iNDFhLTdhN2E0
+        NDA3YzNkOS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
+        InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:01 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjIiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        cnBtL3JwbS8xZjJhNGQ0My04NjQyLTQ5MzktODdkOS1jOWM4OTcxNmUxODMv
+        In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0b35d5592f744944bac79647926a5012
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4MmYzYzRlLTlhZjYtNDI3
+        Yy1hNjY4LWExNzNlNDMwYzYxZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/d82f3c4e-9af6-427c-a668-a173e430c61f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '632'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7d44a5713bd54fc4808e4a015c7be2c3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDgyZjNjNGUtOWFm
+        Ni00MjdjLWE2NjgtYTE3M2U0MzBjNjFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDEuMzMzMjM2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwYjM1ZDU1OTJmNzQ0OTQ0YmFjNzk2NDc5
+        MjZhNTAxMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjAxLjM4
+        OTg3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6MDEuNzk3
+        MzA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8xZDZjMjMxNi00NmUzLTQwMDctOGQxZi00ZDYxYmIzN2M5ZDAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYjZk
+        ZWVmZjYtOGNiOC00Y2UyLTliY2YtM2M4ZjkxNzQyODhjLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/b6deeff6-8cb8-4ce2-9bcf-3c8f9174288c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '465'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0d3676ed534341818343d90b4a2ed047
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2I2ZGVlZmY2LThjYjgtNGNlMi05YmNmLTNjOGY5MTc0Mjg4Yy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI5VDExOjI5OjAxLjc2NzgzMFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250
+        ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL3JwbS9ycG0vMWYyYTRkNDMtODY0Mi00OTM5LTg3ZDkt
+        YzljODk3MTZlMTgzLyJ9
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1814,21 +2318,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 55402052cd25466cabfdd88d2f0d6ca0
+      - f4e08f5535214d22b55e87a802de3270
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1836,7 +2340,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1849,37 +2353,90 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4854f062ec00490c9e392183d24962f0
+      - 9cfd573e504e4e608900036b97e60f29
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '578'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:02 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1920'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b949c7a7c674936bfc0744dede491fc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzE0Mzg5NzRlLTM1N2UtNDIyYS1iOTRjLTE3NThhNWJjZjk2
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMzI5
-        MloiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzL2I5MjNhZDU2LTNlZjctNDAzZS05ZjdmLTQyNGRkOWMyNmRj
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5NjQy
+        NFoiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
         Ni0wMS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVt
         XzEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDYiLCJmcm9t
         c3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -1895,8 +2452,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzYxYzg2MDg1LTM5N2MtNDA4My05ZjA5LTA0YzVkY2UwYTljMy8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMDQyNloi
+        c29yaWVzL2FmOGVhMzhjLTUzMzEtNDI4ZS1iNzQxLTNhNTg1NTA2Y2M4MS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5MTk4Nloi
         LCJpZCI6IlJIRUEtMjAxMjowMDIzIiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         Mi0yNyAxNzowMDowMCIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVtXzIi
         LCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDgiLCJmcm9tc3Ry
@@ -1919,10 +2476,10 @@ http_interactions:
         dW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6
         W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1930,7 +2487,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1943,37 +2500,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1031'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ef8b7b979024dabba307de8d732565c
+      - 5cf95161bd034358b9344cfe6eb2e425
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '442'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlZ3JvdXBzLzUwNWY3YzYxLWY1YjktNDRiOS04ODExLTFlMDZlNjJi
-        YmM1YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE5OjIwLjA2
-        Nzk1MFoiLCJpZCI6InRlc3QtMDEiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zp
+        YWNrYWdlZ3JvdXBzLzg3MmYxYjU3LTUyMjktNGNjNi1hMzhlLTJlOThjOWE5
+        ZmQwNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5
+        ODU1M1oiLCJpZCI6InRlc3QtMDEiLCJkZWZhdWx0Ijp0cnVlLCJ1c2VyX3Zp
         c2libGUiOnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUiOiJ0ZXN0
         LTAxIiwiZGVzY3JpcHRpb24iOiIiLCJwYWNrYWdlcyI6W3sibmFtZSI6InRl
         c3Qtc3JwbTAxIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJhc2VhcmNo
@@ -1981,9 +2538,9 @@ http_interactions:
         ZyI6e30sIm5hbWVfYnlfbGFuZyI6e30sImRpZ2VzdCI6IjhiYzlhYjcyNTZm
         M2Q0OWI1MjQyYjg3MjVlNTY5NDRmMjE2ODdhYzgwNTkwYmIwNGU5YmY0YmZm
         M2UwMGRmMDcifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlZ3JvdXBzLzQ2YmE5M2Q0LWIzZjMtNDhjZS1iZmRmLTBj
-        YjZhOWU1MzYxMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjE5
-        OjIwLjA2NDgxMloiLCJpZCI6InRlc3QtMDIiLCJkZWZhdWx0Ijp0cnVlLCJ1
+        L3JwbS9wYWNrYWdlZ3JvdXBzL2Q5OGMyMGI1LTJlOTAtNGYyYS1hMjhjLTQx
+        YmY0MTgxZDcxMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1
+        OjA3LjA4NjYzOVoiLCJpZCI6InRlc3QtMDIiLCJkZWZhdWx0Ijp0cnVlLCJ1
         c2VyX3Zpc2libGUiOnRydWUsImRpc3BsYXlfb3JkZXIiOjEwMjQsIm5hbWUi
         OiJ0ZXN0LTAyIiwiZGVzY3JpcHRpb24iOiIiLCJwYWNrYWdlcyI6W3sibmFt
         ZSI6InRlc3Qtc3JwbTAyIiwidHlwZSI6MywicmVxdWlyZXMiOm51bGwsImJh
@@ -1993,10 +2550,10 @@ http_interactions:
         YW5nIjp7fSwiZGlnZXN0IjoiMjVmMjBiOTQ0Njc2NTIzMjI0MWQxYWViM2U1
         ODljMjgwMGQzZDhjOWM3MTc2MTk4NTBmNGI1ZjgyZDkzMzQzZiJ9XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2004,7 +2561,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2017,60 +2574,60 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1035'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f315b7aba0f34dcdb21e62bbe9711feb
+      - 51d81f854a4e47b79d372efb2ebe3fa8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '438'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zZDAzODhjZi1iYmM2LTQ3M2QtYmIyNi1jZmE4NTVkMzkxMDUv
+        YWNrYWdlcy9kZDk2OTJkYi01MjE0LTQ4YjAtODgzOS1jMWEwMTVlMGQ3MTkv
         IiwibmFtZSI6InRlc3Qtc3JwbTAzIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6
         IjEuMCIsInJlbGVhc2UiOiIxIiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiNzZk
         YjY2MDk5YzA0MzVmMjQ1YjZkY2JhNTQ1Y2M4ZGI2Mjc2NWY2ZTgwMjc2ZTBk
         NjZkYjY1YzE2ZDhjN2JhYyIsInN1bW1hcnkiOiJEdW1teSBQYWNrYWdlIHRv
         IHByb3ZpZGUgdG9tY2F0NSIsImxvY2F0aW9uX2hyZWYiOiJ0ZXN0LXNycG0w
         My0xLjAtMS5zcmMucnBtIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvZWUwZjQwZmItNzQ2ZC00NTAxLWJkMjIt
-        MTY1MDJjYzU0ZjZjLyIsIm5hbWUiOiJ0ZXN0LXNycG0wMiIsImVwb2NoIjoi
+        Y29udGVudC9ycG0vcGFja2FnZXMvYWRlOTE2MjctNWFhYS00YWYxLTk2ZTct
+        ZjExOWFiOTRmOWVlLyIsIm5hbWUiOiJ0ZXN0LXNycG0wMiIsImVwb2NoIjoi
         MCIsInZlcnNpb24iOiIxLjAiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJzcmMi
         LCJwa2dJZCI6ImY4ZDY3NWI0ZWRkOTkzM2I4YzQzODg0YzgxZjNkOWYxMzVj
         ZGJlNzQxYTkwMTMzNDM1ZGUwZjA2MzIwNzVlNGMiLCJzdW1tYXJ5IjoiRHVt
         bXkgUGFja2FnZSB0byBwcm92aWRlIHRvbWNhdDUiLCJsb2NhdGlvbl9ocmVm
         IjoidGVzdC1zcnBtMDItMS4wLTEuc3JjLnJwbSJ9LHsicHVscF9ocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzZkNjBkYTJmLTBh
-        YTctNDZhZi1iZjZmLWE5YTNkODZlZTE0OS8iLCJuYW1lIjoidGVzdC1zcnBt
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E3MjQwZDI2LTkw
+        ZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIwZS8iLCJuYW1lIjoidGVzdC1zcnBt
         MDEiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMS4wIiwicmVsZWFzZSI6IjEi
         LCJhcmNoIjoic3JjIiwicGtnSWQiOiI1NGNjNDcxM2ZlNzA0ZGZjN2E0ZmQ1
         YjM5OGY4MzRjZWI2YTY5MmY1M2IwYzZhZWZhZjg5ZDg4NDE3YjRjNTFkIiwi
         c3VtbWFyeSI6IkR1bW15IFBhY2thZ2UgdG8gcHJvdmlkZSB0b21jYXQ1Iiwi
         bG9jYXRpb25faHJlZiI6InRlc3Qtc3JwbTAxLTEuMC0xLnNyYy5ycG0ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2078,7 +2635,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2091,7 +2648,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2109,21 +2666,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 876370b57d4a46e6af2a9fc487e4dd63
+      - 5acd268869ff4497950903f1991691e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:02 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/505f7c61-f5b9-44b9-8811-1e06e62bbc5a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/872f1b57-5229-4cc6-a38e-2e98c9a9fd07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2131,7 +2688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2144,35 +2701,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '455'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b2d6efab4ad43d2bcba91653a227106
+      - 5c810e6b2d284aff9195ccf318a09744
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '313'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy81MDVmN2M2MS1mNWI5LTQ0YjktODgxMS0xZTA2ZTYyYmJjNWEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxOToyMC4wNjc5NTBa
+        ZWdyb3Vwcy84NzJmMWI1Ny01MjI5LTRjYzYtYTM4ZS0yZTk4YzlhOWZkMDcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowNy4wOTg1NTNa
         IiwiaWQiOiJ0ZXN0LTAxIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxl
         Ijp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoidGVzdC0wMSIs
         ImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJ0ZXN0LXNy
@@ -2182,10 +2739,10 @@ http_interactions:
         NTI0MmI4NzI1ZTU2OTQ0ZjIxNjg3YWM4MDU5MGJiMDRlOWJmNGJmZjNlMDBk
         ZjA3In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/505f7c61-f5b9-44b9-8811-1e06e62bbc5a/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/872f1b57-5229-4cc6-a38e-2e98c9a9fd07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2193,7 +2750,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2206,35 +2763,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '455'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 48208196d3d64bd49123ec12a3da25eb
+      - 65efa303469340748b495258a16cbb30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '313'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy81MDVmN2M2MS1mNWI5LTQ0YjktODgxMS0xZTA2ZTYyYmJjNWEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxOToyMC4wNjc5NTBa
+        ZWdyb3Vwcy84NzJmMWI1Ny01MjI5LTRjYzYtYTM4ZS0yZTk4YzlhOWZkMDcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowNy4wOTg1NTNa
         IiwiaWQiOiJ0ZXN0LTAxIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxl
         Ijp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoidGVzdC0wMSIs
         ImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJ0ZXN0LXNy
@@ -2244,10 +2801,10 @@ http_interactions:
         NTI0MmI4NzI1ZTU2OTQ0ZjIxNjg3YWM4MDU5MGJiMDRlOWJmNGJmZjNlMDBk
         ZjA3In0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/46ba93d4-b3f3-48ce-bfdf-0cb6a9e53613/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/d98c20b5-2e90-4f2a-a28c-41bf4181d711/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2255,7 +2812,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2268,35 +2825,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '523'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4b306e76f654a5d9a4fc80bcb841ff6
+      - 2efb20798b66433687bdb5efc685ef95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '321'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy80NmJhOTNkNC1iM2YzLTQ4Y2UtYmZkZi0wY2I2YTllNTM2MTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxOToyMC4wNjQ4MTJa
+        ZWdyb3Vwcy9kOThjMjBiNS0yZTkwLTRmMmEtYTI4Yy00MWJmNDE4MWQ3MTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowNy4wODY2Mzla
         IiwiaWQiOiJ0ZXN0LTAyIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxl
         Ijp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoidGVzdC0wMiIs
         ImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJ0ZXN0LXNy
@@ -2307,10 +2864,10 @@ http_interactions:
         Z2VzdCI6IjI1ZjIwYjk0NDY3NjUyMzIyNDFkMWFlYjNlNTg5YzI4MDBkM2Q4
         YzljNzE3NjE5ODUwZjRiNWY4MmQ5MzM0M2YifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/46ba93d4-b3f3-48ce-bfdf-0cb6a9e53613/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/d98c20b5-2e90-4f2a-a28c-41bf4181d711/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2318,7 +2875,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2331,35 +2888,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '523'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a6b31021ef4c44189103bdc718e6b90d
+      - 41b55f7145ef4acb9c430833b0d2e56b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '321'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZWdyb3Vwcy80NmJhOTNkNC1iM2YzLTQ4Y2UtYmZkZi0wY2I2YTllNTM2MTMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoxOToyMC4wNjQ4MTJa
+        ZWdyb3Vwcy9kOThjMjBiNS0yZTkwLTRmMmEtYTI4Yy00MWJmNDE4MWQ3MTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNy0yOFQxNjo1NTowNy4wODY2Mzla
         IiwiaWQiOiJ0ZXN0LTAyIiwiZGVmYXVsdCI6dHJ1ZSwidXNlcl92aXNpYmxl
         Ijp0cnVlLCJkaXNwbGF5X29yZGVyIjoxMDI0LCJuYW1lIjoidGVzdC0wMiIs
         ImRlc2NyaXB0aW9uIjoiIiwicGFja2FnZXMiOlt7Im5hbWUiOiJ0ZXN0LXNy
@@ -2370,10 +2927,10 @@ http_interactions:
         Z2VzdCI6IjI1ZjIwYjk0NDY3NjUyMzIyNDFkMWFlYjNlNTg5YzI4MDBkM2Q4
         YzljNzE3NjE5ODUwZjRiNWY4MmQ5MzM0M2YifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/repo_metadata_files/?repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2381,7 +2938,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2394,7 +2951,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2412,21 +2969,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4f007aed3123440296ca1dc08c2ac03a
+      - 2c8bd7a5fe734703a87a9eb6992fce65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2434,7 +2991,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2447,7 +3004,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2465,21 +3022,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e199d808336e40e5b83c8cd322b712f6
+      - f341db2e5fcd4bd8b8764de8f48e1678
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2487,7 +3044,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2500,7 +3057,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2518,21 +3075,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d0c3cdb89c78430b95418a8df9e3871e
+      - '009529465eb54e19b165e6d4e4b1424e'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/669e9cb5-06b1-47cf-89e6-2be45ec26e0a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/60c45d8f-70ac-4e2e-b41a-7a7a4407c3d9/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2540,7 +3097,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2553,7 +3110,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2571,21 +3128,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1885fc24089a4245a5fc5cffe1fd5474
+      - cddeaad83c67467f821f8b93e51d05bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/modify/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/modify/
     body:
       encoding: UTF-8
       base64_string: 'eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIqIl19
@@ -2595,7 +3152,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2608,7 +3165,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2626,43 +3183,43 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ade613eb62d04e61b47bf74c7584ae18
+      - 3bdf96c1c76b4957a248f2d426ab97dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmNDdiZWYyLTM0ZDEtNGE0
-        Mi04MmQwLTAyZWM1YTNkZDZiZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmNzU2ODZmLWRmMzItNGUy
+        MS1iZTdiLWNkZjk1OTVkNzMwMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/rpm/copy/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/rpm/copy/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25maWciOlt7InNvdXJjZV9yZXBvX3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjY5ZTljYjUtMDZiMS00N2NmLTg5
-        ZTYtMmJlNDVlYzI2ZTBhL3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2VmZTYzMDdiLTZkYjMt
-        NDNhOS04MGQxLWViN2ExMjc0NDIwYS8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzE0Mzg5NzRlLTM1N2UtNDIy
-        YS1iOTRjLTE3NThhNWJjZjk2Zi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vYWR2aXNvcmllcy82MWM4NjA4NS0zOTdjLTQwODMtOWYwOS0wNGM1ZGNl
-        MGE5YzMvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzNk
-        MDM4OGNmLWJiYzYtNDczZC1iYjI2LWNmYTg1NWQzOTEwNS8iLCIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNmQ2MGRhMmYtMGFhNy00NmFm
-        LWJmNmYtYTlhM2Q4NmVlMTQ5LyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9wYWNrYWdlcy9lZTBmNDBmYi03NDZkLTQ1MDEtYmQyMi0xNjUwMmNjNTRm
-        NmMvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjBjNDVkOGYtNzBhYy00ZTJlLWI0
+        MWEtN2E3YTQ0MDdjM2Q5L3ZlcnNpb25zLzEvIiwiZGVzdF9yZXBvIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IyNzNhZGYyLTc4OTUt
+        NDRkNi05NDE1LWQ0MzZkYjdiYzI0NC8iLCJjb250ZW50IjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzL2FmOGVhMzhjLTUzMzEtNDI4
+        ZS1iNzQxLTNhNTg1NTA2Y2M4MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy9iOTIzYWQ1Ni0zZWY3LTQwM2UtOWY3Zi00MjRkZDlj
+        MjZkYzAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2E3
+        MjQwZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIwZS8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYWRlOTE2MjctNWFhYS00YWYx
+        LTk2ZTctZjExOWFiOTRmOWVlLyIsIi9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9kZDk2OTJkYi01MjE0LTQ4YjAtODgzOS1jMWEwMTVlMGQ3
+        MTkvIl19XSwiZGVwZW5kZW5jeV9zb2x2aW5nIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2675,7 +3232,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:21 GMT
+      - Fri, 29 Jul 2022 11:29:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2693,21 +3250,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2b33f961dd74ae894fcc5a71a54b41b
+      - 5e3a3f18627c4ff2bb3b3cca0f178a7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3ZjBlYmVlLWMwZDMtNDE3
-        My1iNTIyLTAwYTk0NTY1ZWExNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzMTcyNzc0LTgzYTctNDA1
+        Yy1iOWU3LWIzOGQ4ZGY3MzgxNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:21 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1f47bef2-34d1-4a42-82d0-02ec5a3dd6bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4f75686f-df32-4e21-be7b-cdf9595d7302/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2728,51 +3285,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - da6737cf107049cabfe254044836a1ca
+      - 2c1a230a511348a7ac6121c792651acf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWY0N2JlZjItMzRk
-        MS00YTQyLTgyZDAtMDJlYzVhM2RkNmJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MjEuODM3MTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGY3NTY4NmYtZGYz
+        Mi00ZTIxLWJlN2ItY2RmOTU5NWQ3MzAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDMuNTk4NTQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZGU2MTNlYjYyZDA0ZTYxYjQ3
-        YmY3NGM3NTg0YWUxOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE5
-        OjIxLjg4NjMwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTk6
-        MjIuMDMyNDY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzYmRmOTZjMWM3NmI0OTU3YTI0
+        OGYyZDQyNmFiOTdkZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjAzLjY2MjY0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MDMuOTkwNDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWZlNjMwN2ItNmRi
-        My00M2E5LTgwZDEtZWI3YTEyNzQ0MjBhLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjI3M2FkZjItNzg5
+        NS00NGQ2LTk0MTUtZDQzNmRiN2JjMjQ0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1f47bef2-34d1-4a42-82d0-02ec5a3dd6bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4f75686f-df32-4e21-be7b-cdf9595d7302/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2793,51 +3350,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74e485a3847e4b18b63ee7690b1f474f
+      - a15d4b2af6ac456492a606a55568aa0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWY0N2JlZjItMzRk
-        MS00YTQyLTgyZDAtMDJlYzVhM2RkNmJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MjEuODM3MTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGY3NTY4NmYtZGYz
+        Mi00ZTIxLWJlN2ItY2RmOTU5NWQ3MzAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDMuNTk4NTQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZGU2MTNlYjYyZDA0ZTYxYjQ3
-        YmY3NGM3NTg0YWUxOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE5
-        OjIxLjg4NjMwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTk6
-        MjIuMDMyNDY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzYmRmOTZjMWM3NmI0OTU3YTI0
+        OGYyZDQyNmFiOTdkZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjAzLjY2MjY0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MDMuOTkwNDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWZlNjMwN2ItNmRi
-        My00M2E5LTgwZDEtZWI3YTEyNzQ0MjBhLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjI3M2FkZjItNzg5
+        NS00NGQ2LTk0MTUtZDQzNmRiN2JjMjQ0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1f47bef2-34d1-4a42-82d0-02ec5a3dd6bf/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4f75686f-df32-4e21-be7b-cdf9595d7302/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2858,51 +3415,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ef6cd9f81ec6461891c81f7722d89a3c
+      - 0ba5afb789a545adb3b8cc59e3817515
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '377'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWY0N2JlZjItMzRk
-        MS00YTQyLTgyZDAtMDJlYzVhM2RkNmJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MjEuODM3MTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGY3NTY4NmYtZGYz
+        Mi00ZTIxLWJlN2ItY2RmOTU5NWQ3MzAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDMuNTk4NTQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
-        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhZGU2MTNlYjYyZDA0ZTYxYjQ3
-        YmY3NGM3NTg0YWUxOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE5
-        OjIxLjg4NjMwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6MTk6
-        MjIuMDMyNDY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkw
-        NTEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzYmRmOTZjMWM3NmI0OTU3YTI0
+        OGYyZDQyNmFiOTdkZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjAzLjY2MjY0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MDMuOTkwNDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
         cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWZlNjMwN2ItNmRi
-        My00M2E5LTgwZDEtZWI3YTEyNzQ0MjBhLyJdfQ==
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjI3M2FkZjItNzg5
+        NS00NGQ2LTk0MTUtZDQzNmRiN2JjMjQ0LyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/47f0ebee-c0d3-4173-b522-00a94565ea17/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/4f75686f-df32-4e21-be7b-cdf9595d7302/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2923,55 +3480,120 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '613'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 85b31c6328584382be2cfb67bb9c1788
+      - c54410afcb41400da2367bd50ccf9283
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '415'
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDdmMGViZWUtYzBk
-        My00MTczLWI1MjItMDBhOTQ1NjVlYTE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6MTk6MjEuOTE0Mzg3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGY3NTY4NmYtZGYz
+        Mi00ZTIxLWJlN2ItY2RmOTU5NWQ3MzAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDMuNTk4NTQwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzYmRmOTZjMWM3NmI0OTU3YTI0
+        OGYyZDQyNmFiOTdkZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5
+        OjAzLjY2MjY0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMjlUMTE6Mjk6
+        MDMuOTkwNDAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy81OWRlNTU3NS0zZGQ3LTQ5ZWUtOWY2Ni0wNTk4M2E0YmYy
+        MDgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjI3M2FkZjItNzg5
+        NS00NGQ2LTk0MTUtZDQzNmRiN2JjMjQ0LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 29 Jul 2022 11:29:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/tasks/13172774-83a7-405c-b9e7-b38d8df73815/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.18.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Jul 2022 11:29:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '770'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4fd923736f4f4ea0b466fad470eb907f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTMxNzI3NzQtODNh
+        Ny00MDVjLWI5ZTctYjM4ZDhkZjczODE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMjlUMTE6Mjk6MDMuNzExMTEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5jb3B5LmNvcHlfY29udGVu
-        dCIsImxvZ2dpbmdfY2lkIjoiYzJiMzNmOTYxZGQ3NGFlODk0ZmNjNWE3MWE1
-        NGI0MWIiLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoxOToyMi4wNjUz
-        NzVaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjE5OjIyLjIzMzcz
-        NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvYjc2MzgxOGYtMDM5Mi00ZmUxLWFlZGEtNjUzZmQxYTExY2Q5LyIsInBh
+        dCIsImxvZ2dpbmdfY2lkIjoiNWUzYTNmMTg2MjdjNGZmMmJiM2IzY2NhMGYx
+        NzhhN2YiLCJzdGFydGVkX2F0IjoiMjAyMi0wNy0yOVQxMToyOTowNC4wNjI5
+        OTJaIiwiZmluaXNoZWRfYXQiOiIyMDIyLTA3LTI5VDExOjI5OjA0LjU3MzUz
+        MFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWQ2YzIzMTYtNDZlMy00MDA3LThkMWYtNGQ2MWJiMzdjOWQwLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWZlNjMw
-        N2ItNmRiMy00M2E5LTgwZDEtZWI3YTEyNzQ0MjBhL3ZlcnNpb25zLzEvIl0s
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjI3M2Fk
+        ZjItNzg5NS00NGQ2LTk0MTUtZDQzNmRiN2JjMjQ0L3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2VmZTYzMDdiLTZkYjMtNDNhOS04MGQxLWVi
-        N2ExMjc0NDIwYS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzY2OWU5Y2I1LTA2YjEtNDdjZi04OWU2LTJiZTQ1ZWMyNmUw
-        YS8iXX0=
+        cG9zaXRvcmllcy9ycG0vcnBtL2IyNzNhZGYyLTc4OTUtNDRkNi05NDE1LWQ0
+        MzZkYjdiYzI0NC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzYwYzQ1ZDhmLTcwYWMtNGUyZS1iNDFhLTdhN2E0NDA3YzNk
+        OS8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2979,7 +3601,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2992,7 +3614,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3010,21 +3632,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1967d1e1abe4e66af50049cc35b3b6c
+      - 1594e2c7c83248b6a04e5efb77fa67a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3032,7 +3654,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3045,7 +3667,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3063,21 +3685,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0341e88952aa482e88260a444610284e
+      - f3a2699671804c36a24fa07e8eb5c51d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3085,7 +3707,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3098,37 +3720,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1920'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9d127eb475974450b50480b5da7aa5bc
+      - f1ddb9aac6674db48b3023421423ae30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '578'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzE0Mzg5NzRlLTM1N2UtNDIyYS1iOTRjLTE3NThhNWJjZjk2
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMzI5
-        MloiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzL2I5MjNhZDU2LTNlZjctNDAzZS05ZjdmLTQyNGRkOWMyNmRj
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5NjQy
+        NFoiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
         Ni0wMS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVt
         XzEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDYiLCJmcm9t
         c3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3144,8 +3766,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzYxYzg2MDg1LTM5N2MtNDA4My05ZjA5LTA0YzVkY2UwYTljMy8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMDQyNloi
+        c29yaWVzL2FmOGVhMzhjLTUzMzEtNDI4ZS1iNzQxLTNhNTg1NTA2Y2M4MS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5MTk4Nloi
         LCJpZCI6IlJIRUEtMjAxMjowMDIzIiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         Mi0yNyAxNzowMDowMCIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVtXzIi
         LCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDgiLCJmcm9tc3Ry
@@ -3168,10 +3790,10 @@ http_interactions:
         dW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6
         W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3179,7 +3801,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3192,7 +3814,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3210,21 +3832,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - eb277cb254f34fa99f31bafc6c1ce0e7
+      - 1a2bf9efa3224101b9c9784d426849df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3232,7 +3854,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3245,44 +3867,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9a24378897ae4dabb8ea57644191c5f7
+      - 93e10c539b4549bf87cc8c96c4bf91a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '195'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zZDAzODhjZi1iYmM2LTQ3M2QtYmIyNi1jZmE4NTVkMzkxMDUv
+        YWNrYWdlcy9kZDk2OTJkYi01MjE0LTQ4YjAtODgzOS1jMWEwMTVlMGQ3MTkv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZWUwZjQwZmItNzQ2ZC00NTAxLWJkMjItMTY1MDJjYzU0ZjZjLyJ9
+        a2FnZXMvYWRlOTE2MjctNWFhYS00YWYxLTk2ZTctZjExOWFiOTRmOWVlLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzZkNjBkYTJmLTBhYTctNDZhZi1iZjZmLWE5YTNkODZlZTE0OS8ifV19
+        Z2VzL2E3MjQwZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIwZS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3290,7 +3912,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3303,7 +3925,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3321,21 +3943,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c5590c6e27ce4fb69ef1cf1bb82fa528
+      - 5f96a9a346a540f895fefcfcc74c243b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3343,7 +3965,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3356,7 +3978,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3374,21 +3996,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a64ca70d0a346a9b834d91eaa46dd93
+      - 25c708dcecc04e8b89a24f685364ed2f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3396,7 +4018,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3409,7 +4031,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:22 GMT
+      - Fri, 29 Jul 2022 11:29:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3427,21 +4049,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8919970d651846f2921c1977015fed03
+      - 1dc293b2e27e405a869880b32cf5c6d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:22 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3449,7 +4071,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3462,37 +4084,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:23 GMT
+      - Fri, 29 Jul 2022 11:29:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1920'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e12094ec4ad546138550ea13220d1a1d
+      - 5b543ed5685242a99ca65a54c52deec2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '578'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9h
-        ZHZpc29yaWVzLzE0Mzg5NzRlLTM1N2UtNDIyYS1iOTRjLTE3NThhNWJjZjk2
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMzI5
-        MloiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
+        ZHZpc29yaWVzL2I5MjNhZDU2LTNlZjctNDAzZS05ZjdmLTQyNGRkOWMyNmRj
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5NjQy
+        NFoiLCJpZCI6IlJIRUEtMjAxMjowMDIyIiwidXBkYXRlZF9kYXRlIjoiMjAx
         Ni0wMS0yNyAxNjowODowNiIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVt
         XzEiLCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDYiLCJmcm9t
         c3RyIjoiZXJyYXRhQHJlZGhhdC5jb20iLCJzdGF0dXMiOiJzdGFibGUiLCJ0
@@ -3508,8 +4130,8 @@ http_interactions:
         dC5vcmciLCJzdW0iOiIiLCJzdW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAi
         fV19XSwicmVmZXJlbmNlcyI6W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNl
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLzYxYzg2MDg1LTM5N2MtNDA4My05ZjA5LTA0YzVkY2UwYTljMy8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjEzOjUxLjYxMDQyNloi
+        c29yaWVzL2FmOGVhMzhjLTUzMzEtNDI4ZS1iNzQxLTNhNTg1NTA2Y2M4MS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTI4VDE2OjU1OjA3LjA5MTk4Nloi
         LCJpZCI6IlJIRUEtMjAxMjowMDIzIiwidXBkYXRlZF9kYXRlIjoiMjAxNi0w
         Mi0yNyAxNzowMDowMCIsImRlc2NyaXB0aW9uIjoidGVzdF9FcnJhdHVtXzIi
         LCJpc3N1ZWRfZGF0ZSI6IjIwMTYtMDEtMjcgMTY6MDg6MDgiLCJmcm9tc3Ry
@@ -3532,10 +4154,10 @@ http_interactions:
         dW1fdHlwZSI6IiIsInZlcnNpb24iOiIxLjAifV19XSwicmVmZXJlbmNlcyI6
         W10sInJlYm9vdF9zdWdnZXN0ZWQiOmZhbHNlfV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3543,7 +4165,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3556,7 +4178,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:23 GMT
+      - Fri, 29 Jul 2022 11:29:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3574,21 +4196,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b367d3fa31ab46cda8e2bfa04528cd06
+      - e0fccb4942f14d6aa52a1ae9cc67809a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3596,7 +4218,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3609,44 +4231,44 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:23 GMT
+      - Fri, 29 Jul 2022 11:29:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '315'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c55ba2cd692449c0a89f09da2e7718ac
+      - 1bc04be63d434e3f9ed78e8d9ed0dd65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '195'
+      - 1.1 centos8-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8zZDAzODhjZi1iYmM2LTQ3M2QtYmIyNi1jZmE4NTVkMzkxMDUv
+        YWNrYWdlcy9kZDk2OTJkYi01MjE0LTQ4YjAtODgzOS1jMWEwMTVlMGQ3MTkv
         In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvZWUwZjQwZmItNzQ2ZC00NTAxLWJkMjItMTY1MDJjYzU0ZjZjLyJ9
+        a2FnZXMvYWRlOTE2MjctNWFhYS00YWYxLTk2ZTctZjExOWFiOTRmOWVlLyJ9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
-        Z2VzLzZkNjBkYTJmLTBhYTctNDZhZi1iZjZmLWE5YTNkODZlZTE0OS8ifV19
+        Z2VzL2E3MjQwZDI2LTkwZjgtNGFjMi1hOTlhLTIyZmEyMjljOWIwZS8ifV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/efe6307b-6db3-43a9-80d1-eb7a1274420a/versions/1/
+    uri: https://centos8-katello-devel.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/b273adf2-7895-44d6-9415-d436db7bc244/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3654,7 +4276,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -3667,7 +4289,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:19:23 GMT
+      - Fri, 29 Jul 2022 11:29:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3685,16 +4307,16 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - abaa894f84794f4c80f90dc2d3565aa8
+      - e53336275d9c4040a77a11395b178613
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 centos8-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:19:23 GMT
+  recorded_at: Fri, 29 Jul 2022 11:29:06 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Not sure why it was disabled to publish/distribute content-view versions by default.
So I added a Setting to configure this.
After setting to `true`, pulp-distributions for already existing versions can be re-created by `republish-repositories` (using hammer, since button was removed in react-ui :wink:).

### RFC:
* naming and describing the setting
* `true`/`false` as default-value
* tests: I did not see any tests for this yet, we might want to add some